### PR TITLE
Fetch expiry options from server instead of hardcoding in CLI

### DIFF
--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -16,8 +16,8 @@ class ConfigController extends Controller
             'message_length' => config('secrets.message_length'),
         ];
 
-        $user = $request->user('sanctum');
-        if ($user?->subscribed()) {
+        $user = $request->user();
+        if ($user->subscribed()) {
             $plan = $user->resolvePlan();
             if ($plan) {
                 $data['plan_limits'] = [

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -10,23 +10,26 @@ class ConfigController extends Controller
 {
     public function __invoke(ConfigRequest $request): ConfigResource
     {
-        $data = [
-            'expiry_options' => config('secrets.expiry_options'),
-            'expiry_limits' => config('secrets.expiry_limits'),
-            'message_length' => config('secrets.message_length'),
-        ];
-
         $user = $request->user();
-        if ($user->subscribed()) {
-            $plan = $user->resolvePlan();
-            if ($plan) {
-                $data['plan_limits'] = [
-                    'expiry_minutes' => $plan->features['expiry']['config']['expiry_minutes'] ?? null,
-                    'message_length' => $plan->features['messages']['config']['message_length'] ?? null,
-                ];
-            }
-        }
+        $plan = $user->resolvePlan();
 
-        return new ConfigResource($data);
+        $maxExpiry = $plan
+            ? ($plan->features['expiry']['config']['expiry_minutes'] ?? config('secrets.expiry_limits.user'))
+            : config('secrets.expiry_limits.user');
+
+        $maxMessageLength = $plan
+            ? ($plan->features['messages']['config']['message_length'] ?? config('secrets.message_length.user'))
+            : config('secrets.message_length.user');
+
+        $expiryOptions = array_values(array_filter(
+            config('secrets.expiry_options'),
+            fn (array $option) => $option['value'] <= $maxExpiry,
+        ));
+
+        return new ConfigResource([
+            'expiry_options' => $expiryOptions,
+            'max_expiry' => $maxExpiry,
+            'max_message_length' => $maxMessageLength,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -3,14 +3,14 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use App\Http\Requests\Api\ConfigRequest;
+use App\Http\Resources\ConfigResource;
 
 class ConfigController extends Controller
 {
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(ConfigRequest $request): ConfigResource
     {
-        $response = [
+        $data = [
             'expiry_options' => config('secrets.expiry_options'),
             'expiry_limits' => config('secrets.expiry_limits'),
             'message_length' => config('secrets.message_length'),
@@ -20,13 +20,13 @@ class ConfigController extends Controller
         if ($user?->subscribed()) {
             $plan = $user->resolvePlan();
             if ($plan) {
-                $response['plan_limits'] = [
+                $data['plan_limits'] = [
                     'expiry_minutes' => $plan->features['expiry']['config']['expiry_minutes'] ?? null,
                     'message_length' => $plan->features['messages']['config']['message_length'] ?? null,
                 ];
             }
         }
 
-        return response()->json($response);
+        return new ConfigResource($data);
     }
 }

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ConfigController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $response = [
+            'expiry_options' => config('secrets.expiry_options'),
+            'expiry_limits' => config('secrets.expiry_limits'),
+            'message_length' => config('secrets.message_length'),
+        ];
+
+        $user = $request->user('sanctum');
+        if ($user?->subscribed()) {
+            $plan = $user->resolvePlan();
+            if ($plan) {
+                $response['plan_limits'] = [
+                    'expiry_minutes' => $plan->features['expiry']['config']['expiry_minutes'] ?? null,
+                    'message_length' => $plan->features['messages']['config']['message_length'] ?? null,
+                ];
+            }
+        }
+
+        return response()->json($response);
+    }
+}

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -8,6 +8,9 @@ use App\Http\Resources\ConfigResource;
 
 class ConfigController extends Controller
 {
+    /**
+     * Return the authenticated user's configuration limits.
+     */
     public function __invoke(ConfigRequest $request): ConfigResource
     {
         $user = $request->user();

--- a/app/Http/Requests/Api/ConfigRequest.php
+++ b/app/Http/Requests/Api/ConfigRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConfigRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Resources/ConfigResource.php
+++ b/app/Http/Resources/ConfigResource.php
@@ -21,16 +21,10 @@ class ConfigResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $data = [
+        return [
             'expiry_options' => $this->resource['expiry_options'],
-            'expiry_limits' => $this->resource['expiry_limits'],
-            'message_length' => $this->resource['message_length'],
+            'max_expiry' => $this->resource['max_expiry'],
+            'max_message_length' => $this->resource['max_message_length'],
         ];
-
-        if (isset($this->resource['plan_limits'])) {
-            $data['plan_limits'] = $this->resource['plan_limits'];
-        }
-
-        return $data;
     }
 }

--- a/app/Http/Resources/ConfigResource.php
+++ b/app/Http/Resources/ConfigResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ConfigResource extends JsonResource
+{
+    /**
+     * Wrap the resource in an envelope.
+     *
+     * @var string|null
+     */
+    public static $wrap = null;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $data = [
+            'expiry_options' => $this->resource['expiry_options'],
+            'expiry_limits' => $this->resource['expiry_limits'],
+            'message_length' => $this->resource['message_length'],
+        ];
+
+        if (isset($this->resource['plan_limits'])) {
+            $data['plan_limits'] = $this->resource['plan_limits'];
+        }
+
+        return $data;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\ConfigController;
 use App\Http\Controllers\Api\SecretController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Http\Request;
@@ -8,6 +9,12 @@ use Illuminate\Support\Facades\Route;
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::prefix('v1')->as('api.v1.')->group(function () {
+    Route::get('config', ConfigController::class)
+        ->middleware('throttle:60,1')
+        ->name('config');
+});
 
 Route::prefix('v1')->as('api.v1.')->middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
     Route::post('secrets', [SecretController::class, 'store'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,22 +14,22 @@ Route::prefix('v1')->as('api.v1.')->group(function () {
     Route::get('config', ConfigController::class)
         ->middleware('throttle:60,1')
         ->name('config');
-});
 
-Route::prefix('v1')->as('api.v1.')->middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
-    Route::post('secrets', [SecretController::class, 'store'])
-        ->middleware('throttle:api-secrets')
-        ->name('secrets.store');
+    Route::middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
+        Route::post('secrets', [SecretController::class, 'store'])
+            ->middleware('throttle:api-secrets')
+            ->name('secrets.store');
 
-    Route::get('secrets', [SecretController::class, 'index'])
-        ->name('secrets.index');
+        Route::get('secrets', [SecretController::class, 'index'])
+            ->name('secrets.index');
 
-    Route::get('secrets/{secret}', [SecretController::class, 'show'])
-        ->name('secrets.show');
+        Route::get('secrets/{secret}', [SecretController::class, 'show'])
+            ->name('secrets.show');
 
-    Route::get('secrets/{secret}/retrieve', [SecretController::class, 'retrieve'])
-        ->name('secrets.retrieve');
+        Route::get('secrets/{secret}/retrieve', [SecretController::class, 'retrieve'])
+            ->name('secrets.retrieve');
 
-    Route::delete('secrets/{secret}', [SecretController::class, 'destroy'])
-        ->name('secrets.destroy');
+        Route::delete('secrets/{secret}', [SecretController::class, 'destroy'])
+            ->name('secrets.destroy');
+    });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,11 +11,12 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 
 Route::prefix('v1')->as('api.v1.')->group(function () {
-    Route::get('config', ConfigController::class)
-        ->middleware('throttle:60,1')
-        ->name('config');
-
+    
     Route::middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
+        Route::get('config', ConfigController::class)
+            ->middleware('throttle:60,1')
+            ->name('config');
+            
         Route::post('secrets', [SecretController::class, 'store'])
             ->middleware('throttle:api-secrets')
             ->name('secrets.store');

--- a/tests/Feature/Api/ConfigApiTest.php
+++ b/tests/Feature/Api/ConfigApiTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ConfigApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_config_endpoint_returns_expiry_options_for_guests(): void
+    {
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'expiry_options' => [
+                    ['label', 'value'],
+                ],
+                'expiry_limits' => ['guest', 'user'],
+                'message_length' => ['guest', 'user'],
+            ])
+            ->assertJsonMissing(['plan_limits']);
+    }
+
+    public function test_config_values_match_server_config(): void
+    {
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonFragment([
+                'expiry_options' => config('secrets.expiry_options'),
+                'expiry_limits' => config('secrets.expiry_limits'),
+                'message_length' => config('secrets.message_length'),
+            ]);
+    }
+
+    public function test_config_endpoint_excludes_plan_limits_for_unsubscribed_users(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonMissing(['plan_limits']);
+    }
+
+    public function test_config_endpoint_includes_plan_limits_for_subscribed_users(): void
+    {
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => [
+                'messages' => [
+                    'order' => 2,
+                    'label' => ':message_length character limit per message',
+                    'config' => ['message_length' => 100000],
+                    'type' => 'feature',
+                ],
+                'expiry' => [
+                    'order' => 3,
+                    'label' => 'Maximum expiry of :expiry_label',
+                    'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonPath('plan_limits.expiry_minutes', 43200)
+            ->assertJsonPath('plan_limits.message_length', 100000);
+    }
+
+    public function test_config_endpoint_excludes_plan_limits_when_plan_record_missing(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_orphan',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_nonexistent',
+            'quantity' => 1,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonMissing(['plan_limits']);
+    }
+
+    public function test_config_endpoint_is_accessible_without_api_plan(): void
+    {
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/Api/ConfigApiTest.php
+++ b/tests/Feature/Api/ConfigApiTest.php
@@ -79,7 +79,7 @@ class ConfigApiTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_config_endpoint_returns_expiry_options(): void
+    public function test_config_returns_user_specific_limits(): void
     {
         $this->subscribeUserToPlan($this->user, $this->plan);
         Sanctum::actingAs($this->user);
@@ -91,12 +91,14 @@ class ConfigApiTest extends TestCase
                 'expiry_options' => [
                     ['label', 'value'],
                 ],
-                'expiry_limits' => ['guest', 'user'],
-                'message_length' => ['guest', 'user'],
-            ]);
+                'max_expiry',
+                'max_message_length',
+            ])
+            ->assertJsonPath('max_expiry', 43200)
+            ->assertJsonPath('max_message_length', 100000);
     }
 
-    public function test_config_values_match_server_config(): void
+    public function test_config_does_not_expose_raw_limits(): void
     {
         $this->subscribeUserToPlan($this->user, $this->plan);
         Sanctum::actingAs($this->user);
@@ -104,39 +106,72 @@ class ConfigApiTest extends TestCase
         $response = $this->getJson('/api/v1/config');
 
         $response->assertOk()
-            ->assertJsonFragment([
-                'expiry_options' => config('secrets.expiry_options'),
-                'expiry_limits' => config('secrets.expiry_limits'),
-                'message_length' => config('secrets.message_length'),
-            ]);
+            ->assertJsonMissing(['expiry_limits'])
+            ->assertJsonMissing(['message_length' => config('secrets.message_length')])
+            ->assertJsonMissing(['plan_limits']);
     }
 
-    public function test_config_endpoint_includes_plan_limits_for_subscribed_users(): void
+    public function test_expiry_options_filtered_to_user_max(): void
     {
-        $this->subscribeUserToPlan($this->user, $this->plan);
-        Sanctum::actingAs($this->user);
-
-        $response = $this->getJson('/api/v1/config');
-
-        $response->assertOk()
-            ->assertJsonPath('plan_limits.expiry_minutes', 43200)
-            ->assertJsonPath('plan_limits.message_length', 100000);
-    }
-
-    public function test_config_endpoint_excludes_plan_limits_when_plan_record_missing(): void
-    {
-        $this->user->subscriptions()->create([
-            'type' => 'default',
-            'stripe_id' => 'sub_orphan',
-            'stripe_status' => 'active',
-            'stripe_price' => 'price_nonexistent',
-            'quantity' => 1,
+        $limitedPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic',
+            'stripe_yearly_price_id' => 'price_yearly_basic',
+            'stripe_product_id' => 'prod_basic',
+            'price_per_month' => 10,
+            'price_per_year' => 100,
+            'features' => [
+                'messages' => [
+                    'order' => 2,
+                    'label' => ':message_length character limit per message',
+                    'config' => ['message_length' => 500],
+                    'type' => 'feature',
+                ],
+                'expiry' => [
+                    'order' => 3,
+                    'label' => 'Maximum expiry of :expiry_label',
+                    'config' => ['expiry_label' => '1 day', 'expiry_minutes' => 1440],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
         ]);
 
+        $this->subscribeUserToPlan($this->user, $limitedPlan);
         Sanctum::actingAs($this->user);
 
         $response = $this->getJson('/api/v1/config');
 
-        $response->assertForbidden();
+        $response->assertOk()
+            ->assertJsonPath('max_expiry', 1440)
+            ->assertJsonPath('max_message_length', 500);
+
+        $expiryValues = array_column($response->json('expiry_options'), 'value');
+
+        // All returned options should be <= 1440 minutes (1 day)
+        foreach ($expiryValues as $value) {
+            $this->assertLessThanOrEqual(1440, $value);
+        }
+
+        // Options beyond 1 day should not be present
+        $this->assertNotContains(4320, $expiryValues);
+        $this->assertNotContains(10080, $expiryValues);
+    }
+
+    public function test_full_plan_gets_all_expiry_options(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->plan);
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $expiryValues = array_column($response->json('expiry_options'), 'value');
+
+        $this->assertCount(count(config('secrets.expiry_options')), $expiryValues);
     }
 }

--- a/tests/Feature/Api/ConfigApiTest.php
+++ b/tests/Feature/Api/ConfigApiTest.php
@@ -12,47 +12,15 @@ class ConfigApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_config_endpoint_returns_expiry_options_for_guests(): void
+    private User $user;
+
+    private Plan $plan;
+
+    protected function setUp(): void
     {
-        $response = $this->getJson('/api/v1/config');
+        parent::setUp();
 
-        $response->assertOk()
-            ->assertJsonStructure([
-                'expiry_options' => [
-                    ['label', 'value'],
-                ],
-                'expiry_limits' => ['guest', 'user'],
-                'message_length' => ['guest', 'user'],
-            ])
-            ->assertJsonMissing(['plan_limits']);
-    }
-
-    public function test_config_values_match_server_config(): void
-    {
-        $response = $this->getJson('/api/v1/config');
-
-        $response->assertOk()
-            ->assertJsonFragment([
-                'expiry_options' => config('secrets.expiry_options'),
-                'expiry_limits' => config('secrets.expiry_limits'),
-                'message_length' => config('secrets.message_length'),
-            ]);
-    }
-
-    public function test_config_endpoint_excludes_plan_limits_for_unsubscribed_users(): void
-    {
-        $user = User::factory()->withPersonalTeam()->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->getJson('/api/v1/config');
-
-        $response->assertOk()
-            ->assertJsonMissing(['plan_limits']);
-    }
-
-    public function test_config_endpoint_includes_plan_limits_for_subscribed_users(): void
-    {
-        $plan = Plan::factory()->create([
+        $this->plan = Plan::factory()->create([
             'name' => 'Prime',
             'stripe_monthly_price_id' => 'price_monthly_prime',
             'stripe_yearly_price_id' => 'price_yearly_prime',
@@ -81,16 +49,72 @@ class ConfigApiTest extends TestCase
             ],
         ]);
 
-        $user = User::factory()->withPersonalTeam()->create();
+        $this->user = User::factory()->withPersonalTeam()->create();
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
         $user->subscriptions()->create([
             'type' => 'default',
-            'stripe_id' => 'sub_test',
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
             'stripe_status' => 'active',
             'stripe_price' => $plan->stripe_monthly_price_id,
             'quantity' => 1,
         ]);
+    }
 
-        Sanctum::actingAs($user);
+    public function test_unauthenticated_request_returns_401(): void
+    {
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_user_without_subscription_gets_403(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertForbidden();
+    }
+
+    public function test_config_endpoint_returns_expiry_options(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->plan);
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'expiry_options' => [
+                    ['label', 'value'],
+                ],
+                'expiry_limits' => ['guest', 'user'],
+                'message_length' => ['guest', 'user'],
+            ]);
+    }
+
+    public function test_config_values_match_server_config(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->plan);
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/v1/config');
+
+        $response->assertOk()
+            ->assertJsonFragment([
+                'expiry_options' => config('secrets.expiry_options'),
+                'expiry_limits' => config('secrets.expiry_limits'),
+                'message_length' => config('secrets.message_length'),
+            ]);
+    }
+
+    public function test_config_endpoint_includes_plan_limits_for_subscribed_users(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->plan);
+        Sanctum::actingAs($this->user);
 
         $response = $this->getJson('/api/v1/config');
 
@@ -101,8 +125,7 @@ class ConfigApiTest extends TestCase
 
     public function test_config_endpoint_excludes_plan_limits_when_plan_record_missing(): void
     {
-        $user = User::factory()->withPersonalTeam()->create();
-        $user->subscriptions()->create([
+        $this->user->subscriptions()->create([
             'type' => 'default',
             'stripe_id' => 'sub_orphan',
             'stripe_status' => 'active',
@@ -110,18 +133,10 @@ class ConfigApiTest extends TestCase
             'quantity' => 1,
         ]);
 
-        Sanctum::actingAs($user);
+        Sanctum::actingAs($this->user);
 
         $response = $this->getJson('/api/v1/config');
 
-        $response->assertOk()
-            ->assertJsonMissing(['plan_limits']);
-    }
-
-    public function test_config_endpoint_is_accessible_without_api_plan(): void
-    {
-        $response = $this->getJson('/api/v1/config');
-
-        $response->assertOk();
+        $response->assertForbidden();
     }
 }

--- a/tools/flashview-cli/src/api.js
+++ b/tools/flashview-cli/src/api.js
@@ -13,10 +13,10 @@ export class FlashViewClient {
     }
 
     /**
-     * Fetch server configuration (public endpoint).
+     * Fetch server configuration (requires authentication).
      *
      * @param {string} baseUrl
-     * @param {string|null} token - Optional auth token for plan-specific limits
+     * @param {string|null} token - Auth token for API access
      * @returns {Promise<Object>}
      */
     static async fetchConfig(baseUrl, token = null) {

--- a/tools/flashview-cli/src/api.js
+++ b/tools/flashview-cli/src/api.js
@@ -13,6 +13,43 @@ export class FlashViewClient {
     }
 
     /**
+     * Fetch server configuration (public endpoint).
+     *
+     * @param {string} baseUrl
+     * @param {string|null} token - Optional auth token for plan-specific limits
+     * @returns {Promise<Object>}
+     */
+    static async fetchConfig(baseUrl, token = null) {
+        const url = `${baseUrl.replace(/\/$/, '')}/api/v1/config`;
+        const headers = { 'Accept': 'application/json' };
+
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10000);
+
+        let response;
+        try {
+            response = await fetch(url, { headers, signal: controller.signal });
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                throw new ApiError('Config fetch timed out', 0);
+            }
+            throw err;
+        } finally {
+            clearTimeout(timeout);
+        }
+
+        if (!response.ok) {
+            throw new ApiError(`Config fetch failed (HTTP ${response.status})`, response.status);
+        }
+
+        return response.json();
+    }
+
+    /**
      * Create an encrypted secret.
      *
      * @param {string} encryptedMessage

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -7,79 +7,12 @@ import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { encryptMessage, decryptMessage } from './crypto.js';
 import { FlashViewClient, ApiError } from './api.js';
-import { getConfig, getConfigInfo, setConfig, clearConfig, getCachedServerConfig, setCachedServerConfig } from './config.js';
+import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
+import { parseExpiry, getServerConfig, FALLBACK_EXPIRY_OPTIONS } from './expiry.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
-
-// Fallback expiry options used when the server is unreachable and no cache exists.
-const FALLBACK_EXPIRY_OPTIONS = [
-    { label: '5 minutes', value: 5 },
-    { label: '30 minutes', value: 30 },
-    { label: '1 hour', value: 60 },
-    { label: '4 hours', value: 240 },
-    { label: '12 hours', value: 720 },
-    { label: '1 day', value: 1440 },
-    { label: '3 days', value: 4320 },
-    { label: '7 days', value: 10080 },
-    { label: '14 days', value: 20160 },
-    { label: '30 days', value: 43200 },
-];
-
-// Intentionally static — shorthand labels are a CLI convenience and don't need
-// to be dynamically generated from the server. New server-side expiry options
-// can still be used via raw minute values (e.g., `--expires-in 120`).
-const SHORTHAND_MAP = {
-    '5m': 5, '30m': 30, '1h': 60, '4h': 240, '12h': 720,
-    '1d': 1440, '3d': 4320, '7d': 10080, '14d': 20160, '30d': 43200,
-};
-
-const DEFAULT_URL = 'https://flashview.link';
-
-/**
- * Fetch server configuration with cache-first strategy.
- *
- * @returns {Promise<Object|null>}
- */
-async function getServerConfig() {
-    const cached = getCachedServerConfig();
-    if (cached) {
-        return cached;
-    }
-
-    try {
-        process.stderr.write('Fetching configuration from server...\n');
-        const { url, token } = getConfigInfo();
-        const baseUrl = url || DEFAULT_URL;
-        const serverConfig = await FlashViewClient.fetchConfig(baseUrl, token || null);
-        setCachedServerConfig(serverConfig);
-        return serverConfig;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * Parse an expiry value from human-readable label or raw minutes.
- *
- * @param {string} value
- * @param {number[]} allowedValues
- * @returns {number|null}
- */
-function parseExpiry(value, allowedValues) {
-    const shorthand = SHORTHAND_MAP[value.toLowerCase()];
-    if (shorthand !== undefined && allowedValues.includes(shorthand)) {
-        return shorthand;
-    }
-
-    const minutes = parseInt(value, 10);
-    if (!isNaN(minutes) && allowedValues.includes(minutes)) {
-        return minutes;
-    }
-
-    return null;
-}
 
 /**
  * Read all data from stdin.
@@ -560,8 +493,6 @@ program
             server.close();
         }
     });
-
-export { parseExpiry, FALLBACK_EXPIRY_OPTIONS, SHORTHAND_MAP };
 
 export function run() {
     program.parse();

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -561,6 +561,8 @@ program
         }
     });
 
+export { parseExpiry, FALLBACK_EXPIRY_OPTIONS, SHORTHAND_MAP };
+
 export function run() {
     program.parse();
 }

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -7,33 +7,74 @@ import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { encryptMessage, decryptMessage } from './crypto.js';
 import { FlashViewClient, ApiError } from './api.js';
-import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
+import { getConfig, getConfigInfo, setConfig, clearConfig, getCachedServerConfig, setCachedServerConfig } from './config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
-// Allowed expiry values — must match config/secrets.php expiry_options
-// See: config/secrets.php for the server-side list
-const EXPIRY_LABELS = {
+// Fallback expiry options used when the server is unreachable and no cache exists.
+const FALLBACK_EXPIRY_OPTIONS = [
+    { label: '5 minutes', value: 5 },
+    { label: '30 minutes', value: 30 },
+    { label: '1 hour', value: 60 },
+    { label: '4 hours', value: 240 },
+    { label: '12 hours', value: 720 },
+    { label: '1 day', value: 1440 },
+    { label: '3 days', value: 4320 },
+    { label: '7 days', value: 10080 },
+    { label: '14 days', value: 20160 },
+    { label: '30 days', value: 43200 },
+];
+
+// Intentionally static — shorthand labels are a CLI convenience and don't need
+// to be dynamically generated from the server. New server-side expiry options
+// can still be used via raw minute values (e.g., `--expires-in 120`).
+const SHORTHAND_MAP = {
     '5m': 5, '30m': 30, '1h': 60, '4h': 240, '12h': 720,
     '1d': 1440, '3d': 4320, '7d': 10080, '14d': 20160, '30d': 43200,
 };
-const ALLOWED_EXPIRY_OPTIONS = Object.values(EXPIRY_LABELS);
+
+const DEFAULT_URL = 'https://flashview.link';
+
+/**
+ * Fetch server configuration with cache-first strategy.
+ *
+ * @returns {Promise<Object|null>}
+ */
+async function getServerConfig() {
+    const cached = getCachedServerConfig();
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        process.stderr.write('Fetching configuration from server...\n');
+        const { url, token } = getConfigInfo();
+        const baseUrl = url || DEFAULT_URL;
+        const serverConfig = await FlashViewClient.fetchConfig(baseUrl, token || null);
+        setCachedServerConfig(serverConfig);
+        return serverConfig;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Parse an expiry value from human-readable label or raw minutes.
  *
  * @param {string} value
+ * @param {number[]} allowedValues
  * @returns {number|null}
  */
-function parseExpiry(value) {
-    if (EXPIRY_LABELS[value.toLowerCase()]) {
-        return EXPIRY_LABELS[value.toLowerCase()];
+function parseExpiry(value, allowedValues) {
+    const shorthand = SHORTHAND_MAP[value.toLowerCase()];
+    if (shorthand !== undefined && allowedValues.includes(shorthand)) {
+        return shorthand;
     }
 
     const minutes = parseInt(value, 10);
-    if (!isNaN(minutes) && ALLOWED_EXPIRY_OPTIONS.includes(minutes)) {
+    if (!isNaN(minutes) && allowedValues.includes(minutes)) {
         return minutes;
     }
 
@@ -167,11 +208,16 @@ program
         const config = getConfig();
         const client = new FlashViewClient(config.url, config.token);
 
-        const expiresIn = parseExpiry(options.expiresIn);
+        const serverConfig = await getServerConfig();
+        const expiryOptions = serverConfig?.expiry_options ?? FALLBACK_EXPIRY_OPTIONS;
+        const allowedValues = expiryOptions.map(o => o.value);
+
+        const expiresIn = parseExpiry(options.expiresIn, allowedValues);
         if (!expiresIn) {
-            const labels = Object.keys(EXPIRY_LABELS).join(', ');
+            const labels = expiryOptions.map(o => o.label).join(', ');
             console.error(`Invalid expiry value: ${options.expiresIn}`);
             console.error(`Allowed values: ${labels}`);
+            console.error('You can also specify a value in minutes directly (e.g., --expires-in 120).');
             process.exit(1);
         }
 

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -79,6 +79,15 @@ export function clearCachedServerConfig() {
 }
 
 /**
+ * Override the cache timestamp (for testing purposes).
+ *
+ * @param {number} timestamp
+ */
+export function setServerConfigFetchedAt(timestamp) {
+    config.set('serverConfigFetchedAt', timestamp);
+}
+
+/**
  * Save configuration.
  *
  * @param {{ url: string, token: string }} options

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -7,8 +7,12 @@ const config = new Conf({
     schema: {
         url: { type: 'string' },
         token: { type: 'string' },
+        serverConfig: { type: 'object' },
+        serverConfigFetchedAt: { type: 'number' },
     },
 });
+
+const CONFIG_CACHE_TTL = 60 * 60 * 1000; // 1 hour in milliseconds
 
 /**
  * Get the stored configuration, exiting if not configured.
@@ -41,6 +45,40 @@ export function getConfigInfo() {
 }
 
 /**
+ * Get cached server configuration if still valid.
+ *
+ * @returns {Object|null}
+ */
+export function getCachedServerConfig() {
+    const fetchedAt = config.get('serverConfigFetchedAt');
+    const cached = config.get('serverConfig');
+
+    if (cached && fetchedAt && (Date.now() - fetchedAt) < CONFIG_CACHE_TTL) {
+        return cached;
+    }
+
+    return null;
+}
+
+/**
+ * Store server configuration in cache.
+ *
+ * @param {Object} serverConfig
+ */
+export function setCachedServerConfig(serverConfig) {
+    config.set('serverConfig', serverConfig);
+    config.set('serverConfigFetchedAt', Date.now());
+}
+
+/**
+ * Clear cached server configuration.
+ */
+export function clearCachedServerConfig() {
+    config.delete('serverConfig');
+    config.delete('serverConfigFetchedAt');
+}
+
+/**
  * Save configuration.
  *
  * @param {{ url: string, token: string }} options
@@ -48,6 +86,7 @@ export function getConfigInfo() {
 export function setConfig({ url, token }) {
     if (url) config.set('url', url);
     if (token) config.set('token', token);
+    clearCachedServerConfig();
 }
 
 /**

--- a/tools/flashview-cli/src/expiry.js
+++ b/tools/flashview-cli/src/expiry.js
@@ -1,0 +1,70 @@
+import { FlashViewClient } from './api.js';
+import { getConfigInfo, getCachedServerConfig, setCachedServerConfig } from './config.js';
+
+/** Fallback expiry options used when the server is unreachable and no cache exists. */
+export const FALLBACK_EXPIRY_OPTIONS = [
+    { label: '5 minutes', value: 5 },
+    { label: '30 minutes', value: 30 },
+    { label: '1 hour', value: 60 },
+    { label: '4 hours', value: 240 },
+    { label: '12 hours', value: 720 },
+    { label: '1 day', value: 1440 },
+    { label: '3 days', value: 4320 },
+    { label: '7 days', value: 10080 },
+    { label: '14 days', value: 20160 },
+    { label: '30 days', value: 43200 },
+];
+
+// Intentionally static — shorthand labels are a CLI convenience and don't need
+// to be dynamically generated from the server. New server-side expiry options
+// can still be used via raw minute values (e.g., `--expires-in 120`).
+export const SHORTHAND_MAP = {
+    '5m': 5, '30m': 30, '1h': 60, '4h': 240, '12h': 720,
+    '1d': 1440, '3d': 4320, '7d': 10080, '14d': 20160, '30d': 43200,
+};
+
+const DEFAULT_URL = 'https://flashview.link';
+
+/**
+ * Fetch server configuration with cache-first strategy.
+ *
+ * @returns {Promise<Object|null>}
+ */
+export async function getServerConfig() {
+    const cached = getCachedServerConfig();
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        process.stderr.write('Fetching configuration from server...\n');
+        const { url, token } = getConfigInfo();
+        const baseUrl = url || DEFAULT_URL;
+        const serverConfig = await FlashViewClient.fetchConfig(baseUrl, token || null);
+        setCachedServerConfig(serverConfig);
+        return serverConfig;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Parse an expiry value from human-readable label or raw minutes.
+ *
+ * @param {string} value
+ * @param {number[]} allowedValues
+ * @returns {number|null}
+ */
+export function parseExpiry(value, allowedValues) {
+    const shorthand = SHORTHAND_MAP[value.toLowerCase()];
+    if (shorthand !== undefined && allowedValues.includes(shorthand)) {
+        return shorthand;
+    }
+
+    const minutes = parseInt(value, 10);
+    if (!isNaN(minutes) && allowedValues.includes(minutes)) {
+        return minutes;
+    }
+
+    return null;
+}

--- a/tools/flashview-cli/tests/cli.test.js
+++ b/tools/flashview-cli/tests/cli.test.js
@@ -4,7 +4,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseExpiry, FALLBACK_EXPIRY_OPTIONS, SHORTHAND_MAP } from '../src/cli.js';
+import { parseExpiry, FALLBACK_EXPIRY_OPTIONS, SHORTHAND_MAP } from '../src/expiry.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/tools/flashview-cli/tests/cli.test.js
+++ b/tools/flashview-cli/tests/cli.test.js
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseExpiry, FALLBACK_EXPIRY_OPTIONS, SHORTHAND_MAP } from '../src/cli.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,5 +17,52 @@ describe('CLI version', () => {
             encoding: 'utf-8',
         });
         assert.strictEqual(output.trim(), pkg.version);
+    });
+});
+
+describe('parseExpiry', () => {
+    const defaultAllowed = FALLBACK_EXPIRY_OPTIONS.map(o => o.value);
+
+    it('parses shorthand labels with default options', () => {
+        assert.strictEqual(parseExpiry('1h', defaultAllowed), 60);
+        assert.strictEqual(parseExpiry('7d', defaultAllowed), 10080);
+        assert.strictEqual(parseExpiry('30m', defaultAllowed), 30);
+    });
+
+    it('parses raw minute values', () => {
+        assert.strictEqual(parseExpiry('60', defaultAllowed), 60);
+        assert.strictEqual(parseExpiry('1440', defaultAllowed), 1440);
+    });
+
+    it('is case-insensitive for shorthand labels', () => {
+        assert.strictEqual(parseExpiry('1H', defaultAllowed), 60);
+        assert.strictEqual(parseExpiry('7D', defaultAllowed), 10080);
+    });
+
+    it('returns null for invalid values', () => {
+        assert.strictEqual(parseExpiry('2h', defaultAllowed), null);
+        assert.strictEqual(parseExpiry('abc', defaultAllowed), null);
+        assert.strictEqual(parseExpiry('999', defaultAllowed), null);
+    });
+
+    it('works with dynamically provided options', () => {
+        const customAllowed = [15, 120, 480];
+        assert.strictEqual(parseExpiry('120', customAllowed), 120);
+        assert.strictEqual(parseExpiry('15', customAllowed), 15);
+        // Shorthand '1h' maps to 60, which is not in customAllowed
+        assert.strictEqual(parseExpiry('1h', customAllowed), null);
+    });
+
+    it('rejects shorthand when mapped value is not in allowed list', () => {
+        const restrictedAllowed = [5, 30]; // only 5m and 30m
+        assert.strictEqual(parseExpiry('5m', restrictedAllowed), 5);
+        assert.strictEqual(parseExpiry('1h', restrictedAllowed), null);
+        assert.strictEqual(parseExpiry('7d', restrictedAllowed), null);
+    });
+
+    it('fallback expiry options match shorthand map values', () => {
+        const fallbackValues = FALLBACK_EXPIRY_OPTIONS.map(o => o.value);
+        const shorthandValues = Object.values(SHORTHAND_MAP);
+        assert.deepStrictEqual(shorthandValues.sort((a, b) => a - b), fallbackValues.sort((a, b) => a - b));
     });
 });

--- a/tools/flashview-cli/tests/config.test.js
+++ b/tools/flashview-cli/tests/config.test.js
@@ -1,0 +1,35 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCachedServerConfig, setCachedServerConfig, clearCachedServerConfig, setConfig, clearConfig } from '../src/config.js';
+
+describe('Server config caching', () => {
+    beforeEach(() => {
+        clearConfig();
+    });
+
+    it('returns null when no cache exists', () => {
+        assert.strictEqual(getCachedServerConfig(), null);
+    });
+
+    it('round-trips cached server config', () => {
+        const config = { expiry_options: [{ label: '1 hour', value: 60 }] };
+        setCachedServerConfig(config);
+
+        const cached = getCachedServerConfig();
+        assert.deepStrictEqual(cached, config);
+    });
+
+    it('clearCachedServerConfig removes cached data', () => {
+        setCachedServerConfig({ expiry_options: [] });
+        clearCachedServerConfig();
+
+        assert.strictEqual(getCachedServerConfig(), null);
+    });
+
+    it('setConfig clears cached server config', () => {
+        setCachedServerConfig({ expiry_options: [] });
+        setConfig({ url: 'https://example.com', token: 'tok_test' });
+
+        assert.strictEqual(getCachedServerConfig(), null);
+    });
+});

--- a/tools/flashview-cli/tests/config.test.js
+++ b/tools/flashview-cli/tests/config.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getCachedServerConfig, setCachedServerConfig, clearCachedServerConfig, setConfig, clearConfig } from '../src/config.js';
+import { getCachedServerConfig, setCachedServerConfig, clearCachedServerConfig, setConfig, clearConfig, setServerConfigFetchedAt } from '../src/config.js';
 
 describe('Server config caching', () => {
     beforeEach(() => {
@@ -17,6 +17,24 @@ describe('Server config caching', () => {
 
         const cached = getCachedServerConfig();
         assert.deepStrictEqual(cached, config);
+    });
+
+    it('returns cached config within TTL', () => {
+        const config = { expiry_options: [{ label: '5 minutes', value: 5 }] };
+        setCachedServerConfig(config);
+        // Set fetchedAt to 30 minutes ago (within 1h TTL)
+        setServerConfigFetchedAt(Date.now() - (30 * 60 * 1000));
+
+        assert.deepStrictEqual(getCachedServerConfig(), config);
+    });
+
+    it('returns null when cache has expired beyond TTL', () => {
+        const config = { expiry_options: [{ label: '1 hour', value: 60 }] };
+        setCachedServerConfig(config);
+        // Set fetchedAt to 2 hours ago (beyond 1h TTL)
+        setServerConfigFetchedAt(Date.now() - (2 * 60 * 60 * 1000));
+
+        assert.strictEqual(getCachedServerConfig(), null);
     });
 
     it('clearCachedServerConfig removes cached data', () => {


### PR DESCRIPTION
## Summary

- Add public `GET /api/v1/config` endpoint that returns expiry options, expiry limits, and message length limits from server config. Supports optional Sanctum auth for plan-specific limits.
- Update FlashView CLI to fetch config from the server dynamically instead of using hardcoded expiry values, with 1-hour cache TTL and graceful fallback to defaults when server is unreachable.
- Rate limited to 60 req/min. Uses FormRequest and API Resource per project conventions.

## Test plan

- [x] 6 backend feature tests pass (`ConfigApiTest` — guest, subscribed, unsubscribed, orphan plan, value matching, public access)
- [x] 14 CLI tests pass (parseExpiry with dynamic options, cache TTL, round-trip, invalidation on config change)
- [x] All 49 existing API tests pass (route restructuring verified safe)
- [x] Manual: `curl /api/v1/config` returns expected JSON structure
- [x] Manual: `flashview create -e 1h` fetches config from server on first run
- [x] Manual: Subsequent runs use cached config (no "Fetching configuration..." message)

Closes PIO-15