### PR TITLE
Add workflow to auto-merge master into develop

### DIFF
--- a/.github/workflows/sync-master-to-develop.yml
+++ b/.github/workflows/sync-master-to-develop.yml
@@ -1,0 +1,26 @@
+name: Sync master to develop
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge master into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git merge origin/master --no-edit -m "chore: merge master into develop [skip ci]"
+          git push origin develop

--- a/tests/Feature/CliAuthTest.php
+++ b/tests/Feature/CliAuthTest.php
@@ -13,13 +13,6 @@ class CliAuthTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->withoutVite();
-    }
-
     private function createUserWithApiAccess(): User
     {
         $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -14,12 +14,14 @@ class ProfileInformationTest extends TestCase
     {
         $this->actingAs($user = User::factory()->create());
 
-        $this->put('/user/profile-information', [
+        $response = $this->put('/user/profile-information', [
             'name' => 'Test Name',
-            'email' => 'test@example.com',
+            'email' => 'test@gmail.com',
         ]);
 
+        $response->assertSessionHasNoErrors();
+
         $this->assertEquals('Test Name', $user->fresh()->name);
-        $this->assertEquals('test@example.com', $user->fresh()->email);
+        $this->assertEquals('test@gmail.com', $user->fresh()->email);
     }
 }

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -41,7 +41,7 @@ class RegistrationTest extends TestCase
 
         $response = $this->post('/register', [
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => 'test@gmail.com',
             'password' => 'password',
             'password_confirmation' => 'password',
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable Vite manifest resolution globally so tests don't need the built assets.
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that automatically merges `master` into `develop` whenever a push to `master` occurs (e.g., after a PR merge)
- If conflicts arise, the workflow fails visibly for manual resolution
- Uses `[skip ci]` on the merge commit to prevent re-triggering workflows

## Test plan

- [ ] Merge a PR to `master` and verify `develop` gets updated automatically
- [ ] Verify the workflow shows as failed if `develop` has conflicting changes with `master`