### PR TITLE
Rename CLI 'configure' command to 'config'

### DIFF
--- a/resources/markdown/cli.md
+++ b/resources/markdown/cli.md
@@ -36,14 +36,14 @@ This opens your browser, lets you authenticate with your existing credentials (i
 Alternatively, you can manually create a token from your [API Tokens]({ROUTE:api-tokens.index}) page and configure the CLI directly:
 
 ```
-flashview configure set --token your-api-token
+flashview config set --token your-api-token
 ```
 
 The default server URL is `https://flashview.link`. To use a self-hosted instance, pass `--url`:
 
 ```
 flashview login --url https://your-server.com
-flashview configure set --token your-api-token --url https://your-server.com
+flashview config set --token your-api-token --url https://your-server.com
 ```
 
 ## Usage

--- a/tools/flashview-cli/README.md
+++ b/tools/flashview-cli/README.md
@@ -25,26 +25,26 @@ This opens your browser, lets you authenticate with your existing credentials (i
 Alternatively, you can manually create a token from your [API Tokens](https://flashview.link/user/api-tokens) page and configure the CLI directly:
 
 ```
-flashview configure set --token your-api-token
+flashview config set --token your-api-token
 ```
 
 The default server URL is `https://flashview.link`. To use a self-hosted instance, pass `--url`:
 
 ```
 flashview login --url https://your-server.com
-flashview configure set --token your-api-token --url https://your-server.com
+flashview config set --token your-api-token --url https://your-server.com
 ```
 
 ### View current configuration
 
 ```bash
-flashview configure show
+flashview config show
 ```
 
 ### Clear stored configuration
 
 ```bash
-flashview configure clear
+flashview config clear
 ```
 
 ## Usage

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -56,7 +56,7 @@ function withErrorHandling(fn) {
         } catch (err) {
             if (err instanceof ApiError) {
                 if (err.status === 401) {
-                    console.error('Authentication failed. Run `flashview configure set` to update your token.');
+                    console.error('Authentication failed. Run `flashview config set` to update your token.');
                 } else if (err.status === 403) {
                     console.error(err.message);
                 } else if (err.status === 410) {
@@ -93,13 +93,13 @@ program
     .description('FlashView CLI — Create and manage encrypted secrets')
     .version(pkg.version);
 
-// --- Configure ---
+// --- Config ---
 
-const configure = program
-    .command('configure')
+const configCmd = program
+    .command('config')
     .description('Manage CLI configuration');
 
-configure
+configCmd
     .command('set')
     .description('Set API token and server URL')
     .option('--url <url>', 'FlashView server URL (default: https://flashview.link)')
@@ -109,7 +109,7 @@ configure
         console.log('Configuration saved.');
     });
 
-configure
+configCmd
     .command('show')
     .description('Show current configuration')
     .action(() => {
@@ -119,7 +119,7 @@ configure
         console.log(`Config:     ${path}`);
     });
 
-configure
+configCmd
     .command('clear')
     .description('Clear stored configuration')
     .action(() => {

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -24,7 +24,7 @@ export function getConfig() {
     const token = config.get('token');
 
     if (!token) {
-        console.error('Not configured. Run: flashview login or flashview configure set --token <token>');
+        console.error('Not configured. Run: flashview login or flashview config set --token <token>');
         process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- Rename the FlashView CLI `configure` command to `config` for brevity and consistency with common CLI conventions (e.g., `git config`)
- Update all error messages, CLI README, and user-facing `/cli` documentation page to reference the new command name
- Subcommands (`set`, `show`, `clear`) remain unchanged

## Test plan
- [x] Verify `flashview config set --token <token>` saves configuration
- [x] Verify `flashview config show` displays current configuration
- [x] Verify `flashview config clear` removes stored configuration
- [x] Verify `flashview configure` is no longer recognized
- [x] Verify error messages reference `flashview config set` (not `configure`)
- [x] Verify `/cli` documentation page shows `config` command
- [x] All existing CLI tests pass (45/45)

Closes PIO-25