### PR TITLE
Add user-level toggle for secret retrieval notifications

### DIFF
--- a/app/Http/Controllers/NotificationPreferencesController.php
+++ b/app/Http/Controllers/NotificationPreferencesController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateNotificationPreferencesRequest;
+use Illuminate\Http\RedirectResponse;
+
+class NotificationPreferencesController extends Controller
+{
+    public function update(UpdateNotificationPreferencesRequest $request): RedirectResponse
+    {
+        $request->user()->update($request->validated());
+
+        return back();
+    }
+}

--- a/app/Http/Requests/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateNotificationPreferencesRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateNotificationPreferencesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'notify_secret_retrieved' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Scopes\ActiveScope;
 use App\Notifications\SecretRetrievedNotification;
 use App\Traits\HasHashId;
+use Database\Factories\SecretFactory;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,7 +20,7 @@ class Secret extends Model
 {
     use ExportsPermissions;
 
-    /** @use HasFactory<\Database\Factories\SecretFactory> */
+    /** @use HasFactory<SecretFactory> */
     use HasFactory;
 
     use HasHashId;
@@ -95,10 +96,10 @@ class Secret extends Model
                     $plan = $user->plan->jsonSerialize();
 
                     /**
-                     * @var \App\Models\User $user
+                     * @var User $user
                      */
                     if (isset($plan['id'])) {
-                        if ($plan['settings']['notification']['notifications']) {
+                        if ($plan['settings']['notification']['notifications'] && $user->notify_secret_retrieved) {
                             $user->notify(new SecretRetrievedNotification($secret));
                         }
                     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,6 +40,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'name',
         'email',
         'password',
+        'notify_secret_retrieved',
     ];
 
     /**
@@ -133,6 +134,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'notify_secret_retrieved' => 'boolean',
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {
@@ -36,6 +36,7 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
             'profile_photo_path' => null,
             'current_team_id' => null,
+            'notify_secret_retrieved' => false,
         ];
     }
 
@@ -46,6 +47,16 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the user has opted in to secret retrieved notifications.
+     */
+    public function withSecretRetrievedNotifications(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'notify_secret_retrieved' => true,
         ]);
     }
 

--- a/database/migrations/2026_03_23_063844_add_notify_secret_retrieved_to_users_table.php
+++ b/database/migrations/2026_03_23_063844_add_notify_secret_retrieved_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('notify_secret_retrieved')->default(false)->after('profile_photo_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('notify_secret_retrieved');
+        });
+    }
+};

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { computed } from 'vue';
+import { useForm, usePage } from '@inertiajs/vue3';
+import ActionMessage from '@/Components/ActionMessage.vue';
+import FormSection from '@/Components/FormSection.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+
+const page = usePage();
+const user = computed(() => page.props.auth.user);
+
+const planSupportsNotifications = computed(() =>
+    user.value.plan?.settings?.notification?.notifications ?? false
+);
+
+const form = useForm({
+    notify_secret_retrieved: user.value.notify_secret_retrieved ?? false,
+});
+
+const updateNotificationPreferences = () => {
+    form.put(route('user.notification-preferences.update'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <FormSection @submitted="updateNotificationPreferences">
+        <template #title>
+            Notification Preferences
+        </template>
+
+        <template #description>
+            Manage your email notification preferences.
+        </template>
+
+        <template #form>
+            <div v-if="planSupportsNotifications" class="col-span-6">
+                <label class="flex items-center">
+                    <Checkbox
+                        v-model:checked="form.notify_secret_retrieved"
+                    />
+                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                        Notify me via email when my secret is retrieved
+                    </span>
+                </label>
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
+                    You will receive an email each time any of your secrets is opened by a recipient.
+                </p>
+            </div>
+
+            <div v-else class="col-span-6">
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Secret retrieval notifications are available on paid plans.
+                    <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                        View plans
+                    </a>
+                </p>
+            </div>
+        </template>
+
+        <template v-if="planSupportsNotifications" #actions>
+            <ActionMessage :on="form.recentlySuccessful" class="me-3">
+                Saved.
+            </ActionMessage>
+
+            <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                Save
+            </PrimaryButton>
+        </template>
+    </FormSection>
+</template>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -2,9 +2,9 @@
 import { computed } from 'vue';
 import { useForm, usePage } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
+import ActionSection from '@/Components/ActionSection.vue';
 import FormSection from '@/Components/FormSection.vue';
 import Checkbox from '@/Components/Checkbox.vue';
-import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 
 const page = usePage();
@@ -26,7 +26,7 @@ const updateNotificationPreferences = () => {
 </script>
 
 <template>
-    <FormSection @submitted="updateNotificationPreferences">
+    <FormSection v-if="planSupportsNotifications" @submitted="updateNotificationPreferences">
         <template #title>
             Notification Preferences
         </template>
@@ -36,7 +36,7 @@ const updateNotificationPreferences = () => {
         </template>
 
         <template #form>
-            <div v-if="planSupportsNotifications" class="col-span-6">
+            <div class="col-span-6">
                 <label class="flex items-center">
                     <Checkbox
                         v-model:checked="form.notify_secret_retrieved"
@@ -49,18 +49,9 @@ const updateNotificationPreferences = () => {
                     You will receive an email each time any of your secrets is opened by a recipient.
                 </p>
             </div>
-
-            <div v-else class="col-span-6">
-                <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Secret retrieval notifications are available on paid plans.
-                    <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
-                        View plans
-                    </a>
-                </p>
-            </div>
         </template>
 
-        <template v-if="planSupportsNotifications" #actions>
+        <template #actions>
             <ActionMessage :on="form.recentlySuccessful" class="me-3">
                 Saved.
             </ActionMessage>
@@ -70,4 +61,23 @@ const updateNotificationPreferences = () => {
             </PrimaryButton>
         </template>
     </FormSection>
+
+    <ActionSection v-else>
+        <template #title>
+            Notification Preferences
+        </template>
+
+        <template #description>
+            Manage your email notification preferences.
+        </template>
+
+        <template #content>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+                Secret retrieval notifications are available on paid plans.
+                <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                    View plans
+                </a>
+            </p>
+        </template>
+    </ActionSection>
 </template>

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -6,6 +6,7 @@ import SectionBorder from '@/Components/SectionBorder.vue';
 import TwoFactorAuthenticationForm from '@/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue';
 import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue';
+import NotificationPreferencesForm from './Partials/NotificationPreferencesForm.vue';
 import PassKeyForm from './Partials/PassKeyForm.vue';
 import Page from '../Page.vue';
 
@@ -47,6 +48,10 @@ defineProps({
                 </div>
 
                 <PassKeyForm class="mt-10 sm:mt-0" />
+
+                <SectionBorder />
+
+                <NotificationPreferencesForm class="mt-10 sm:mt-0" />
 
                 <SectionBorder />
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\MarkdownDocumentController;
+use App\Http\Controllers\NotificationPreferencesController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
@@ -78,6 +79,9 @@ Route::middleware([
     Route::get('plans/{plan}/{period}', [PlanController::class, 'subscribe'])->name('plans.subscribe');
     Route::post('plans/cancel', [PlanController::class, 'unsubscribe'])->name('plans.unsubscribe');
     Route::post('plans/resume', [PlanController::class, 'resume'])->name('plans.resume');
+
+    Route::put('/user/notification-preferences', [NotificationPreferencesController::class, 'update'])
+        ->name('user.notification-preferences.update');
 
     Route::get('secrets', [SecretController::class,  'index'])->name('secrets.index');
     Route::delete('secrets/{secret}', [SecretController::class,  'destroy'])->name('secrets.destroy');

--- a/tests/Feature/NotificationPreferencesTest.php
+++ b/tests/Feature/NotificationPreferencesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotificationPreferencesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_update_notification_preferences(): void
+    {
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => true,
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_user_can_enable_secret_retrieved_notification(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => true,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertTrue($user->fresh()->notify_secret_retrieved);
+    }
+
+    public function test_user_can_disable_secret_retrieved_notification(): void
+    {
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => false,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertFalse($user->fresh()->notify_secret_retrieved);
+    }
+
+    public function test_validation_requires_boolean(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => 'not-a-boolean',
+        ]);
+
+        $response->assertSessionHasErrors('notify_secret_retrieved');
+    }
+}

--- a/tests/Feature/SecretRetrievedNotificationTest.php
+++ b/tests/Feature/SecretRetrievedNotificationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\Secret;
+use App\Models\User;
+use App\Notifications\SecretRetrievedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class SecretRetrievedNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Allow the Secret retrieved event to fire during tests
+        $reflection = new \ReflectionProperty($this->app, 'isRunningInConsole');
+        $reflection->setValue($this->app, false);
+    }
+
+    public function test_notification_sent_when_plan_allows_and_user_opted_in(): void
+    {
+        Notification::fake();
+
+        $plan = $this->createPlanWithNotifications(true);
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Notification::assertSentTo($user, SecretRetrievedNotification::class);
+    }
+
+    public function test_notification_not_sent_when_user_opted_out(): void
+    {
+        Notification::fake();
+
+        $plan = $this->createPlanWithNotifications(true);
+        $user = User::factory()->create(['notify_secret_retrieved' => false]);
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Notification::assertNotSentTo($user, SecretRetrievedNotification::class);
+    }
+
+    public function test_notification_not_sent_when_plan_disallows(): void
+    {
+        Notification::fake();
+
+        $plan = $this->createPlanWithNotifications(false);
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Notification::assertNotSentTo($user, SecretRetrievedNotification::class);
+    }
+
+    public function test_notification_not_sent_for_guest_secrets(): void
+    {
+        Notification::fake();
+
+        $secret = $this->createActiveSecret();
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_notification_not_sent_when_user_has_no_plan(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Notification::assertNotSentTo($user, SecretRetrievedNotification::class);
+    }
+
+    private function createPlanWithNotifications(bool $enabled): Plan
+    {
+        return Plan::factory()->create([
+            'name' => $enabled ? 'Pro' : 'Free',
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Get notified when a message is retrieved',
+                    'config' => ['notifications' => $enabled],
+                    'type' => $enabled ? 'feature' : 'missing',
+                ],
+            ],
+            'stripe_product_id' => 'prod_test',
+            'stripe_monthly_price_id' => 'price_monthly_test',
+            'stripe_yearly_price_id' => 'price_yearly_test',
+            'price_per_month' => 9.99,
+            'price_per_year' => 99.99,
+        ]);
+    }
+
+    /**
+     * Create an active secret with an encrypted message.
+     */
+    private function createActiveSecret(?User $user = null): Secret
+    {
+        return Secret::withoutGlobalScopes()->create([
+            'message' => 'test-secret-message',
+            'user_id' => $user?->id,
+            'expires_at' => now()->addHour(),
+        ]);
+    }
+
+    /**
+     * Create a Cashier subscription linking the user to a plan.
+     */
+    private function createSubscriptionForUser(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `notify_secret_retrieved` boolean column to users table (default: off)
- Add Notification Preferences section on Profile page with email notification toggle
- Notification is only sent when both the plan allows it AND the user has opted in
- Shows upgrade message for users whose plan doesn't support notifications

## Test plan
- [x] Verify notification preferences form appears on Profile page between PassKey and Logout sections
- [x] Verify free-plan users see upgrade message instead of checkbox
- [x] Verify paid-plan users can toggle notification on/off and save
- [x] Verify notification is sent when retrieving a secret (plan allows + user opted in)
- [x] Verify notification is NOT sent when user has opted out
- [x] Verify notification is NOT sent when plan disallows even if user opted in
- [x] Verify guest secrets (no user) don't trigger errors
- [x] Run full test suite: `php artisan test`

Resolves PIO-21