### PR TITLE
Fix CLI version and add auto version bump workflow

### DIFF
--- a/.github/workflows/cli-version-bump.yml
+++ b/.github/workflows/cli-version-bump.yml
@@ -1,0 +1,78 @@
+name: CLI Version Bump
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+    paths:
+      - 'tools/flashview-cli/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cli-version-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/flashview-cli
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if last commit is a version bump
+        id: check-bump
+        working-directory: .
+        run: |
+          LAST_MSG=$(git log -1 --pretty=%s)
+          if echo "$LAST_MSG" | grep -q "chore(release): bump flashview-cli"; then
+            echo "already_bumped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Determine bump type from PR labels
+        id: bump-type
+        if: steps.check-bump.outputs.already_bumped != 'true'
+        working-directory: .
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"major"'; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -q '"minor"'; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version
+        if: steps.check-bump.outputs.already_bumped != 'true'
+        run: npm version ${{ steps.bump-type.outputs.type }} --no-git-tag-version
+
+      - name: Commit version bump
+        if: steps.check-bump.outputs.already_bumped != 'true'
+        working-directory: .
+        run: |
+          NEW_VERSION=$(node -p "require('./tools/flashview-cli/package.json').version")
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tools/flashview-cli/package.json tools/flashview-cli/package-lock.json
+          git commit -m "chore(release): bump flashview-cli to v${NEW_VERSION} [skip ci]"
+          git push origin HEAD:${{ github.head_ref }}
+
+      - run: npm ci
+
+      - run: npm test

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: publish-cli
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/tools/flashview-cli/package-lock.json
+++ b/tools/flashview-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pioneer-dynamics/flashview-cli",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pioneer-dynamics/flashview-cli",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "dependencies": {
                 "commander": "^12.0.0",
                 "conf": "^13.0.0",

--- a/tools/flashview-cli/package.json
+++ b/tools/flashview-cli/package.json
@@ -8,7 +8,7 @@
         "src/",
         "README.md"
     ],
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "CLI tool for FlashView — create and manage encrypted secrets",
     "repository": {
         "type": "git",

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -1,10 +1,17 @@
 import { Command } from 'commander';
 import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
 import { encryptMessage } from './crypto.js';
 import { FlashViewClient, ApiError } from './api.js';
 import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
 // Allowed expiry values — must match config/secrets.php expiry_options
 // See: config/secrets.php for the server-side list
@@ -108,7 +115,7 @@ const program = new Command();
 program
     .name('flashview')
     .description('FlashView CLI — Create and manage encrypted secrets')
-    .version('1.0.0');
+    .version(pkg.version);
 
 // --- Configure ---
 

--- a/tools/flashview-cli/tests/cli.test.js
+++ b/tools/flashview-cli/tests/cli.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+
+describe('CLI version', () => {
+    it('outputs the version from package.json', () => {
+        const output = execSync('node bin/flashview.js --version', {
+            cwd: join(__dirname, '..'),
+            encoding: 'utf-8',
+        });
+        assert.strictEqual(output.trim(), pkg.version);
+    });
+});


### PR DESCRIPTION
## Summary

- **Fix CLI version bug:** The CLI was displaying hardcoded `1.0.0` instead of the actual version from `package.json`. Now reads the version dynamically using `fs.readFileSync` with `import.meta.url`-based path resolution.
- **Add auto version bump workflow:** New GitHub Action (`cli-version-bump.yml`) that triggers on PRs to `master` when `tools/flashview-cli/**` changes. Determines bump type (patch/minor/major) from PR labels and commits the version change back to the source branch with `[skip ci]`.
- **Add publish concurrency group:** Prevents overlapping npm publish runs.
- **Add CLI version test:** Verifies `--version` output matches `package.json`.

## Test plan

- [x] Run `node bin/flashview.js --version` in `tools/flashview-cli/` — should output `1.1.2`
- [x] Run `npm test` in `tools/flashview-cli/` — all tests should pass
- [x] Verify `cli-version-bump.yml` workflow structure is correct
- [x] Verify `publish-cli.yml` concurrency group is properly configured

## Regression risk

LOW — changes are isolated to the standalone CLI tool and GitHub Actions workflows. No impact to the main Laravel application.

## Linear ticket

PIO-19