### PR TITLE
Rename hash_id to Message ID in CLI output and docs

### DIFF
--- a/resources/markdown/cli.md
+++ b/resources/markdown/cli.md
@@ -78,8 +78,8 @@ flashview list --page 2
 ### Burn (Delete) a Secret
 
 ```
-flashview burn <hash_id>
-flashview burn <hash_id> --yes   # skip confirmation
+flashview burn <message_id>
+flashview burn <message_id> --yes   # skip confirmation
 ```
 
 ## Security

--- a/tools/flashview-cli/README.md
+++ b/tools/flashview-cli/README.md
@@ -87,13 +87,13 @@ flashview list --json
 ### Burn (delete) a secret
 
 ```bash
-flashview burn <hash_id>
+flashview burn <message_id>
 
 # Skip confirmation
-flashview burn <hash_id> --yes
+flashview burn <message_id> --yes
 
 # JSON output
-flashview burn <hash_id> --json
+flashview burn <message_id> --json
 ```
 
 ## Security Notes

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -191,7 +191,7 @@ program
 // --- Get ---
 
 program
-    .command('get <hashId>')
+    .command('get <messageId>')
     .description('Retrieve and decrypt a secret (text secrets only)')
     .requiredOption('-p, --passphrase <passphrase>', 'Decryption passphrase')
     .option('--json', 'Output as JSON (for scripting)')
@@ -267,7 +267,7 @@ program
 // --- Status ---
 
 program
-    .command('status <hashId>')
+    .command('status <messageId>')
     .description('Show status of a secret (use message ID from create output or list)')
     .option('--json', 'Output as JSON (for scripting)')
     .action(withErrorHandling(async (hashId, options) => {
@@ -294,7 +294,7 @@ program
 // --- Burn ---
 
 program
-    .command('burn <hashId>')
+    .command('burn <messageId>')
     .description('Burn (delete) a secret')
     .option('--json', 'Output as JSON (for scripting)')
     .option('-y, --yes', 'Skip confirmation prompt')

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -15,6 +15,27 @@ const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
 /**
+ * Remap `hash_id` to `message_id` in an object or array of objects.
+ *
+ * @param {object|object[]} obj
+ * @returns {object|object[]}
+ */
+function renameHashIdKey(obj) {
+    if (Array.isArray(obj)) {
+        return obj.map(renameHashIdKey);
+    }
+    if (obj && typeof obj === 'object') {
+        const { hash_id, ...rest } = obj;
+        const result = { ...rest };
+        if (hash_id !== undefined) {
+            result.message_id = hash_id;
+        }
+        return result;
+    }
+    return obj;
+}
+
+/**
  * Read all data from stdin.
  *
  * @returns {Promise<string>}
@@ -172,14 +193,14 @@ program
             console.log(JSON.stringify({
                 url: result.data.url,
                 passphrase,
-                hash_id: result.data.hash_id,
+                message_id: result.data.hash_id,
                 expires_at: result.data.expires_at,
             }));
         } else {
             console.log('Secret created successfully!\n');
             console.log(`URL:        ${result.data.url}`);
             console.log(`Passphrase: ${passphrase}`);
-            console.log(`Hash ID:    ${result.data.hash_id}`);
+            console.log(`Message ID: ${result.data.hash_id}`);
             console.log(`Expires:    ${result.data.expires_at}`);
             console.log('\nSave the URL and passphrase now — they cannot be retrieved later.');
             console.log('\nNote: CLI retrieval requires the recipient to have a FlashView account with API access.');
@@ -222,7 +243,7 @@ program
 
         if (options.json) {
             console.log(JSON.stringify({
-                hash_id: result.data.hash_id,
+                message_id: result.data.hash_id,
                 message: plaintext,
             }));
         } else {
@@ -244,13 +265,14 @@ program
         const result = await client.listSecrets(parseInt(options.page, 10));
 
         if (options.json) {
-            console.log(JSON.stringify(result));
+            const remapped = { ...result, data: result.data.map(renameHashIdKey) };
+            console.log(JSON.stringify(remapped));
         } else {
             if (!result.data.length) {
                 console.log('No secrets found.');
                 return;
             }
-            console.log('Hash ID          Expires At               Status');
+            console.log('Message ID       Expires At               Status');
             console.log('\u2500'.repeat(60));
             for (const secret of result.data) {
                 const status = secret.is_retrieved ? 'Retrieved' : secret.is_expired ? 'Expired' : 'Active';
@@ -266,7 +288,7 @@ program
 
 program
     .command('status <hashId>')
-    .description('Show status of a secret (use hash ID from create output or list)')
+    .description('Show status of a secret (use message ID from create output or list)')
     .option('--json', 'Output as JSON (for scripting)')
     .action(withErrorHandling(async (hashId, options) => {
         const config = getConfig();
@@ -276,10 +298,10 @@ program
         const secret = result.data;
 
         if (options.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify({ ...result, data: renameHashIdKey(result.data) }));
         } else {
             const status = secret.is_retrieved ? 'Retrieved' : secret.is_expired ? 'Expired' : 'Active';
-            console.log(`Hash ID:      ${secret.hash_id}`);
+            console.log(`Message ID:   ${secret.hash_id}`);
             console.log(`Status:       ${status}`);
             console.log(`Created:      ${secret.created_at}`);
             console.log(`Expires:      ${secret.expires_at}`);

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -9,31 +9,11 @@ import { encryptMessage, decryptMessage } from './crypto.js';
 import { FlashViewClient, ApiError } from './api.js';
 import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
 import { parseExpiry, getServerConfig, FALLBACK_EXPIRY_OPTIONS } from './expiry.js';
+import { renameHashIdKey } from './transform.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
-
-/**
- * Remap `hash_id` to `message_id` in an object or array of objects.
- *
- * @param {object|object[]} obj
- * @returns {object|object[]}
- */
-function renameHashIdKey(obj) {
-    if (Array.isArray(obj)) {
-        return obj.map(renameHashIdKey);
-    }
-    if (obj && typeof obj === 'object') {
-        const { hash_id, ...rest } = obj;
-        const result = { ...rest };
-        if (hash_id !== undefined) {
-            result.message_id = hash_id;
-        }
-        return result;
-    }
-    return obj;
-}
 
 /**
  * Read all data from stdin.
@@ -515,7 +495,6 @@ program
             server.close();
         }
     });
-
 export function run() {
     program.parse();
 }

--- a/tools/flashview-cli/src/transform.js
+++ b/tools/flashview-cli/src/transform.js
@@ -1,0 +1,20 @@
+/**
+ * Remap `hash_id` to `message_id` in an object or array of objects.
+ *
+ * @param {object|object[]} obj
+ * @returns {object|object[]}
+ */
+export function renameHashIdKey(obj) {
+    if (Array.isArray(obj)) {
+        return obj.map(renameHashIdKey);
+    }
+    if (obj && typeof obj === 'object') {
+        const { hash_id, ...rest } = obj;
+        const result = { ...rest };
+        if (hash_id !== undefined) {
+            result.message_id = hash_id;
+        }
+        return result;
+    }
+    return obj;
+}


### PR DESCRIPTION
## Summary

- Rename all user-facing "Hash ID" labels to "Message ID" in FlashView CLI human-readable output (`create`, `list`, `status` commands)
- Remap `hash_id` JSON key to `message_id` in CLI `--json` output for `create`, `get`, `list`, and `status` commands
- Update `<hash_id>` placeholder to `<message_id>` in CLI README and website CLI documentation

## Breaking change

The `--json` output now uses `message_id` instead of `hash_id`. Scripts parsing CLI JSON output should update references accordingly. The HTTP API response keys are unchanged.

## What does NOT change

- Database columns, model attributes, migrations
- API response JSON keys (`SecretResource`, `SecretMessageResource`)
- Web UI (already uses "Message ID")
- Email notifications (already uses "Message ID")

## Test plan

- [x] Run `flashview create -m "test" --json` — verify JSON has `message_id` key (not `hash_id`)
- [x] Run `flashview create -m "test"` — verify label says "Message ID:"
- [x] Run `flashview list` — verify table header says "Message ID"
- [x] Run `flashview list --json` — verify each item has `message_id` key
- [x] Run `flashview status <id>` — verify label says "Message ID:"
- [x] Run `flashview status <id> --json` — verify `message_id` key in output
- [x] Visit `/cli` page — verify burn examples use `<message_id>`
- [x] Check CLI README — verify burn examples use `<message_id>`
- [x] Run existing test suite — no regressions

Closes PIO-32