### PR TITLE
Add repository field to flashview-cli package.json

### DIFF
--- a/tools/flashview-cli/package.json
+++ b/tools/flashview-cli/package.json
@@ -10,6 +10,11 @@
     ],
     "version": "1.1.0",
     "description": "CLI tool for FlashView — create and manage encrypted secrets",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/pioneer-dynamics/FlashView",
+        "directory": "tools/flashview-cli"
+    },
     "type": "module",
     "bin": {
         "flashview": "./bin/flashview.js"


### PR DESCRIPTION
Required for npm publish with --provenance flag to verify the package source matches the GitHub Actions build.