### PR TITLE
Fix test failures from Vite manifest and email DNS validation

### DIFF
--- a/tests/Feature/CliAuthTest.php
+++ b/tests/Feature/CliAuthTest.php
@@ -13,13 +13,6 @@ class CliAuthTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->withoutVite();
-    }
-
     private function createUserWithApiAccess(): User
     {
         $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -14,12 +14,14 @@ class ProfileInformationTest extends TestCase
     {
         $this->actingAs($user = User::factory()->create());
 
-        $this->put('/user/profile-information', [
+        $response = $this->put('/user/profile-information', [
             'name' => 'Test Name',
-            'email' => 'test@example.com',
+            'email' => 'test@gmail.com',
         ]);
 
+        $response->assertSessionHasNoErrors();
+
         $this->assertEquals('Test Name', $user->fresh()->name);
-        $this->assertEquals('test@example.com', $user->fresh()->email);
+        $this->assertEquals('test@gmail.com', $user->fresh()->email);
     }
 }

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -41,7 +41,7 @@ class RegistrationTest extends TestCase
 
         $response = $this->post('/register', [
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => 'test@gmail.com',
             'password' => 'password',
             'password_confirmation' => 'password',
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable Vite manifest resolution globally so tests don't need the built assets.
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary

- Add `withoutVite()` to the base `TestCase::setUp()` so all tests skip Vite manifest resolution globally, preventing `ViteManifestNotFoundException` errors
- Remove the redundant `withoutVite()` call from `CliAuthTest` (now inherited from base class)
- Fix `ProfileInformationTest` and `RegistrationTest` which silently failed because `test@example.com` is rejected by the `email:rfc,dns` validation rule (example.com is IANA-reserved with no MX records)
- Add `assertSessionHasNoErrors()` to `ProfileInformationTest` to surface validation failures early

## Test plan

- [x] Full test suite passes: 79 passed, 0 failed
- [x] All previously-failing tests now pass (SecretApiTest, AuthenticationTest, CliPageTest, EmailVerificationTest, ProfileInformationTest, RegistrationTest)
- [x] CliAuthTest still passes without its own `withoutVite()` call
- [x] Tests pass both with and without `public/build/manifest.json` present