### PR TITLE
Fix default permission selection when re-running flashview login

### DIFF
--- a/app/Http/Controllers/CliAuthController.php
+++ b/app/Http/Controllers/CliAuthController.php
@@ -20,12 +20,20 @@ class CliAuthController extends Controller
      */
     public function show(CliAuthorizeRequest $request): Response
     {
+        $user = $request->user();
+
+        $existingToken = $user->tokens()->where('name', 'FlashView CLI')->first();
+
+        $defaultPermissions = $existingToken
+            ? $existingToken->abilities
+            : Jetstream::$defaultPermissions;
+
         return Inertia::render('Cli/Authorize', [
             'port' => (int) $request->validated('port'),
             'state' => $request->validated('state'),
-            'hasApiAccess' => $request->user()->hasApiAccess(),
+            'hasApiAccess' => $user->hasApiAccess(),
             'availablePermissions' => Jetstream::$permissions,
-            'defaultPermissions' => Jetstream::$defaultPermissions,
+            'defaultPermissions' => $defaultPermissions,
         ]);
     }
 

--- a/resources/js/Pages/Cli/Authorize.vue
+++ b/resources/js/Pages/Cli/Authorize.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-import { Link, router, usePage } from '@inertiajs/vue3'
+import { Head, Link, router, usePage } from '@inertiajs/vue3'
 import AuthenticationCard from '@/Components/AuthenticationCard.vue'
 import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue'
 import Checkbox from '@/Components/Checkbox.vue'
@@ -31,6 +31,8 @@ function submit(action) {
 </script>
 
 <template>
+    <Head title="CLI Login" />
+
     <AuthenticationCard>
         <template #logo>
             <AuthenticationCardLogo />

--- a/tests/Feature/CliAuthTest.php
+++ b/tests/Feature/CliAuthTest.php
@@ -339,4 +339,50 @@ class CliAuthTest extends TestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors(['code', 'state']);
     }
+
+    public function test_authorize_page_defaults_to_existing_token_abilities(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $user->createToken('FlashView CLI', ['secrets:create', 'secrets:list']);
+
+        $response = $this->actingAs($user)
+            ->get('/cli/authorize?port=12345&state=abcdef1234567890');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('defaultPermissions', ['secrets:create', 'secrets:list'])
+        );
+    }
+
+    public function test_authorize_page_defaults_to_jetstream_defaults_when_no_cli_token_exists(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $response = $this->actingAs($user)
+            ->get('/cli/authorize?port=12345&state=abcdef1234567890');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('defaultPermissions', Jetstream::$defaultPermissions)
+        );
+    }
+
+    public function test_authorize_page_defaults_to_jetstream_defaults_when_only_non_cli_tokens_exist(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $user->createToken('Other Token', ['secrets:create', 'secrets:list', 'secrets:delete']);
+
+        $response = $this->actingAs($user)
+            ->get('/cli/authorize?port=12345&state=abcdef1234567890');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('defaultPermissions', Jetstream::$defaultPermissions)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- When re-running `flashview login`, the authorization page now pre-selects the existing CLI token's abilities instead of always defaulting to `secrets:create`
- Falls back to Jetstream defaults when no CLI token exists
- Added tests for existing token abilities, no-token fallback, and non-CLI token fallback

## Test plan

- [x] Run `flashview login` for the first time — only `secrets:create` should be pre-checked
- [x] Select additional permissions, approve, then run `flashview login` again — previous selections should be pre-checked
- [x] Change permissions on re-login, approve, login again — new selections should be reflected
- [x] Deny authorization — existing token permissions should remain unchanged on next login
- [x] User with non-CLI API tokens but no CLI token should see system defaults only

Closes PIO-18