### PR TITLE
Add Node.js CLI tool for FlashView (PIO-11)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,50 @@
+name: Publish FlashView CLI
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'tools/flashview-cli/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/flashview-cli
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - run: npm test
+
+      - name: Check if version already published
+        id: version-check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          NPM_VERSION=$(npm view @pioneer-dynamics/flashview-cli version 2>/dev/null || echo "0.0.0")
+          if [ "$LOCAL_VERSION" = "$NPM_VERSION" ]; then
+            echo "Version $LOCAL_VERSION already published. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing version $LOCAL_VERSION (current npm: $NPM_VERSION)"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.skip != 'true'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/app/Http/Controllers/MarkdownDocumentController.php
+++ b/app/Http/Controllers/MarkdownDocumentController.php
@@ -174,4 +174,9 @@ class MarkdownDocumentController extends Controller
     {
         return $this->baseMarkdownRender('markdown/use-cases.md', 'Use Cases', false);
     }
+
+    public function cli()
+    {
+        return $this->baseMarkdownRender('markdown/cli.md', 'CLI Tool', false);
+    }
 }

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -407,6 +407,9 @@ const logout = () => {
                                     <li>
                                         <div class="flex flex-wrap gap-2"><a href="https://docs.flashview.link" target="_blank" class="hover:underline">Docs</a></div>
                                     </li>
+                                    <li>
+                                        <Link :href="route('cli.index')" class="hover:underline">CLI Tool</Link>
+                                    </li>
                                 </ul>
                             </div>
                             <div>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -62,6 +62,11 @@ const logout = () => {
                                             My Secrets
                                         </NavLink>
                                     </template>
+                                    <template v-else>
+                                        <NavLink :href="route('welcome')" :active="route().current('welcome')">
+                                            New Secret
+                                        </NavLink>
+                                    </template>
                                     <template v-if="true">
                                         <NavLink :href="route('plans.index')" :active="route().current('plans.index')">
                                             Pricing
@@ -255,6 +260,11 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('secrets.index')"
                                     :active="route().current('secrets.index')">
                                     My Secrets
+                                </ResponsiveNavLink>
+                            </template>
+                            <template v-else>
+                                <ResponsiveNavLink :href="route('welcome')" :active="route().current('welcome')">
+                                    New Secret
                                 </ResponsiveNavLink>
                             </template>
                             <template v-if="true">

--- a/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue';
-import { useForm } from '@inertiajs/vue3';
+import { useForm, Link } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
 import Checkbox from '@/Components/Checkbox.vue';
@@ -14,6 +14,7 @@ import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import SectionBorder from '@/Components/SectionBorder.vue';
 import TextInput from '@/Components/TextInput.vue';
+import Alert from '@/Components/Alert.vue';
 
 const props = defineProps({
     tokens: Array,
@@ -74,6 +75,17 @@ const deleteApiToken = () => {
 
 <template>
     <div>
+        <!-- CLI Tool Info -->
+        <div class="mb-6">
+            <Alert type="Info" :hideTitle="true">
+                <span class="dark:text-gray-300">
+                    You can also create and manage secrets from your terminal using the
+                    <Link :href="route('cli.index')" class="underline font-semibold">FlashView CLI</Link>.
+                    Learn more and get started.
+                </span>
+            </Alert>
+        </div>
+
         <!-- Generate API Token -->
         <FormSection @submitted="createApiToken">
             <template #title>

--- a/resources/markdown/cli.md
+++ b/resources/markdown/cli.md
@@ -1,0 +1,86 @@
+# FlashView CLI
+
+The {CONFIG:app.name} CLI lets you create and manage encrypted secrets directly from your terminal. Just like the web interface, secrets are encrypted on your machine before being sent to the server — your plaintext never leaves your device.
+
+The CLI requires a {CONFIG:app.name} account with API access (available on paid plans). See [Pricing]({ROUTE:plans.index}) for plan details.
+
+## Requirements
+
+- Node.js 18 or later
+- A {CONFIG:app.name} account with a plan that includes API access
+
+## Installation
+
+Install the CLI globally via npm:
+
+```
+npm install -g @pioneer-dynamics/flashview-cli
+```
+
+Or run it without installing using npx:
+
+```
+npx @pioneer-dynamics/flashview-cli --help
+```
+
+## Setup
+
+You'll need an API token to use the CLI. Generate one from your [API Tokens]({ROUTE:api-tokens.index}) page (requires a plan with API access).
+
+Then configure the CLI:
+
+```
+flashview configure set --token your-api-token
+```
+
+The default server URL is `https://flashview.link`. To use a self-hosted instance, pass `--url`:
+
+```
+flashview configure set --token your-api-token --url https://your-server.com
+```
+
+## Usage
+
+### Create a Secret
+
+```
+# With an inline message
+flashview create --message "my secret password"
+
+# Pipe from stdin
+echo "my secret" | flashview create
+
+# With custom expiry (default: 1 day)
+flashview create -m "secret" --expires-in 7d
+
+# JSON output for scripting
+flashview create -m "secret" --json
+```
+
+**Available expiry options:** 5m, 30m, 1h, 4h, 12h, 1d, 3d, 7d, 14d, 30d
+
+After creating a secret, save the URL and passphrase immediately — they cannot be retrieved later.
+
+### List Your Secrets
+
+```
+flashview list
+flashview list --page 2
+```
+
+### Burn (Delete) a Secret
+
+```
+flashview burn <hash_id>
+flashview burn <hash_id> --yes   # skip confirmation
+```
+
+## Security
+
+- **End-to-end encryption:** Secrets are encrypted locally using AES-256-GCM with PBKDF2 key derivation (SHA-512, 64,000 iterations). The server never sees your plaintext.
+- **Passphrases stay local:** Encryption passphrases are never sent to the server.
+- **Token storage:** API tokens are stored in your OS config directory. On shared systems, set appropriate file permissions.
+
+## Source Code
+
+The CLI is open source. View the source and report issues on <a href="https://github.com/pioneer-dynamics/FlashView/tree/master/tools/flashview-cli" target="_blank" rel="noopener noreferrer">GitHub</a>.

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,7 @@ Route::get('/security', [MarkdownDocumentController::class, 'security'])->name('
 Route::get('/faq', [MarkdownDocumentController::class, 'faq'])->name('faq.index');
 Route::get('/about', [MarkdownDocumentController::class, 'about'])->name('about.index');
 Route::get('/use-cases', [MarkdownDocumentController::class, 'useCases'])->name('useCases.index');
+Route::get('/cli', [MarkdownDocumentController::class, 'cli'])->name('cli.index');
 
 Route::middleware(config('fortify.middleware', ['web']))->group(function () {
     Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])

--- a/tests/Feature/Api/NodeToolCompatibilityTest.php
+++ b/tests/Feature/Api/NodeToolCompatibilityTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Rules\MessageLength;
+use Tests\TestCase;
+
+class NodeToolCompatibilityTest extends TestCase
+{
+    /**
+     * Validate that Node.js CLI ciphertext format (hex salt + base64 ciphertext)
+     * is correctly parsed by the MessageLength validation rule.
+     */
+    public function test_node_encrypted_format_passes_message_length_validation(): void
+    {
+        // Simulate Node.js output: hex(8-byte salt) + base64(12-byte IV + encrypted + 16-byte authTag)
+        $salt = random_bytes(8);
+        $iv = random_bytes(12);
+        $plaintextLength = 13; // "Hello, World!" = 13 bytes
+        $encrypted = random_bytes($plaintextLength);
+        $authTag = random_bytes(16);
+
+        $ciphertext = bin2hex($salt).base64_encode($iv.$encrypted.$authTag);
+
+        // The MessageLength rule should parse this and estimate plaintext = 13 bytes
+        $rule = new MessageLength('guest', 10000);
+
+        $failed = false;
+        $rule->validate('message', $ciphertext, function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertFalse($failed, 'Node.js ciphertext format should pass MessageLength validation');
+    }
+
+    /**
+     * Validate that the 28-byte overhead calculation is correct.
+     */
+    public function test_overhead_calculation_matches_node_format(): void
+    {
+        $salt = random_bytes(8);
+        $iv = random_bytes(12);
+        $plaintextLength = 5;
+        $encrypted = random_bytes($plaintextLength);
+        $authTag = random_bytes(16);
+
+        $ciphertext = bin2hex($salt).base64_encode($iv.$encrypted.$authTag);
+
+        // Extract and verify the overhead math
+        $base64Part = substr($ciphertext, 16);
+        $binary = base64_decode($base64Part);
+        $estimatedPlaintext = strlen($binary) - 28;
+
+        $this->assertEquals($plaintextLength, $estimatedPlaintext);
+    }
+
+    /**
+     * Validate that a message exceeding the guest limit is correctly rejected.
+     */
+    public function test_node_format_exceeding_limit_fails_validation(): void
+    {
+        $guestLimit = config('secrets.message_length.guest');
+
+        $salt = random_bytes(8);
+        $iv = random_bytes(12);
+        $plaintextLength = $guestLimit + 1;
+        $encrypted = random_bytes($plaintextLength);
+        $authTag = random_bytes(16);
+
+        $ciphertext = bin2hex($salt).base64_encode($iv.$encrypted.$authTag);
+
+        $rule = new MessageLength('guest', $guestLimit);
+
+        $failed = false;
+        $rule->validate('message', $ciphertext, function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertTrue($failed, 'Message exceeding guest limit should fail validation');
+    }
+
+    /**
+     * Validate that empty message (0-byte plaintext) is rejected by min_length.
+     */
+    public function test_node_format_empty_message_fails_min_length(): void
+    {
+        $salt = random_bytes(8);
+        $iv = random_bytes(12);
+        $encrypted = ''; // 0 bytes plaintext
+        $authTag = random_bytes(16);
+
+        $ciphertext = bin2hex($salt).base64_encode($iv.$encrypted.$authTag);
+
+        $rule = new MessageLength('guest', 10000, 1);
+
+        $failed = false;
+        $rule->validate('message', $ciphertext, function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertTrue($failed, 'Empty message should fail min_length validation');
+    }
+}

--- a/tests/Feature/Api/NodeToolCompatibilityTest.php
+++ b/tests/Feature/Api/NodeToolCompatibilityTest.php
@@ -23,7 +23,8 @@ class NodeToolCompatibilityTest extends TestCase
         $ciphertext = bin2hex($salt).base64_encode($iv.$encrypted.$authTag);
 
         // The MessageLength rule should parse this and estimate plaintext = 13 bytes
-        $rule = new MessageLength('guest', 10000);
+        $guestLimit = config('secrets.message_length.guest');
+        $rule = new MessageLength('guest', $guestLimit);
 
         $failed = false;
         $rule->validate('message', $ciphertext, function () use (&$failed) {

--- a/tests/Feature/CliPageTest.php
+++ b/tests/Feature/CliPageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class CliPageTest extends TestCase
+{
+    public function test_cli_page_returns_200(): void
+    {
+        $response = $this->get('/cli');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_cli_page_renders_correct_inertia_component(): void
+    {
+        $response = $this->get('/cli');
+
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Doc/Page')
+            ->where('title', 'CLI Tool')
+            ->where('showUpdatedAt', false)
+            ->has('markdown')
+        );
+    }
+}

--- a/tools/flashview-cli/.gitignore
+++ b/tools/flashview-cli/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/flashview-cli/README.md
+++ b/tools/flashview-cli/README.md
@@ -1,0 +1,96 @@
+# FlashView CLI
+
+A command-line tool for creating and managing encrypted secrets via the FlashView API. Secrets are encrypted locally on your machine before being sent to the server — your plaintext never leaves your device.
+
+## Requirements
+
+- Node.js 18 or later
+
+## Installation
+
+```bash
+# From the repository
+cd tools/flashview-cli
+npm install
+npm link
+
+# Or install globally (when published)
+npm install -g flashview-cli
+```
+
+## Setup
+
+Configure your API token and server URL:
+
+```bash
+flashview configure set --url https://your-flashview-server.com --token your-api-token
+```
+
+You can generate an API token from your FlashView dashboard under **API Tokens** (requires a plan with API access).
+
+### View current configuration
+
+```bash
+flashview configure show
+```
+
+### Clear stored configuration
+
+```bash
+flashview configure clear
+```
+
+## Usage
+
+### Create a secret
+
+```bash
+# With inline message
+flashview create --message "my secret password"
+
+# Pipe from stdin
+echo "my secret" | flashview create
+
+# With custom expiry (default: 1d)
+flashview create -m "secret" --expires-in 7d
+
+# With a specific passphrase
+flashview create -m "secret" --passphrase "my-custom-passphrase"
+
+# JSON output for scripting
+flashview create -m "secret" --json
+```
+
+**Expiry options:** `5m`, `30m`, `1h`, `4h`, `12h`, `1d`, `3d`, `7d`, `14d`, `30d`
+
+After creating a secret, save the URL and passphrase immediately — they cannot be retrieved later.
+
+### List secrets
+
+```bash
+flashview list
+
+# Paginated
+flashview list --page 2
+
+# JSON output
+flashview list --json
+```
+
+### Burn (delete) a secret
+
+```bash
+flashview burn <hash_id>
+
+# Skip confirmation
+flashview burn <hash_id> --yes
+
+# JSON output
+flashview burn <hash_id> --json
+```
+
+## Security Notes
+
+- Encryption is performed locally using AES-256-GCM with PBKDF2 key derivation (SHA-512, 64,000 iterations). The server never sees your plaintext.
+- API tokens are stored in plaintext in your OS config directory (e.g., `~/.config/flashview-cli/config.json`). On shared systems, set appropriate file permissions: `chmod 600 ~/.config/flashview-cli/config.json`.
+- Passphrases are never sent to the server.

--- a/tools/flashview-cli/README.md
+++ b/tools/flashview-cli/README.md
@@ -9,13 +9,7 @@ A command-line tool for creating and managing encrypted secrets via the FlashVie
 ## Installation
 
 ```bash
-# From the repository
-cd tools/flashview-cli
-npm install
-npm link
-
-# Or install globally (when published)
-npm install -g flashview-cli
+npm install -g @pioneer-dynamics/flashview-cli
 ```
 
 ## Setup
@@ -23,7 +17,7 @@ npm install -g flashview-cli
 Configure your API token and server URL:
 
 ```bash
-flashview configure set --url https://your-flashview-server.com --token your-api-token
+flashview configure set --url https://flashview.link --token your-api-token
 ```
 
 You can generate an API token from your FlashView dashboard under **API Tokens** (requires a plan with API access).

--- a/tools/flashview-cli/bin/flashview.js
+++ b/tools/flashview-cli/bin/flashview.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { run } from '../src/cli.js';
+
+run();

--- a/tools/flashview-cli/package-lock.json
+++ b/tools/flashview-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flashview-cli",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flashview-cli",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "dependencies": {
                 "commander": "^12.0.0",
                 "conf": "^13.0.0",

--- a/tools/flashview-cli/package-lock.json
+++ b/tools/flashview-cli/package-lock.json
@@ -1,0 +1,268 @@
+{
+    "name": "flashview-cli",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "flashview-cli",
+            "version": "1.0.0",
+            "dependencies": {
+                "commander": "^12.0.0",
+                "conf": "^13.0.0",
+                "random-words": "^2.0.0"
+            },
+            "bin": {
+                "flashview": "bin/flashview.js"
+            },
+            "devDependencies": {},
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/atomically": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+            "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-fs": "^2.0.0",
+                "when-exit": "^2.1.4"
+            }
+        },
+        "node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conf": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/conf/-/conf-13.1.0.tgz",
+            "integrity": "sha512-Bi6v586cy1CoTFViVO4lGTtx780lfF96fUmS1lSX6wpZf6330NvHUu6fReVuDP1de8Mg0nkZb01c8tAQdz1o3w==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "atomically": "^2.0.3",
+                "debounce-fn": "^6.0.0",
+                "dot-prop": "^9.0.0",
+                "env-paths": "^3.0.0",
+                "json-schema-typed": "^8.0.1",
+                "semver": "^7.6.3",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/debounce-fn": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+            "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dot-prop": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+            "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^4.18.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/random-words": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/random-words/-/random-words-2.0.1.tgz",
+            "integrity": "sha512-nZNJAmgcFmtJMTDDIUCm/iK4R6RydC6NvALvWhYItXQrgYGk1F7Gww416LpVROFQtfVd5TaLEf4WuSsko03N7w==",
+            "license": "MIT",
+            "dependencies": {
+                "seedrandom": "^3.0.5"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+            "license": "MIT"
+        },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/stubborn-fs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+            "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-utils": "^1.0.1"
+            }
+        },
+        "node_modules/stubborn-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+            "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+            "license": "MIT"
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/when-exit": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+            "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+            "license": "MIT"
+        }
+    }
+}

--- a/tools/flashview-cli/package.json
+++ b/tools/flashview-cli/package.json
@@ -8,7 +8,7 @@
         "src/",
         "README.md"
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "CLI tool for FlashView — create and manage encrypted secrets",
     "type": "module",
     "bin": {

--- a/tools/flashview-cli/package.json
+++ b/tools/flashview-cli/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "flashview-cli",
+    "version": "1.0.0",
+    "description": "CLI tool for FlashView — create and manage encrypted secrets",
+    "type": "module",
+    "bin": {
+        "flashview": "./bin/flashview.js"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "scripts": {
+        "test": "node --test tests/*.test.js"
+    },
+    "dependencies": {
+        "commander": "^12.0.0",
+        "conf": "^13.0.0",
+        "random-words": "^2.0.0"
+    },
+    "devDependencies": {}
+}

--- a/tools/flashview-cli/package.json
+++ b/tools/flashview-cli/package.json
@@ -1,5 +1,13 @@
 {
-    "name": "flashview-cli",
+    "name": "@pioneer-dynamics/flashview-cli",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "bin/",
+        "src/",
+        "README.md"
+    ],
     "version": "1.0.0",
     "description": "CLI tool for FlashView — create and manage encrypted secrets",
     "type": "module",

--- a/tools/flashview-cli/src/api.js
+++ b/tools/flashview-cli/src/api.js
@@ -1,0 +1,110 @@
+const DEFAULT_TIMEOUT = 30000; // 30 seconds
+
+export class FlashViewClient {
+    /**
+     * @param {string} baseUrl
+     * @param {string} token
+     * @param {number} timeout
+     */
+    constructor(baseUrl, token, timeout = DEFAULT_TIMEOUT) {
+        this.baseUrl = baseUrl.replace(/\/$/, '');
+        this.token = token;
+        this.timeout = timeout;
+    }
+
+    /**
+     * Create an encrypted secret.
+     *
+     * @param {string} encryptedMessage
+     * @param {number} expiresIn - Minutes until expiry
+     * @param {string|null} email - Optional recipient email
+     * @returns {Promise<Object>}
+     */
+    async createSecret(encryptedMessage, expiresIn = 1440, email = null) {
+        const body = { message: encryptedMessage, expires_in: expiresIn };
+        if (email) {
+            body.email = email;
+        }
+
+        return this.request('POST', '/api/v1/secrets', body);
+    }
+
+    /**
+     * List the authenticated user's secrets.
+     *
+     * @param {number} page
+     * @returns {Promise<Object>}
+     */
+    async listSecrets(page = 1) {
+        return this.request('GET', `/api/v1/secrets?page=${page}`);
+    }
+
+    /**
+     * Burn (delete) a secret.
+     *
+     * @param {string} hashId
+     * @returns {Promise<Object>}
+     */
+    async burnSecret(hashId) {
+        return this.request('DELETE', `/api/v1/secrets/${hashId}`);
+    }
+
+    /**
+     * @param {string} method
+     * @param {string} path
+     * @param {Object|null} body
+     * @returns {Promise<Object>}
+     */
+    async request(method, path, body = null) {
+        const url = `${this.baseUrl}${path}`;
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), this.timeout);
+
+        const options = {
+            method,
+            signal: controller.signal,
+            headers: {
+                'Authorization': `Bearer ${this.token}`,
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+        };
+
+        if (body) {
+            options.body = JSON.stringify(body);
+        }
+
+        let response;
+        try {
+            response = await fetch(url, options);
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                throw new ApiError('Request timed out', 0);
+            }
+            throw err;
+        } finally {
+            clearTimeout(timeout);
+        }
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            const message = error.message || `HTTP ${response.status}`;
+            throw new ApiError(message, response.status, error.errors);
+        }
+
+        return response.json();
+    }
+}
+
+export class ApiError extends Error {
+    /**
+     * @param {string} message
+     * @param {number} status
+     * @param {Object|null} errors
+     */
+    constructor(message, status, errors = null) {
+        super(message);
+        this.status = status;
+        this.errors = errors;
+    }
+}

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -1,0 +1,260 @@
+import { Command } from 'commander';
+import { createInterface } from 'node:readline';
+import { encryptMessage } from './crypto.js';
+import { FlashViewClient, ApiError } from './api.js';
+import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
+
+// Allowed expiry values — must match config/secrets.php expiry_options
+// See: config/secrets.php for the server-side list
+const EXPIRY_LABELS = {
+    '5m': 5, '30m': 30, '1h': 60, '4h': 240, '12h': 720,
+    '1d': 1440, '3d': 4320, '7d': 10080, '14d': 20160, '30d': 43200,
+};
+const ALLOWED_EXPIRY_OPTIONS = Object.values(EXPIRY_LABELS);
+
+/**
+ * Parse an expiry value from human-readable label or raw minutes.
+ *
+ * @param {string} value
+ * @returns {number|null}
+ */
+function parseExpiry(value) {
+    if (EXPIRY_LABELS[value.toLowerCase()]) {
+        return EXPIRY_LABELS[value.toLowerCase()];
+    }
+
+    const minutes = parseInt(value, 10);
+    if (!isNaN(minutes) && ALLOWED_EXPIRY_OPTIONS.includes(minutes)) {
+        return minutes;
+    }
+
+    return null;
+}
+
+/**
+ * Read all data from stdin.
+ *
+ * @returns {Promise<string>}
+ */
+async function readStdin() {
+    const chunks = [];
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString('utf8').trim();
+}
+
+/**
+ * Prompt for a yes/no confirmation.
+ *
+ * @param {string} question
+ * @returns {Promise<boolean>}
+ */
+function confirm(question) {
+    return new Promise((resolve) => {
+        const rl = createInterface({ input: process.stdin, output: process.stdout });
+        rl.question(question, (answer) => {
+            rl.close();
+            resolve(answer.toLowerCase() === 'y');
+        });
+    });
+}
+
+/**
+ * Wrap an async action with standard API error handling.
+ *
+ * @param {Function} fn
+ * @returns {Function}
+ */
+function withErrorHandling(fn) {
+    return async (...args) => {
+        try {
+            await fn(...args);
+        } catch (err) {
+            if (err instanceof ApiError) {
+                if (err.status === 401) {
+                    console.error('Authentication failed. Run `flashview configure set` to update your token.');
+                } else if (err.status === 403) {
+                    console.error(err.message);
+                } else if (err.status === 422 && err.errors) {
+                    console.error('Validation errors:');
+                    for (const [field, messages] of Object.entries(err.errors)) {
+                        for (const msg of messages) {
+                            console.error(`  ${field}: ${msg}`);
+                        }
+                    }
+                } else if (err.status === 0) {
+                    console.error(err.message);
+                } else {
+                    console.error(`Error: ${err.message}`);
+                }
+                process.exit(1);
+            }
+
+            if (err.code === 'ECONNREFUSED' || err.code === 'ENOTFOUND') {
+                console.error('Could not connect to server. Check your URL and network.');
+                process.exit(1);
+            }
+
+            throw err;
+        }
+    };
+}
+
+const program = new Command();
+
+program
+    .name('flashview')
+    .description('FlashView CLI — Create and manage encrypted secrets')
+    .version('1.0.0');
+
+// --- Configure ---
+
+const configure = program
+    .command('configure')
+    .description('Manage CLI configuration');
+
+configure
+    .command('set')
+    .description('Set API token and server URL')
+    .requiredOption('--url <url>', 'FlashView server URL')
+    .requiredOption('--token <token>', 'API token (from FlashView dashboard)')
+    .action(({ url, token }) => {
+        setConfig({ url, token });
+        console.log('Configuration saved.');
+    });
+
+configure
+    .command('show')
+    .description('Show current configuration')
+    .action(() => {
+        const { url, token, path } = getConfigInfo();
+        console.log(`Server URL: ${url || '(not set)'}`);
+        console.log(`API Token:  ${token ? token.substring(0, 8) + '...' : '(not set)'}`);
+        console.log(`Config:     ${path}`);
+    });
+
+configure
+    .command('clear')
+    .description('Clear stored configuration')
+    .action(() => {
+        clearConfig();
+        console.log('Configuration cleared.');
+    });
+
+// --- Create ---
+
+program
+    .command('create')
+    .description('Create an encrypted secret')
+    .option('-m, --message <text>', 'Secret message (reads from stdin if omitted)')
+    .option('-p, --passphrase <passphrase>', 'Encryption passphrase (auto-generated if omitted)')
+    .option('-e, --expires-in <duration>', 'Expiry duration (5m, 30m, 1h, 4h, 12h, 1d, 3d, 7d, 14d, 30d)', '1d')
+    .option('--email <address>', 'Recipient email address')
+    .option('--json', 'Output as JSON (for scripting)')
+    .action(withErrorHandling(async (options) => {
+        const config = getConfig();
+        const client = new FlashViewClient(config.url, config.token);
+
+        const expiresIn = parseExpiry(options.expiresIn);
+        if (!expiresIn) {
+            const labels = Object.keys(EXPIRY_LABELS).join(', ');
+            console.error(`Invalid expiry value: ${options.expiresIn}`);
+            console.error(`Allowed values: ${labels}`);
+            process.exit(1);
+        }
+
+        let message = options.message;
+        if (!message) {
+            if (process.stdin.isTTY) {
+                console.error('No message provided. Use --message or pipe input via stdin.');
+                console.error('Example: echo "my secret" | flashview create');
+                process.exit(1);
+            }
+            message = await readStdin();
+        }
+
+        const { passphrase, secret } = encryptMessage(message, options.passphrase);
+
+        const result = await client.createSecret(secret, expiresIn, options.email);
+
+        if (options.json) {
+            console.log(JSON.stringify({
+                url: result.data.url,
+                passphrase,
+                hash_id: result.data.hash_id,
+                expires_at: result.data.expires_at,
+            }));
+        } else {
+            console.log('Secret created successfully!\n');
+            console.log(`URL:        ${result.data.url}`);
+            console.log(`Passphrase: ${passphrase}`);
+            console.log(`Hash ID:    ${result.data.hash_id}`);
+            console.log(`Expires:    ${result.data.expires_at}`);
+            console.log('\nSave the URL and passphrase now — they cannot be retrieved later.');
+        }
+    }));
+
+// --- List ---
+
+program
+    .command('list')
+    .description('List your secrets')
+    .option('-p, --page <number>', 'Page number', '1')
+    .option('--json', 'Output as JSON (for scripting)')
+    .action(withErrorHandling(async (options) => {
+        const config = getConfig();
+        const client = new FlashViewClient(config.url, config.token);
+
+        const result = await client.listSecrets(parseInt(options.page, 10));
+
+        if (options.json) {
+            console.log(JSON.stringify(result));
+        } else {
+            if (!result.data.length) {
+                console.log('No secrets found.');
+                return;
+            }
+            console.log('Hash ID          Expires At               Status');
+            console.log('\u2500'.repeat(60));
+            for (const secret of result.data) {
+                const status = secret.is_retrieved ? 'Retrieved' : secret.is_expired ? 'Expired' : 'Active';
+                console.log(`${secret.hash_id.padEnd(17)}${secret.expires_at.padEnd(25)}${status}`);
+            }
+            if (result.meta?.last_page > 1) {
+                console.log(`\nPage ${result.meta.current_page} of ${result.meta.last_page}`);
+            }
+        }
+    }));
+
+// --- Burn ---
+
+program
+    .command('burn <hashId>')
+    .description('Burn (delete) a secret')
+    .option('--json', 'Output as JSON (for scripting)')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .action(withErrorHandling(async (hashId, options) => {
+        if (!options.yes && !options.json && process.stdin.isTTY) {
+            const confirmed = await confirm(`Burn secret ${hashId}? This cannot be undone. (y/N) `);
+            if (!confirmed) {
+                console.log('Cancelled.');
+                return;
+            }
+        }
+
+        const config = getConfig();
+        const client = new FlashViewClient(config.url, config.token);
+
+        await client.burnSecret(hashId);
+
+        if (options.json) {
+            console.log(JSON.stringify({ message: 'Secret burned successfully.' }));
+        } else {
+            console.log('Secret burned successfully.');
+        }
+    }));
+
+export function run() {
+    program.parse();
+}

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -117,7 +117,7 @@ const configure = program
 configure
     .command('set')
     .description('Set API token and server URL')
-    .requiredOption('--url <url>', 'FlashView server URL')
+    .option('--url <url>', 'FlashView server URL (default: https://flashview.link)')
     .requiredOption('--token <token>', 'API token (from FlashView dashboard)')
     .action(({ url, token }) => {
         setConfig({ url, token });

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -1,5 +1,7 @@
 import Conf from 'conf';
 
+const DEFAULT_URL = 'https://flashview.link';
+
 const config = new Conf({
     projectName: 'flashview-cli',
     schema: {
@@ -14,11 +16,11 @@ const config = new Conf({
  * @returns {{ url: string, token: string }}
  */
 export function getConfig() {
-    const url = config.get('url');
+    const url = config.get('url') || DEFAULT_URL;
     const token = config.get('token');
 
-    if (!url || !token) {
-        console.error('Not configured. Run: flashview configure set --url <url> --token <token>');
+    if (!token) {
+        console.error('Not configured. Run: flashview configure set --token <token>');
         process.exit(1);
     }
 
@@ -44,8 +46,8 @@ export function getConfigInfo() {
  * @param {{ url: string, token: string }} options
  */
 export function setConfig({ url, token }) {
-    config.set('url', url);
-    config.set('token', token);
+    if (url) config.set('url', url);
+    if (token) config.set('token', token);
 }
 
 /**

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -1,0 +1,56 @@
+import Conf from 'conf';
+
+const config = new Conf({
+    projectName: 'flashview-cli',
+    schema: {
+        url: { type: 'string' },
+        token: { type: 'string' },
+    },
+});
+
+/**
+ * Get the stored configuration, exiting if not configured.
+ *
+ * @returns {{ url: string, token: string }}
+ */
+export function getConfig() {
+    const url = config.get('url');
+    const token = config.get('token');
+
+    if (!url || !token) {
+        console.error('Not configured. Run: flashview configure set --url <url> --token <token>');
+        process.exit(1);
+    }
+
+    return { url, token };
+}
+
+/**
+ * Get configuration info for display.
+ *
+ * @returns {{ url: string|undefined, token: string|undefined, path: string }}
+ */
+export function getConfigInfo() {
+    return {
+        url: config.get('url'),
+        token: config.get('token'),
+        path: config.path,
+    };
+}
+
+/**
+ * Save configuration.
+ *
+ * @param {{ url: string, token: string }} options
+ */
+export function setConfig({ url, token }) {
+    config.set('url', url);
+    config.set('token', token);
+}
+
+/**
+ * Clear all stored configuration.
+ */
+export function clearConfig() {
+    config.clear();
+}

--- a/tools/flashview-cli/src/crypto.js
+++ b/tools/flashview-cli/src/crypto.js
@@ -1,0 +1,78 @@
+import { randomBytes, pbkdf2Sync, createCipheriv, createDecipheriv } from 'node:crypto';
+import { generate } from 'random-words';
+
+const PBKDF2_ITERATIONS = 64000;
+const KEY_LENGTH = 32; // 256-bit key for AES-256-GCM
+const IV_LENGTH = 12;  // 96-bit IV for AES-GCM
+const SALT_LENGTH = 8; // 8 bytes = 16 hex chars
+
+/**
+ * Generate an 8-word hyphenated passphrase.
+ *
+ * @returns {string}
+ */
+export function generatePassphrase() {
+    return generate({ exactly: 8, join: '-' });
+}
+
+/**
+ * Encrypt a plaintext message using AES-256-GCM with PBKDF2 key derivation.
+ *
+ * Output format matches the browser's OpenCrypto implementation:
+ * hex(8-byte salt) + base64(12-byte IV + encrypted data + 16-byte auth tag)
+ *
+ * @param {string} plaintext
+ * @param {string|null} passphrase - Auto-generated if null
+ * @returns {{ passphrase: string, secret: string }}
+ */
+export function encryptMessage(plaintext, passphrase = null) {
+    if (!passphrase) {
+        passphrase = generatePassphrase();
+    }
+
+    const salt = randomBytes(SALT_LENGTH);
+    const key = pbkdf2Sync(passphrase, salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha512');
+    const iv = randomBytes(IV_LENGTH);
+
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag(); // 16 bytes
+
+    // Combine IV + encrypted + authTag (matches OpenCrypto format)
+    const ciphertext = Buffer.concat([iv, encrypted, authTag]);
+
+    // Format: hex(salt) + base64(IV + encrypted + authTag)
+    const saltHex = salt.toString('hex');
+    const ciphertextBase64 = ciphertext.toString('base64');
+
+    return {
+        passphrase,
+        secret: saltHex + ciphertextBase64,
+    };
+}
+
+/**
+ * Decrypt a ciphertext string using AES-256-GCM with PBKDF2 key derivation.
+ *
+ * @param {string} ciphertextString - hex(salt) + base64(IV + encrypted + authTag)
+ * @param {string} passphrase
+ * @returns {string}
+ */
+export function decryptMessage(ciphertextString, passphrase) {
+    const saltHex = ciphertextString.substring(0, 16);
+    const salt = Buffer.from(saltHex, 'hex');
+
+    const ciphertext = Buffer.from(ciphertextString.substring(16), 'base64');
+
+    const key = pbkdf2Sync(passphrase, salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha512');
+
+    const iv = ciphertext.subarray(0, 12);
+    const authTag = ciphertext.subarray(ciphertext.length - 16);
+    const encryptedData = ciphertext.subarray(12, ciphertext.length - 16);
+
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encryptedData), decipher.final()]);
+
+    return decrypted.toString('utf8');
+}

--- a/tools/flashview-cli/tests/api.test.js
+++ b/tools/flashview-cli/tests/api.test.js
@@ -1,0 +1,44 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { FlashViewClient, ApiError } from '../src/api.js';
+
+describe('FlashViewClient', () => {
+    it('constructs with correct base URL stripping trailing slash', () => {
+        const client = new FlashViewClient('https://example.com/', 'test-token');
+        assert.equal(client.baseUrl, 'https://example.com');
+    });
+
+    it('constructs without trailing slash', () => {
+        const client = new FlashViewClient('https://example.com', 'test-token');
+        assert.equal(client.baseUrl, 'https://example.com');
+    });
+
+    it('accepts custom timeout', () => {
+        const client = new FlashViewClient('https://example.com', 'test-token', 5000);
+        assert.equal(client.timeout, 5000);
+    });
+
+    it('uses default timeout of 30 seconds', () => {
+        const client = new FlashViewClient('https://example.com', 'test-token');
+        assert.equal(client.timeout, 30000);
+    });
+});
+
+describe('ApiError', () => {
+    it('stores status and errors', () => {
+        const error = new ApiError('Not found', 404, { id: ['Invalid'] });
+        assert.equal(error.message, 'Not found');
+        assert.equal(error.status, 404);
+        assert.deepEqual(error.errors, { id: ['Invalid'] });
+    });
+
+    it('defaults errors to null', () => {
+        const error = new ApiError('Timeout', 0);
+        assert.equal(error.errors, null);
+    });
+
+    it('is an instance of Error', () => {
+        const error = new ApiError('Test', 500);
+        assert.ok(error instanceof Error);
+    });
+});

--- a/tools/flashview-cli/tests/crypto.test.js
+++ b/tools/flashview-cli/tests/crypto.test.js
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { encryptMessage, decryptMessage, generatePassphrase } from '../src/crypto.js';
+
+describe('generatePassphrase', () => {
+    it('generates an 8-word hyphenated passphrase', () => {
+        const passphrase = generatePassphrase();
+        const words = passphrase.split('-');
+        assert.equal(words.length, 8, 'Passphrase should have 8 words');
+        for (const word of words) {
+            assert.ok(word.length > 0, 'Each word should be non-empty');
+        }
+    });
+
+    it('generates unique passphrases', () => {
+        const a = generatePassphrase();
+        const b = generatePassphrase();
+        assert.notEqual(a, b, 'Two generated passphrases should differ');
+    });
+});
+
+describe('encryptMessage', () => {
+    it('returns passphrase and encrypted secret', () => {
+        const result = encryptMessage('Hello, World!');
+        assert.ok(result.passphrase, 'Should return a passphrase');
+        assert.ok(result.secret, 'Should return an encrypted secret');
+    });
+
+    it('uses provided passphrase when given', () => {
+        const passphrase = 'my-custom-passphrase';
+        const result = encryptMessage('Hello', passphrase);
+        assert.equal(result.passphrase, passphrase);
+    });
+
+    it('auto-generates passphrase when not provided', () => {
+        const result = encryptMessage('Hello');
+        const words = result.passphrase.split('-');
+        assert.equal(words.length, 8);
+    });
+
+    it('produces format: 16 hex chars + base64 data', () => {
+        const result = encryptMessage('Test message');
+        const saltHex = result.secret.substring(0, 16);
+        const base64Part = result.secret.substring(16);
+
+        // Salt should be valid hex (16 chars = 8 bytes)
+        assert.match(saltHex, /^[0-9a-f]{16}$/, 'Salt should be 16 hex characters');
+
+        // Base64 part should decode without error
+        const decoded = Buffer.from(base64Part, 'base64');
+        assert.ok(decoded.length > 0, 'Base64 should decode to non-empty buffer');
+
+        // Decoded buffer should contain: 12 (IV) + plaintext length + 16 (auth tag) bytes
+        // "Test message" = 12 bytes, so total = 12 + 12 + 16 = 40
+        assert.equal(decoded.length, 40, 'Decoded ciphertext should be IV + encrypted + authTag');
+    });
+
+    it('produces different ciphertext for same plaintext (random salt/IV)', () => {
+        const a = encryptMessage('Same message', 'same-passphrase');
+        const b = encryptMessage('Same message', 'same-passphrase');
+        assert.notEqual(a.secret, b.secret, 'Different salt/IV should produce different ciphertext');
+    });
+});
+
+describe('decryptMessage', () => {
+    it('round-trips encryption and decryption', () => {
+        const plaintext = 'Hello, World!';
+        const { passphrase, secret } = encryptMessage(plaintext);
+        const decrypted = decryptMessage(secret, passphrase);
+        assert.equal(decrypted, plaintext);
+    });
+
+    it('round-trips with custom passphrase', () => {
+        const plaintext = 'Secret data 123!@#';
+        const passphrase = 'my-test-passphrase';
+        const { secret } = encryptMessage(plaintext, passphrase);
+        const decrypted = decryptMessage(secret, passphrase);
+        assert.equal(decrypted, plaintext);
+    });
+
+    it('round-trips with empty string', () => {
+        const { passphrase, secret } = encryptMessage('');
+        const decrypted = decryptMessage(secret, passphrase);
+        assert.equal(decrypted, '');
+    });
+
+    it('round-trips with unicode characters', () => {
+        const plaintext = 'Hello \u{1F680} World \u00E9\u00E8\u00EA \u4F60\u597D';
+        const { passphrase, secret } = encryptMessage(plaintext);
+        const decrypted = decryptMessage(secret, passphrase);
+        assert.equal(decrypted, plaintext);
+    });
+
+    it('round-trips with long message', () => {
+        const plaintext = 'A'.repeat(10000);
+        const { passphrase, secret } = encryptMessage(plaintext);
+        const decrypted = decryptMessage(secret, passphrase);
+        assert.equal(decrypted, plaintext);
+    });
+
+    it('fails with wrong passphrase', () => {
+        const { secret } = encryptMessage('Hello', 'correct-passphrase');
+        assert.throws(() => {
+            decryptMessage(secret, 'wrong-passphrase');
+        }, 'Should throw with wrong passphrase');
+    });
+
+    it('fails with corrupted ciphertext', () => {
+        const { passphrase, secret } = encryptMessage('Hello');
+        const corrupted = secret.substring(0, 16) + 'AAAA' + secret.substring(20);
+        assert.throws(() => {
+            decryptMessage(corrupted, passphrase);
+        }, 'Should throw with corrupted ciphertext');
+    });
+});
+
+describe('ciphertext format compatibility', () => {
+    it('matches expected overhead for MessageLength validation', () => {
+        // The MessageLength rule subtracts 28 bytes (12 IV + 16 auth tag) from the
+        // decoded base64 length to estimate plaintext length.
+        const plaintext = 'Hello'; // 5 bytes
+        const { secret } = encryptMessage(plaintext, 'test-passphrase');
+
+        const base64Part = secret.substring(16);
+        const decoded = Buffer.from(base64Part, 'base64');
+
+        // decoded length = IV (12) + plaintext (5) + authTag (16) = 33
+        assert.equal(decoded.length, 33);
+
+        // The estimated plaintext length (what MessageLength calculates)
+        const estimatedPlaintext = decoded.length - 28;
+        assert.equal(estimatedPlaintext, 5, 'Estimated plaintext length should match actual');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a standalone Node.js CLI tool (`tools/flashview-cli/`) for creating, listing, and burning encrypted secrets via the FlashView API
- Performs AES-256-GCM encryption with PBKDF2 (SHA-512, 64,000 iterations) client-side, matching the browser's OpenCrypto implementation exactly
- Supports: `configure` (set/show/clear), `create` (with stdin piping, JSON output, human-readable expiry), `list`, and `burn` (with confirmation prompt)

## Test plan
- [x] 22 Node.js unit tests passing (encryption round-trip, format compatibility, API client)
- [x] 4 PHPUnit cross-compatibility tests passing (validates ciphertext format against `MessageLength` rule)
- [x] Manual: create secret via CLI, verify it decrypts correctly in the browser
- [x] Manual: test all CLI commands (configure set/show/clear, create, list, burn)
- [x] Manual: test error handling (invalid token, plan without API access, invalid expiry)
- [x] Manual: test stdin piping (`echo "secret" | flashview create`)
- [x] Manual: test JSON output mode for scripting

## Regression risks (informational)
- Encryption format in `crypto.js` is coupled to browser's `encryption.js` — changes to either must be mirrored
- Hardcoded expiry options in `cli.js` must stay in sync with `config/secrets.php`
- CLI depends on API response shape from `SecretResource`