### PR TITLE
Add backend API endpoints for client tools (PIO-12)

### DIFF
--- a/app/Http/Controllers/Api/SecretController.php
+++ b/app/Http/Controllers/Api/SecretController.php
@@ -18,8 +18,8 @@ class SecretController extends Controller
      */
     public function index(ListSecretsRequest $request): JsonResponse
     {
-        $secrets = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()
-            ->where('user_id', $request->user()->id)
+        $secrets = Secret::withoutEvents(fn () => $request->user()->secrets()
+            ->withoutGlobalScopes()
             ->orderBy('created_at', 'desc')
             ->paginate());
 

--- a/app/Http/Controllers/Api/SecretController.php
+++ b/app/Http/Controllers/Api/SecretController.php
@@ -4,30 +4,19 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\BurnSecretRequest;
+use App\Http\Requests\Api\ListSecretsRequest;
 use App\Http\Requests\Api\StoreSecretRequest;
 use App\Http\Resources\SecretResource;
 use App\Models\Secret;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
-use Illuminate\Routing\Controllers\HasMiddleware;
-use Illuminate\Routing\Controllers\Middleware;
 use Illuminate\Support\Facades\URL;
 
-class SecretController extends Controller implements HasMiddleware
+class SecretController extends Controller
 {
-    public static function middleware(): array
-    {
-        return [
-            new Middleware('ability:secrets:create', only: ['store']),
-            new Middleware('ability:secrets:list', only: ['index']),
-            new Middleware('ability:secrets:delete', only: ['destroy']),
-        ];
-    }
-
     /**
      * List authenticated user's secrets.
      */
-    public function index(Request $request): JsonResponse
+    public function index(ListSecretsRequest $request): JsonResponse
     {
         $secrets = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()
             ->where('user_id', $request->user()->id)

--- a/app/Http/Controllers/Api/SecretController.php
+++ b/app/Http/Controllers/Api/SecretController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\BurnSecretRequest;
+use App\Http\Requests\Api\StoreSecretRequest;
+use App\Http\Resources\SecretResource;
+use App\Models\Secret;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Facades\URL;
+
+class SecretController extends Controller implements HasMiddleware
+{
+    public static function middleware(): array
+    {
+        return [
+            new Middleware('ability:secrets:create', only: ['store']),
+            new Middleware('ability:secrets:list', only: ['index']),
+            new Middleware('ability:secrets:delete', only: ['destroy']),
+        ];
+    }
+
+    /**
+     * List authenticated user's secrets.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $secrets = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()
+            ->where('user_id', $request->user()->id)
+            ->orderBy('created_at', 'desc')
+            ->paginate());
+
+        return SecretResource::collection($secrets)->response();
+    }
+
+    /**
+     * Create a new secret and return the web signed URL.
+     */
+    public function store(StoreSecretRequest $request): JsonResponse
+    {
+        $secret = Secret::create([
+            'message' => $request->message,
+            'expires_at' => $expiresAt = now()->addMinutes((int) $request->expires_in),
+            'user_id' => $request->user()->id,
+        ]);
+
+        $url = URL::temporarySignedRoute('secret.show', $expiresAt, ['secret' => $secret->hash_id]);
+
+        return (new SecretResource($secret))
+            ->additional(['data' => ['url' => $url]])
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Burn (delete) a secret.
+     */
+    public function destroy(BurnSecretRequest $request, string $secret): JsonResponse
+    {
+        $secretRecord = $request->getSecretRecord();
+        $secretRecord->markSilentlyAsRetrieved();
+
+        return response()->json(['message' => 'Secret burned successfully.']);
+    }
+}

--- a/app/Http/Middleware/EnsurePlanHasApiAccess.php
+++ b/app/Http/Middleware/EnsurePlanHasApiAccess.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePlanHasApiAccess
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->subscribed()) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => 'API access requires an active subscription with API support.',
+                ], 403);
+            }
+
+            abort(403, 'API access requires an active subscription with API support.');
+        }
+
+        if (! $user->hasApiAccess()) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => 'Your current plan does not include API access. Please upgrade to a plan with API support.',
+                ], 403);
+            }
+
+            abort(403, 'Your current plan does not include API access.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -36,7 +36,9 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         return array_merge(parent::share($request), [
-            //
+            'auth' => [
+                'hasApiAccess' => fn () => $request->user()?->hasApiAccess() ?? false,
+            ],
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -35,10 +36,8 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
-        $parentShare = parent::share($request);
+        Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
 
-        $parentShare['auth']['hasApiAccess'] = fn () => $request->user()?->hasApiAccess() ?? false;
-
-        return $parentShare;
+        return parent::share($request);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,10 +35,10 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
-        return array_merge(parent::share($request), [
-            'auth' => [
-                'hasApiAccess' => fn () => $request->user()?->hasApiAccess() ?? false,
-            ],
-        ]);
+        $parentShare = parent::share($request);
+
+        $parentShare['auth']['hasApiAccess'] = fn () => $request->user()?->hasApiAccess() ?? false;
+
+        return $parentShare;
     }
 }

--- a/app/Http/Requests/Api/BurnSecretRequest.php
+++ b/app/Http/Requests/Api/BurnSecretRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Models\Secret;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Vinkla\Hashids\Facades\Hashids;
+
+class BurnSecretRequest extends FormRequest
+{
+    private ?Secret $secretRecord = null;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $secret = $this->getSecretRecord();
+
+        if (! $secret) {
+            return false;
+        }
+
+        return $this->user()->can('delete', $secret);
+    }
+
+    public function getSecretRecord(): ?Secret
+    {
+        if ($this->secretRecord !== null) {
+            return $this->secretRecord;
+        }
+
+        $decoded = Hashids::connection('Secret')->decode($this->route('secret'));
+        $id = $decoded[0] ?? null;
+
+        if (! $id) {
+            return null;
+        }
+
+        return $this->secretRecord = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()
+            ->where('user_id', $this->user()->id)
+            ->where('id', $id)
+            ->first());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Api/BurnSecretRequest.php
+++ b/app/Http/Requests/Api/BurnSecretRequest.php
@@ -38,8 +38,8 @@ class BurnSecretRequest extends FormRequest
             return null;
         }
 
-        return $this->secretRecord = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()
-            ->where('user_id', $this->user()->id)
+        return $this->secretRecord = Secret::withoutEvents(fn () => $this->user()->secrets()
+            ->withoutGlobalScopes()
             ->where('id', $id)
             ->first());
     }

--- a/app/Http/Requests/Api/ListSecretsRequest.php
+++ b/app/Http/Requests/Api/ListSecretsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Models\Secret;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListSecretsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->can('viewAny', Secret::class);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Api/StoreSecretRequest.php
+++ b/app/Http/Requests/Api/StoreSecretRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Rules\MessageLength;
+use App\Rules\ValidExpiry;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSecretRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'message' => ['required', 'string', 'min:1', new MessageLength($this->getUserType(), $this->getAllowedMessageLength())],
+            'expires_in' => ['required', 'numeric', new ValidExpiry($this->getUserType())],
+        ];
+    }
+
+    private function getUserType(): string
+    {
+        if ($this->user()->subscribed()) {
+            return 'subscribed';
+        }
+
+        return 'user';
+    }
+
+    private function getAllowedMessageLength(): int
+    {
+        return config('secrets.message_length.user');
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'expires_in' => 'expiry',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/StoreSecretRequest.php
+++ b/app/Http/Requests/Api/StoreSecretRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Models\Secret;
 use App\Rules\MessageLength;
 use App\Rules\ValidExpiry;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -14,7 +15,7 @@ class StoreSecretRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return $this->user()->can('create', Secret::class);
     }
 
     /**

--- a/app/Http/Resources/SecretResource.php
+++ b/app/Http/Resources/SecretResource.php
@@ -20,6 +20,7 @@ class SecretResource extends JsonResource
             'created_at' => $this->created_at,
             'is_expired' => $this->expires_at->isPast(),
             'is_retrieved' => $this->retrieved_at !== null,
+            'retrieved_at' => $this->retrieved_at,
         ];
     }
 }

--- a/app/Http/Resources/SecretResource.php
+++ b/app/Http/Resources/SecretResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SecretResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'hash_id' => $this->hash_id,
+            'expires_at' => $this->expires_at,
+            'created_at' => $this->created_at,
+            'is_expired' => $this->expires_at->isPast(),
+            'is_retrieved' => $this->retrieved_at !== null,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -106,12 +106,12 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return $plan && ($plan->features['api']['type'] ?? 'missing') === 'feature';
     }
 
-    public function getPlanAttribute()
+    public function getPlanAttribute(): PlanResource
     {
         return new PlanResource($this->resolvePlan());
     }
 
-    public function getFrequencyAttribute()
+    public function getFrequencyAttribute(): string
     {
         $stripePrice = $this->subscription?->stripe_price;
         $plan = $this->resolvePlan();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Resources\PlanResource;
+use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -22,7 +23,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
     use Billable;
     use HasApiTokens;
 
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory;
 
     use HasPasskeys;
@@ -74,21 +75,49 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return $this->subscriptions()->active()->first();
     }
 
+    /**
+     * Resolve the user's current subscription Plan model.
+     */
+    public function resolvePlan(): ?Plan
+    {
+        $stripePrice = $this->subscription?->stripe_price;
+
+        if (! $stripePrice) {
+            return null;
+        }
+
+        return Plan::where(fn ($q) => $q
+            ->where('stripe_monthly_price_id', $stripePrice)
+            ->orWhere('stripe_yearly_price_id', $stripePrice)
+        )->first();
+    }
+
+    /**
+     * Check if the user's plan includes API access.
+     */
+    public function hasApiAccess(): bool
+    {
+        if (! $this->subscribed()) {
+            return false;
+        }
+
+        $plan = $this->resolvePlan();
+
+        return $plan && ($plan->features['api']['type'] ?? 'missing') === 'feature';
+    }
+
     public function getPlanAttribute()
     {
-        $stripe_price_id = $this->subscription?->stripe_price;
-
-        return new PlanResource(Plan::where('stripe_monthly_price_id', $stripe_price_id)->orWhere('stripe_yearly_price_id', $stripe_price_id)->first());
+        return new PlanResource($this->resolvePlan());
     }
 
     public function getFrequencyAttribute()
     {
-        $stripe_price_id = $this->subscription?->stripe_price;
-
-        $plan = Plan::where('stripe_monthly_price_id', $stripe_price_id)->orWhere('stripe_yearly_price_id', $stripe_price_id)->first();
+        $stripePrice = $this->subscription?->stripe_price;
+        $plan = $this->resolvePlan();
 
         if ($plan) {
-            return $plan->stripe_monthly_price_id == $stripe_price_id ? 'monthly' : 'yearly';
+            return $plan->stripe_monthly_price_id == $stripePrice ? 'monthly' : 'yearly';
         } else {
             return 'monthly';
         }
@@ -121,6 +150,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         }));
 
         static::deleting(queueable(function (User $customer) {
+            $customer->tokens()->delete();
             $customer->subscriptions()->active()->each(function ($subscription) {
                 $subscription->cancelNow();
             });

--- a/app/Observers/SubscriptionObserver.php
+++ b/app/Observers/SubscriptionObserver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Observers;
+
+use Laravel\Cashier\Subscription;
+
+class SubscriptionObserver
+{
+    public function updated(Subscription $subscription): void
+    {
+        if ($subscription->isDirty('stripe_price') || $subscription->isDirty('ends_at') || $subscription->isDirty('stripe_status')) {
+            $user = $subscription->user;
+
+            if (! $user->hasApiAccess()) {
+                $user->tokens()->delete();
+            }
+        }
+    }
+
+    public function deleted(Subscription $subscription): void
+    {
+        $subscription->user->tokens()->delete();
+    }
+}

--- a/app/Policies/SecretPolicy.php
+++ b/app/Policies/SecretPolicy.php
@@ -12,7 +12,15 @@ class SecretPolicy
      */
     public function viewAny(User $user): bool
     {
-        return false;
+        return $user->tokenCan('secrets:list');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->tokenCan('secrets:create');
     }
 
     /**
@@ -20,10 +28,6 @@ class SecretPolicy
      */
     public function delete(User $user, Secret $secret): bool
     {
-        if ($secret->user_id === $user->id) {
-            return true;
-        }
-
-        return false;
+        return $secret->user_id === $user->id && $user->tokenCan('secrets:delete');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace App\Providers;
 
+use App\Observers\SubscriptionObserver;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Cashier\Subscription;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -15,12 +17,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // 
+        //
     }
 
     private function forceHttps()
     {
-        if (!app()->environment('local')) {
+        if (! app()->environment('local')) {
             URL::forceScheme('https');
         }
     }
@@ -33,6 +35,8 @@ class AppServiceProvider extends ServiceProvider
         $this->defineRateLimits();
 
         $this->forceHttps();
+
+        Subscription::observe(SubscriptionObserver::class);
     }
 
     private function defineRateLimits()
@@ -50,6 +54,16 @@ class AppServiceProvider extends ServiceProvider
                     ->perDay(config('secrets.rate_limit.guest.per_day')
                     )->by($request->ip());
             }
+        });
+
+        RateLimiter::for('api-secrets', function (Request $request) {
+            if ($request->user()->subscribed()) {
+                return Limit::none();
+            }
+
+            $perMinute = config('secrets.rate_limit.user.per_minute', 60);
+
+            return Limit::perMinute($perMinute)->by($request->user()->id);
         });
     }
 }

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -34,13 +34,9 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configurePermissions(): void
     {
-        Jetstream::defaultApiTokenPermissions(['read']);
+        Jetstream::defaultApiTokenPermissions(['secrets:create']);
 
         Jetstream::permissions([
-            'create',
-            'read',
-            'update',
-            'delete',
             'secrets:create',
             'secrets:list',
             'secrets:delete',

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -41,6 +41,9 @@ class JetstreamServiceProvider extends ServiceProvider
             'read',
             'update',
             'delete',
+            'secrets:create',
+            'secrets:list',
+            'secrets:delete',
         ]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\XFrameHeadersMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -16,18 +21,23 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
 
         $middleware->replace(
-            \Illuminate\Http\Middleware\TrustProxies::class,
-            \App\Http\Middleware\TrustProxies::class,
+            TrustProxies::class,
+            App\Http\Middleware\TrustProxies::class,
         );
 
         $middleware->web(append: [
-            \App\Http\Middleware\HandleInertiaRequests::class,
-            \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
-            \App\Http\Middleware\XFrameHeadersMiddleware::class,
+            HandleInertiaRequests::class,
+            AddLinkHeadersForPreloadedAssets::class,
+            XFrameHeadersMiddleware::class,
         ]);
 
         $middleware->validateCsrfTokens(except: [
             'stripe/*',
+        ]);
+
+        $middleware->alias([
+            'ability' => CheckAbilities::class,
+            'abilities' => CheckAbilities::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -36,7 +37,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->alias([
-            'ability' => CheckAbilities::class,
+            'ability' => CheckForAnyAbility::class,
             'abilities' => CheckAbilities::class,
         ]);
     })

--- a/database/migrations/2026_03_21_055438_add_meter_id_to_subscription_items_table.php
+++ b/database/migrations/2026_03_21_055438_add_meter_id_to_subscription_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->string('meter_id')->nullable()->after('stripe_price');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->dropColumn('meter_id');
+        });
+    }
+};

--- a/database/migrations/2026_03_21_055439_add_meter_event_name_to_subscription_items_table.php
+++ b/database/migrations/2026_03_21_055439_add_meter_event_name_to_subscription_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->string('meter_event_name')->nullable()->after('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->dropColumn('meter_event_name');
+        });
+    }
+};

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -67,7 +67,7 @@ class PlanSeederLocal extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'missing',
                     ],
@@ -127,7 +127,7 @@ class PlanSeederLocal extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'missing',
                     ],
@@ -187,7 +187,7 @@ class PlanSeederLocal extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'feature',
                     ],

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -67,7 +67,7 @@ class PlanSeederProd extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'missing',
                     ],
@@ -127,7 +127,7 @@ class PlanSeederProd extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'missing',
                     ],
@@ -187,7 +187,7 @@ class PlanSeederProd extends Seeder
                     ],
                     'api' => [
                         'order' => 6,
-                        'label' => 'API Access (coming soon)',
+                        'label' => 'API Access',
                         'config' => [],
                         'type' => 'feature',
                     ],

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -188,7 +188,7 @@ const logout = () => {
                                                 Profile
                                             </DropdownLink>
 
-                                            <DropdownLink v-if="$page.props.jetstream.hasApiFeatures"
+                                            <DropdownLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"
                                                 :href="route('api-tokens.index')">
                                                 API Tokens
                                             </DropdownLink>
@@ -295,7 +295,7 @@ const logout = () => {
                                     Profile
                                 </ResponsiveNavLink>
 
-                                <ResponsiveNavLink v-if="$page.props.jetstream.hasApiFeatures"
+                                <ResponsiveNavLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"
                                     :href="route('api-tokens.index')" :active="route().current('api-tokens.index')">
                                     API Tokens
                                 </ResponsiveNavLink>

--- a/resources/js/Pages/Secret/Index.vue
+++ b/resources/js/Pages/Secret/Index.vue
@@ -53,7 +53,7 @@ const burn = () => {
                         </tr>
                     </thead>
                     <tbody>
-                        <tr v-for="secret in secrets.data" class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700">
+                        <tr v-for="secret in secrets.data" :key="secret.hash_id" class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700">
                             <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
                                 {{ secret.hash_id }}
                             </th>

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,11 +9,14 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-Route::prefix('v1')->middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
+Route::prefix('v1')->as('api.v1.')->middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
     Route::post('secrets', [SecretController::class, 'store'])
-        ->middleware('throttle:api-secrets');
+        ->middleware('throttle:api-secrets')
+        ->name('secrets.store');
 
-    Route::get('secrets', [SecretController::class, 'index']);
+    Route::get('secrets', [SecretController::class, 'index'])
+        ->name('secrets.index');
 
-    Route::delete('secrets/{secret}', [SecretController::class, 'destroy']);
+    Route::delete('secrets/{secret}', [SecretController::class, 'destroy'])
+        ->name('secrets.destroy');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,19 @@
 <?php
 
+use App\Http\Controllers\Api\SecretController;
+use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::prefix('v1')->middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
+    Route::post('secrets', [SecretController::class, 'store'])
+        ->middleware('throttle:api-secrets');
+
+    Route::get('secrets', [SecretController::class, 'index']);
+
+    Route::delete('secrets/{secret}', [SecretController::class, 'destroy']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,12 +3,14 @@
 use App\Http\Controllers\MarkdownDocumentController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
+use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Laravel\Fortify\Http\Controllers\RegisteredUserController;
 use Laravel\Fortify\RoutePath;
+use Laravel\Jetstream\Http\Controllers\Inertia\ApiTokenController;
 
 Route::get('/', function () {
     return Inertia::render('Welcome', [
@@ -60,6 +62,13 @@ Route::middleware([
 
     Route::get('secrets', [SecretController::class,  'index'])->name('secrets.index');
     Route::delete('secrets/{secret}', [SecretController::class,  'destroy'])->name('secrets.destroy');
+
+    Route::middleware([EnsurePlanHasApiAccess::class])->group(function () {
+        Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
+        Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
+        Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
+        Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+    });
 
     Route::get('/billing', function (Request $request) {
         return $request->user()->redirectToBillingPortal(route('dashboard'));

--- a/tests/Feature/Api/SecretApiTest.php
+++ b/tests/Feature/Api/SecretApiTest.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Plan;
+use App\Models\Secret;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SecretApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Plan $primePlan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->primePlan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => [
+                'messages' => [
+                    'order' => 2,
+                    'label' => ':message_length character limit per message',
+                    'config' => ['message_length' => 100000],
+                    'type' => 'feature',
+                ],
+                'expiry' => [
+                    'order' => 3,
+                    'label' => 'Maximum expiry of :expiry_label',
+                    'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
+                    'type' => 'feature',
+                ],
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Get notified when a message is retrieved',
+                    'config' => ['notifications' => true],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $this->user = User::factory()->withPersonalTeam()->create();
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+    }
+
+    /**
+     * Build a fake encrypted message that passes MessageLength validation.
+     * Format: 16-char salt + base64(28-byte header + plaintext)
+     */
+    private function buildEncryptedMessage(string $plaintext = 'hello'): string
+    {
+        $salt = str_repeat('a', 16);
+        $header = str_repeat("\0", 28);
+        $body = $header.$plaintext;
+
+        return $salt.base64_encode($body);
+    }
+
+    private function createSecretForUser(User $user, array $overrides = []): Secret
+    {
+        return Secret::withoutEvents(fn () => Secret::forceCreate(array_merge([
+            'message' => encrypt('test-encrypted-message'),
+            'expires_at' => now()->addDay(),
+            'user_id' => $user->id,
+            'ip_address_sent' => encrypt('127.0.0.1', false),
+        ], $overrides)));
+    }
+
+    // --- Store endpoint tests ---
+
+    public function test_can_create_secret_via_api(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $response = $this->postJson('/api/v1/secrets', [
+            'message' => $this->buildEncryptedMessage('test secret message'),
+            'expires_in' => 1440,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => ['hash_id', 'url', 'expires_at', 'created_at'],
+            ]);
+
+        $this->assertDatabaseHas('secrets', [
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertStringContainsString('signature=', $response->json('data.url'));
+    }
+
+    public function test_store_validates_required_fields(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $response = $this->postJson('/api/v1/secrets', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['message', 'expires_in']);
+    }
+
+    public function test_store_validates_invalid_expiry(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $response = $this->postJson('/api/v1/secrets', [
+            'message' => $this->buildEncryptedMessage('test'),
+            'expires_in' => 999999,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['expires_in']);
+    }
+
+    // --- Index endpoint tests ---
+
+    public function test_can_list_own_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $this->createSecretForUser($this->user);
+        $this->createSecretForUser($this->user);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['hash_id', 'expires_at', 'created_at', 'is_expired', 'is_retrieved'],
+                ],
+                'links',
+                'meta',
+            ]);
+    }
+
+    public function test_cannot_see_other_users_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $otherUser = User::factory()->withPersonalTeam()->create();
+        $this->createSecretForUser($otherUser);
+        $this->createSecretForUser($this->user);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_index_includes_expired_and_retrieved_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $this->createSecretForUser($this->user);
+        $this->createSecretForUser($this->user, [
+            'expires_at' => now()->subDay(),
+            'message' => null,
+            'retrieved_at' => now()->subHour(),
+        ]);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_index_does_not_burn_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $this->getJson('/api/v1/secrets');
+
+        $freshSecret = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()->find($secret->id));
+        $this->assertNotNull($freshSecret->message);
+        $this->assertNull($freshSecret->retrieved_at);
+    }
+
+    // --- Destroy endpoint tests ---
+
+    public function test_can_burn_own_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:delete']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $response = $this->deleteJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertOk()
+            ->assertJson(['message' => 'Secret burned successfully.']);
+
+        $freshSecret = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()->find($secret->id));
+        $this->assertNull($freshSecret->message);
+        $this->assertNotNull($freshSecret->retrieved_at);
+    }
+
+    public function test_cannot_burn_other_users_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:delete']);
+
+        $otherUser = User::factory()->withPersonalTeam()->create();
+        $secret = $this->createSecretForUser($otherUser);
+
+        $response = $this->deleteJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertForbidden();
+    }
+
+    public function test_destroy_does_not_trigger_retrieval_event(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:delete']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $this->deleteJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $freshSecret = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()->find($secret->id));
+        $this->assertNotNull($freshSecret->retrieved_at);
+    }
+
+    // --- Token abilities tests ---
+
+    public function test_store_requires_create_ability(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $response = $this->postJson('/api/v1/secrets', [
+            'message' => $this->buildEncryptedMessage('test'),
+            'expires_in' => 1440,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_index_requires_list_ability(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertForbidden();
+    }
+
+    public function test_destroy_requires_delete_ability(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $response = $this->deleteJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertForbidden();
+    }
+
+    // --- Authentication tests ---
+
+    public function test_unauthenticated_requests_are_rejected(): void
+    {
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertUnauthorized();
+    }
+
+    // --- Plan-based access gating tests ---
+
+    public function test_user_without_subscription_gets_403(): void
+    {
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertForbidden()
+            ->assertJson(['message' => 'API access requires an active subscription with API support.']);
+    }
+
+    public function test_user_with_non_api_plan_gets_403(): void
+    {
+        $basicPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic',
+            'stripe_yearly_price_id' => 'price_yearly_basic',
+            'stripe_product_id' => 'prod_basic',
+            'price_per_month' => 25,
+            'price_per_year' => 250,
+            'features' => [
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'missing',
+                ],
+            ],
+        ]);
+
+        $this->subscribeUserToPlan($this->user, $basicPlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $response = $this->getJson('/api/v1/secrets');
+
+        $response->assertForbidden()
+            ->assertJson(['message' => 'Your current plan does not include API access. Please upgrade to a plan with API support.']);
+    }
+
+    // --- Token revocation tests ---
+
+    public function test_tokens_revoked_when_subscription_cancelled(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->createToken('test-token', ['secrets:create']);
+        $this->assertCount(1, $this->user->fresh()->tokens);
+
+        $subscription = $this->user->subscriptions()->first();
+        $subscription->update([
+            'stripe_status' => 'canceled',
+            'ends_at' => now(),
+        ]);
+
+        $this->assertCount(0, $this->user->fresh()->tokens);
+    }
+
+    public function test_tokens_revoked_when_plan_downgraded(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->createToken('test-token', ['secrets:create']);
+        $this->assertCount(1, $this->user->fresh()->tokens);
+
+        $basicPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic_2',
+            'stripe_yearly_price_id' => 'price_yearly_basic_2',
+            'stripe_product_id' => 'prod_basic_2',
+            'price_per_month' => 25,
+            'price_per_year' => 250,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $subscription = $this->user->subscriptions()->first();
+        $subscription->update([
+            'stripe_price' => $basicPlan->stripe_monthly_price_id,
+        ]);
+
+        $this->assertCount(0, $this->user->fresh()->tokens);
+    }
+
+    public function test_tokens_kept_when_plan_still_has_api_access(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->createToken('test-token', ['secrets:create']);
+        $this->assertCount(1, $this->user->fresh()->tokens);
+
+        $subscription = $this->user->subscriptions()->first();
+        $subscription->update([
+            'stripe_price' => $this->primePlan->stripe_yearly_price_id,
+        ]);
+
+        $this->assertCount(1, $this->user->fresh()->tokens);
+    }
+
+    // --- Token management page gating tests ---
+
+    public function test_token_management_page_accessible_with_api_plan(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->get('/user/api-tokens');
+
+        $response->assertOk();
+    }
+
+    public function test_token_management_page_blocked_without_api_plan(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->get('/user/api-tokens');
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/ApiTokenPermissionsTest.php
+++ b/tests/Feature/ApiTokenPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -19,6 +20,24 @@ class ApiTokenPermissionsTest extends TestCase
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_perms',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/tests/Feature/CreateApiTokenTest.php
+++ b/tests/Feature/CreateApiTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Features;
@@ -18,6 +19,24 @@ class CreateApiTokenTest extends TestCase
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_create',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
 
         $this->post('/user/api-tokens', [
             'name' => 'Test Token',

--- a/tests/Feature/DeleteApiTokenTest.php
+++ b/tests/Feature/DeleteApiTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -19,6 +20,24 @@ class DeleteApiTokenTest extends TestCase
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_delete',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',


### PR DESCRIPTION
## Summary

- Add versioned API endpoints (`/api/v1/`) for secret CRUD: create, list, and burn secrets via Sanctum-authenticated tokens
- Gate API access by subscription plan — only Prime plan users can create tokens and use API endpoints
- Automatically revoke Sanctum tokens when users downgrade to a plan without API access or cancel their subscription
- Remove "(coming soon)" from API Access plan feature labels

## Changes

### New Files
- `app/Http/Controllers/Api/SecretController.php` — API controller with `store`, `index`, `destroy`
- `app/Http/Middleware/EnsurePlanHasApiAccess.php` — Plan-based API access gate middleware
- `app/Http/Requests/Api/StoreSecretRequest.php` — API store validation (reuses MessageLength/ValidExpiry rules)
- `app/Http/Requests/Api/BurnSecretRequest.php` — API burn authorization with hash ID resolution
- `app/Http/Resources/SecretResource.php` — JSON API resource for secrets
- `app/Observers/SubscriptionObserver.php` — Revokes tokens on plan change/cancellation
- `tests/Feature/Api/SecretApiTest.php` — 21 comprehensive tests

### Modified Files
- `app/Models/User.php` — Added `resolvePlan()`, `hasApiAccess()`, refactored plan accessors, token cleanup on delete
- `routes/api.php` — Versioned API routes with Sanctum + plan gate middleware
- `routes/web.php` — Override Jetstream token routes with plan gate middleware
- `bootstrap/app.php` — Register Sanctum ability middleware aliases
- `app/Providers/AppServiceProvider.php` — API rate limiter, SubscriptionObserver registration
- `app/Http/Middleware/HandleInertiaRequests.php` — Share `hasApiAccess` Inertia prop
- `resources/js/Layouts/AppLayout.vue` — Conditionally show "API Tokens" nav link
- `database/seeders/PlanSeeder{Prod,Local}.php` — Remove "(coming soon)" labels

### Regression Notes
- `getPlanAttribute()` refactored to use `resolvePlan()` — verified behavior equivalent for all existing consumers (`Secret::booted()`, `ValidExpiry`, `MessageLength`)
- Subscription swap between two API-enabled plans correctly preserves tokens
- Seeder label change requires re-seeding existing environments

## Test plan
- [x] 21 new API feature tests pass (endpoints, auth, abilities, plan gating, token revocation)
- [x] 3 existing Jetstream token tests updated and passing
- [x] Full test suite: 52 pass, 2 pre-existing failures (unrelated ProfileInformation + Registration)
- [ ] Manual: verify API Tokens nav link visibility by plan
- [ ] Manual: verify signed URL from API store response works in browser
- [ ] Manual: verify token revocation on plan downgrade via Stripe