### PR TITLE
Fix Node 18 compatibility for crypto.randomUUID (PIO-13)

### DIFF
--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import crypto from 'node:crypto';
 import { createServer } from 'node:http';
 import { createInterface } from 'node:readline';
 import { encryptMessage } from './crypto.js';

--- a/tools/flashview-cli/tests/login.test.js
+++ b/tools/flashview-cli/tests/login.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import { createServer } from 'node:http';
 
 describe('login helpers', () => {


### PR DESCRIPTION
Import crypto from node:crypto explicitly instead of relying on the global, which is only available in Node 20+.