### PR TITLE
Fix invalid hash_id returning 500 instead of 404

### DIFF
--- a/app/Exceptions/HashIdDecodeException.php
+++ b/app/Exceptions/HashIdDecodeException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class HashIdDecodeException extends Exception
+{
+    public function __construct(string $hashId = '', ?\Throwable $previous = null)
+    {
+        parent::__construct("Failed to decode hash ID: {$hashId}", 0, $previous);
+    }
+
+    public function render(Request $request): Response|JsonResponse
+    {
+        if ($request->expectsJson()) {
+            return response()->json(['message' => 'Not Found'], 404);
+        }
+
+        abort(404);
+    }
+}

--- a/app/Exceptions/InvalidHashIdException.php
+++ b/app/Exceptions/InvalidHashIdException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class InvalidHashIdException extends Exception
+{
+    public function __construct(string $hashId = '')
+    {
+        parent::__construct("Invalid hash ID: {$hashId}");
+    }
+
+    public function render(Request $request): Response|JsonResponse
+    {
+        if ($request->expectsJson()) {
+            return response()->json(['message' => 'Not Found'], 404);
+        }
+
+        abort(404);
+    }
+}

--- a/app/Traits/HasHashId.php
+++ b/app/Traits/HasHashId.php
@@ -2,6 +2,8 @@
 
 namespace App\Traits;
 
+use App\Exceptions\HashIdDecodeException;
+use App\Exceptions\InvalidHashIdException;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Vinkla\Hashids\Facades\Hashids as LaravelHashids;
 
@@ -51,8 +53,18 @@ trait HasHashId
         );
     }
 
-    public static function findByHashID($hash_id)
+    public static function findByHashID(string $hash_id): static
     {
-        return self::findOrFail(LaravelHashids::connection(self::getHashIdConnection())->decode($hash_id)[0]);
+        try {
+            $id = static::decodeHashId($hash_id);
+        } catch (\Throwable $e) {
+            throw new HashIdDecodeException($hash_id, $e);
+        }
+
+        if ($id === null) {
+            throw new InvalidHashIdException($hash_id);
+        }
+
+        return self::findOrFail($id);
     }
 }

--- a/tests/Feature/Api/SecretRetrievalTest.php
+++ b/tests/Feature/Api/SecretRetrievalTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature\Api;
 
+use App\Exceptions\InvalidHashIdException;
 use App\Models\Plan;
 use App\Models\Secret;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use Tests\TestCase;
 
@@ -239,6 +241,42 @@ class SecretRetrievalTest extends TestCase
         $response = $this->getJson("/api/v1/secrets/{$secret->hash_id}/retrieve");
 
         $response->assertForbidden();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidHashIdProvider(): array
+    {
+        return [
+            'garbage string' => ['invalid-hash'],
+            'special characters' => ['!!!@@@'],
+            'random alphanumeric' => ['abc123xyz'],
+        ];
+    }
+
+    #[DataProvider('invalidHashIdProvider')]
+    public function test_invalid_hash_id_returns_404(string $invalidHashId): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $response = $this->getJson("/api/v1/secrets/{$invalidHashId}/retrieve");
+
+        $response->assertNotFound();
+    }
+
+    #[DataProvider('invalidHashIdProvider')]
+    public function test_invalid_hash_id_throws_invalid_hash_id_exception(string $invalidHashId): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:list']);
+
+        $this->withoutExceptionHandling();
+
+        $this->expectException(InvalidHashIdException::class);
+
+        $this->getJson("/api/v1/secrets/{$invalidHashId}/retrieve");
     }
 
     public function test_forbidden_request_does_not_consume_secret(): void


### PR DESCRIPTION
## Summary

- Add `InvalidHashIdException` and `HashIdDecodeException` — self-rendering domain exceptions that return 404 for invalid hash IDs
- Fix `findByHashID()` in `HasHashId` trait to use the safe `decodeHashId()` method with try-catch, instead of directly accessing `decode()[0]`
- Add tests verifying invalid hash IDs (garbage strings, special characters) return 404

## Context

When an invalid `hash_id` was provided to `GET /api/v1/secrets/{secret}/retrieve`, the Hashids library returned an empty array and accessing `[0]` threw `ErrorException: Undefined array key 0`, resulting in a 500 Server Error. This fix ensures a clean 404 response instead.

## Blast radius

Low — only `Api\SecretController::retrieve()` calls `findByHashID()`. All other endpoints already use `decodeHashId()` safely.

## Test plan

- [x] Invalid hash IDs return 404 (garbage string, special characters, random alphanumeric)
- [x] Invalid hash IDs throw `InvalidHashIdException`
- [x] Existing retrieval tests still pass (17/17)
- [x] Manual: `GET /api/v1/secrets/invalid-hash/retrieve` returns `{"message": "Not Found"}` with 404 status

Refs: PIO-34