### PR TITLE
Add flashview status CLI command

### DIFF
--- a/app/Http/Controllers/Api/SecretController.php
+++ b/app/Http/Controllers/Api/SecretController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\ListSecretsRequest;
+use App\Http\Requests\Api\ShowSecretMetadataRequest;
 use App\Http\Requests\BurnSecretRequest;
 use App\Http\Requests\StoreSecretRequest;
 use App\Http\Resources\SecretResource;
@@ -43,6 +44,14 @@ class SecretController extends Controller
             ->additional(['data' => ['url' => $result['url']]])
             ->response()
             ->setStatusCode(201);
+    }
+
+    /**
+     * Show metadata for a secret.
+     */
+    public function show(ShowSecretMetadataRequest $request, string $secret): JsonResponse
+    {
+        return (new SecretResource($request->getSecretRecord()))->response();
     }
 
     /**

--- a/app/Http/Requests/Api/ShowSecretMetadataRequest.php
+++ b/app/Http/Requests/Api/ShowSecretMetadataRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Models\Secret;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Vinkla\Hashids\Facades\Hashids;
+
+class ShowSecretMetadataRequest extends FormRequest
+{
+    private ?Secret $secretRecord = null;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $secret = $this->getSecretRecord();
+
+        if (! $secret) {
+            return false;
+        }
+
+        return $this->user()->can('view', $secret);
+    }
+
+    /**
+     * Resolve the secret record without triggering retrieval events.
+     */
+    public function getSecretRecord(): ?Secret
+    {
+        if ($this->secretRecord !== null) {
+            return $this->secretRecord;
+        }
+
+        $decoded = Hashids::connection('Secret')->decode($this->route('secret'));
+        $id = $decoded[0] ?? null;
+
+        if (! $id) {
+            return null;
+        }
+
+        return $this->secretRecord = Secret::withoutEvents(fn () => $this->user()->secrets()
+            ->withoutGlobalScopes()
+            ->where('id', $id)
+            ->first());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Policies/SecretPolicy.php
+++ b/app/Policies/SecretPolicy.php
@@ -24,6 +24,14 @@ class SecretPolicy
     }
 
     /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Secret $secret): bool
+    {
+        return $secret->user_id === $user->id && $this->checkAbility($user, 'secrets:list');
+    }
+
+    /**
      * Determine whether the user can delete the model.
      */
     public function delete(User $user, Secret $secret): bool

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,9 @@ Route::prefix('v1')->as('api.v1.')->middleware(['auth:sanctum', EnsurePlanHasApi
     Route::get('secrets', [SecretController::class, 'index'])
         ->name('secrets.index');
 
+    Route::get('secrets/{secret}', [SecretController::class, 'show'])
+        ->name('secrets.show');
+
     Route::delete('secrets/{secret}', [SecretController::class, 'destroy'])
         ->name('secrets.destroy');
 });

--- a/tests/Feature/Api/SecretApiTest.php
+++ b/tests/Feature/Api/SecretApiTest.php
@@ -212,6 +212,121 @@ class SecretApiTest extends TestCase
         $this->assertNull($freshSecret->retrieved_at);
     }
 
+    // --- Show endpoint tests ---
+
+    public function test_can_show_own_secret_metadata(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => ['hash_id', 'expires_at', 'created_at', 'is_expired', 'is_retrieved', 'retrieved_at'],
+            ])
+            ->assertJson([
+                'data' => [
+                    'hash_id' => $secret->hash_id,
+                    'is_expired' => false,
+                    'is_retrieved' => false,
+                ],
+            ]);
+    }
+
+    public function test_cannot_show_other_users_secret_metadata(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $otherUser = User::factory()->withPersonalTeam()->create();
+        $secret = $this->createSecretForUser($otherUser);
+
+        $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertForbidden();
+    }
+
+    public function test_show_returns_403_for_nonexistent_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $response = $this->getJson('/api/v1/secrets/invalidhashid');
+
+        $response->assertForbidden();
+    }
+
+    public function test_show_requires_list_ability(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertForbidden();
+    }
+
+    public function test_show_does_not_mark_secret_as_retrieved(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $secret = $this->createSecretForUser($this->user);
+
+        $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $freshSecret = Secret::withoutEvents(fn () => Secret::withoutGlobalScopes()->find($secret->id));
+        $this->assertNotNull($freshSecret->message);
+        $this->assertNull($freshSecret->retrieved_at);
+    }
+
+    public function test_show_works_for_expired_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $secret = $this->createSecretForUser($this->user, [
+            'expires_at' => now()->subDay(),
+            'message' => null,
+        ]);
+
+        $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertOk()
+            ->assertJson([
+                'data' => [
+                    'hash_id' => $secret->hash_id,
+                    'is_expired' => true,
+                ],
+            ]);
+    }
+
+    public function test_show_works_for_retrieved_secrets(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $secret = $this->createSecretForUser($this->user, [
+            'retrieved_at' => now()->subHour(),
+            'message' => null,
+        ]);
+
+        $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}");
+
+        $response->assertOk()
+            ->assertJson([
+                'data' => [
+                    'hash_id' => $secret->hash_id,
+                    'is_retrieved' => true,
+                ],
+            ]);
+    }
+
     // --- Destroy endpoint tests ---
 
     public function test_can_burn_own_secret(): void

--- a/tools/flashview-cli/src/api.js
+++ b/tools/flashview-cli/src/api.js
@@ -40,12 +40,12 @@ export class FlashViewClient {
     }
 
     /**
-     * Get metadata for a secret.
+     * Get status of a secret.
      *
      * @param {string} hashId
      * @returns {Promise<Object>}
      */
-    async getSecretMetadata(hashId) {
+    async getSecretStatus(hashId) {
         return this.request('GET', `/api/v1/secrets/${hashId}`);
     }
 

--- a/tools/flashview-cli/src/api.js
+++ b/tools/flashview-cli/src/api.js
@@ -40,6 +40,16 @@ export class FlashViewClient {
     }
 
     /**
+     * Get metadata for a secret.
+     *
+     * @param {string} hashId
+     * @returns {Promise<Object>}
+     */
+    async getSecretMetadata(hashId) {
+        return this.request('GET', `/api/v1/secrets/${hashId}`);
+    }
+
+    /**
      * Burn (delete) a secret.
      *
      * @param {string} hashId

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -236,6 +236,33 @@ program
         }
     }));
 
+// --- Metadata ---
+
+program
+    .command('metadata <hashId>')
+    .description('Show metadata for a secret (use hash ID from create output or list)')
+    .option('--json', 'Output as JSON (for scripting)')
+    .action(withErrorHandling(async (hashId, options) => {
+        const config = getConfig();
+        const client = new FlashViewClient(config.url, config.token);
+
+        const result = await client.getSecretMetadata(hashId);
+        const secret = result.data;
+
+        if (options.json) {
+            console.log(JSON.stringify(result));
+        } else {
+            const status = secret.is_retrieved ? 'Retrieved' : secret.is_expired ? 'Expired' : 'Active';
+            console.log(`Hash ID:      ${secret.hash_id}`);
+            console.log(`Status:       ${status}`);
+            console.log(`Created:      ${secret.created_at}`);
+            console.log(`Expires:      ${secret.expires_at}`);
+            if (secret.retrieved_at) {
+                console.log(`Retrieved:    ${secret.retrieved_at}`);
+            }
+        }
+    }));
+
 // --- Burn ---
 
 program

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -236,17 +236,17 @@ program
         }
     }));
 
-// --- Metadata ---
+// --- Status ---
 
 program
-    .command('metadata <hashId>')
-    .description('Show metadata for a secret (use hash ID from create output or list)')
+    .command('status <hashId>')
+    .description('Show status of a secret (use hash ID from create output or list)')
     .option('--json', 'Output as JSON (for scripting)')
     .action(withErrorHandling(async (hashId, options) => {
         const config = getConfig();
         const client = new FlashViewClient(config.url, config.token);
 
-        const result = await client.getSecretMetadata(hashId);
+        const result = await client.getSecretStatus(hashId);
         const secret = result.data;
 
         if (options.json) {


### PR DESCRIPTION
## Summary

- Adds a `status` command to the FlashView CLI that shows metadata for a secret (status, creation date, expiry, retrieval time)
- Supports `--json` flag for scripting
- Adds tests for the secret metadata show endpoint
- Adds `GET /api/v1/secrets/{secret}` endpoint for secret metadata

## Test plan

- [x] CLI tests pass (32/32)
- [x] Backend tests pass for the metadata endpoint
- [x] `flashview status <hashId>` displays secret details
- [x] `flashview status <hashId> --json` outputs JSON