### PR TITLE
Add webhook notifications for API customers

### DIFF
--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -4,20 +4,15 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateWebhookSettingsRequest;
+use App\Http\Resources\WebhookResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class WebhookController extends Controller
 {
-    public function show(Request $request): JsonResponse
+    public function show(Request $request): WebhookResource
     {
-        $user = $request->user();
-
-        return response()->json([
-            'webhook_url' => $user->webhook_url,
-            'webhook_secret' => $user->webhook_secret ? str_repeat('*', 56).substr($user->webhook_secret, -8) : null,
-            'configured' => $user->hasWebhookConfigured(),
-        ]);
+        return new WebhookResource($request->user());
     }
 
     public function update(UpdateWebhookSettingsRequest $request): JsonResponse
@@ -35,12 +30,10 @@ class WebhookController extends Controller
 
         $user->updateQuietly($data);
 
-        return response()->json([
-            'webhook_url' => $user->webhook_url,
-            'webhook_secret' => $user->webhook_secret ? str_repeat('*', 56).substr($user->webhook_secret, -8) : null,
-            'configured' => $user->hasWebhookConfigured(),
-            'message' => 'Webhook settings updated.',
-        ]);
+        return response()->json(array_merge(
+            (new WebhookResource($user))->resolve(),
+            ['message' => 'Webhook settings updated.'],
+        ));
     }
 
     public function regenerateSecret(Request $request): JsonResponse

--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateWebhookSettingsRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'webhook_url' => $user->webhook_url,
+            'webhook_secret' => $user->webhook_secret ? str_repeat('*', 56).substr($user->webhook_secret, -8) : null,
+            'configured' => $user->hasWebhookConfigured(),
+        ]);
+    }
+
+    public function update(UpdateWebhookSettingsRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $data = $request->validated();
+
+        if (filled($data['webhook_url']) && blank($user->webhook_secret)) {
+            $data['webhook_secret'] = bin2hex(random_bytes(32));
+        }
+
+        if (blank($data['webhook_url'])) {
+            $data['webhook_secret'] = null;
+        }
+
+        $user->updateQuietly($data);
+
+        return response()->json([
+            'webhook_url' => $user->webhook_url,
+            'webhook_secret' => $user->webhook_secret ? str_repeat('*', 56).substr($user->webhook_secret, -8) : null,
+            'configured' => $user->hasWebhookConfigured(),
+            'message' => 'Webhook settings updated.',
+        ]);
+    }
+
+    public function regenerateSecret(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user->hasWebhookConfigured(), 422);
+
+        $newSecret = bin2hex(random_bytes(32));
+        $user->updateQuietly(['webhook_secret' => $newSecret]);
+
+        return response()->json([
+            'webhook_secret' => $newSecret,
+            'message' => 'Webhook secret regenerated. Update your integration with the new secret.',
+        ]);
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $request->user()->updateQuietly([
+            'webhook_url' => null,
+            'webhook_secret' => null,
+        ]);
+
+        return response()->json([
+            'message' => 'Webhook configuration removed.',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -12,6 +12,8 @@ class WebhookController extends Controller
 {
     public function show(Request $request): WebhookResource
     {
+        abort_unless($request->user()->planSupportsWebhook(), 403);
+
         return new WebhookResource($request->user());
     }
 
@@ -40,6 +42,7 @@ class WebhookController extends Controller
     {
         $user = $request->user();
 
+        abort_unless($user->planSupportsWebhook(), 403);
         abort_unless($user->hasWebhookConfigured(), 422);
 
         $newSecret = bin2hex(random_bytes(32));
@@ -53,6 +56,7 @@ class WebhookController extends Controller
 
     public function destroy(Request $request): JsonResponse
     {
+        abort_unless($request->user()->planSupportsWebhook(), 403);
         $request->user()->updateQuietly([
             'webhook_url' => null,
             'webhook_secret' => null,

--- a/app/Http/Controllers/WebhookSettingsController.php
+++ b/app/Http/Controllers/WebhookSettingsController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateWebhookSettingsRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class WebhookSettingsController extends Controller
+{
+    public function update(UpdateWebhookSettingsRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $data = $request->validated();
+
+        if (filled($data['webhook_url']) && blank($user->webhook_secret)) {
+            $data['webhook_secret'] = bin2hex(random_bytes(32));
+        }
+
+        if (blank($data['webhook_url'])) {
+            $data['webhook_secret'] = null;
+        }
+
+        $user->updateQuietly($data);
+
+        return back();
+    }
+
+    public function regenerateSecret(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user->hasWebhookConfigured(), 422);
+
+        $user->updateQuietly([
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/WebhookSettingsController.php
+++ b/app/Http/Controllers/WebhookSettingsController.php
@@ -26,6 +26,18 @@ class WebhookSettingsController extends Controller
         return back();
     }
 
+    public function revealSecret(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user->planSupportsWebhook(), 403);
+        abort_unless($user->hasWebhookConfigured(), 422);
+
+        return back()->with('flash', [
+            'webhookSecret' => $user->webhook_secret,
+        ]);
+    }
+
     public function regenerateSecret(Request $request): RedirectResponse
     {
         $user = $request->user();
@@ -37,6 +49,8 @@ class WebhookSettingsController extends Controller
             'webhook_secret' => bin2hex(random_bytes(32)),
         ]);
 
-        return back();
+        return back()->with('flash', [
+            'webhookSecret' => $user->fresh()->webhook_secret,
+        ]);
     }
 }

--- a/app/Http/Controllers/WebhookSettingsController.php
+++ b/app/Http/Controllers/WebhookSettingsController.php
@@ -30,6 +30,7 @@ class WebhookSettingsController extends Controller
     {
         $user = $request->user();
 
+        abort_unless($user->planSupportsWebhook(), 403);
         abort_unless($user->hasWebhookConfigured(), 422);
 
         $user->updateQuietly([

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,14 +37,17 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
-        Inertia::share('auth.user.webhook_url', fn () => $request->user()?->webhook_url);
-        Inertia::share('auth.user.webhook_secret', function () use ($request) {
-            if (! $request->routeIs('profile.show')) {
-                return null;
-            }
 
-            return $request->user()?->webhook_secret;
-        });
+        if ($request->user()) {
+            Inertia::share('auth.user.webhook_url', fn () => $request->user()->webhook_url);
+            Inertia::share('auth.user.webhook_secret', function () use ($request) {
+                if (! $request->routeIs('profile.show')) {
+                    return null;
+                }
+
+                return $request->user()->webhook_secret;
+            });
+        }
 
         return parent::share($request);
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -36,19 +36,34 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
-        Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
+        // Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
 
-        if ($request->user()) {
-            Inertia::share('auth.user.webhook_url', fn () => $request->user()->webhook_url);
-            Inertia::share('auth.user.webhook_secret', function () use ($request) {
-                if (! $request->routeIs('profile.show')) {
-                    return null;
-                }
+        // if ($request->user()) {
+        //     Inertia::share('auth.user.webhook_url', fn () => $request->user()->webhook_url);
+        //     Inertia::share('auth.user.webhook_secret', function () use ($request) {
+        //         if (! $request->routeIs('profile.show')) {
+        //             return null;
+        //         }
 
-                return $request->user()->webhook_secret;
-            });
-        }
+        //         return $request->user()->webhook_secret;
+        //     });
+        // }
 
-        return parent::share($request);
+        // return parent::share($request);
+
+        $authedShare = $request->user() 
+            ? [
+                'auth' => [
+                    'hasApiAccess' => fn () => $request->user()?->hasApiAccess() ?? false,
+                    'user' => [
+                        'webhook_url', fn() => $request->user()->webhook_url,
+                        'webhook_secret', fn() => $request->routeIs('profile.show') ? $request->user()?->webhook_secret : null,
+                    ]
+                ]
+            ]
+            : [];
+
+
+        return array_merge_recursive(parent::share($request), $authedShare);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,7 +38,13 @@ class HandleInertiaRequests extends Middleware
     {
         Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
         Inertia::share('auth.user.webhook_url', fn () => $request->user()?->webhook_url);
-        Inertia::share('auth.user.webhook_secret', fn () => $request->user()?->webhook_secret);
+        Inertia::share('auth.user.webhook_secret', function () use ($request) {
+            if (! $request->routeIs('profile.show')) {
+                return null;
+            }
+
+            return $request->user()?->webhook_secret;
+        });
 
         return parent::share($request);
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -56,14 +56,14 @@ class HandleInertiaRequests extends Middleware
                 'auth' => [
                     'hasApiAccess' => fn () => $request->user()?->hasApiAccess() ?? false,
                     'user' => [
-                        'webhook_url', fn() => $request->user()->webhook_url,
-                        'webhook_secret', fn() => $request->routeIs('profile.show') ? $request->user()?->webhook_secret : null,
+                        'webhook_url' => fn() => $request->user()->webhook_url,
+                        'webhook_secret' => fn() => $request->routeIs('profile.show') ? $request->user()?->webhook_secret : null,
                     ]
                 ]
             ]
             : [];
 
 
-        return array_merge_recursive(parent::share($request), $authedShare);
+        return array_merge(parent::share($request), $authedShare);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,7 +46,6 @@ class HandleInertiaRequests extends Middleware
 
             return [
                 'webhook_url' => $user->webhook_url,
-                'webhook_secret' => $request->routeIs('profile.show') ? $user->webhook_secret : null,
             ];
         });
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -36,34 +36,20 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
-        // Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
+        Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
+        Inertia::share('auth.webhook', function () use ($request) {
+            $user = $request->user();
 
-        // if ($request->user()) {
-        //     Inertia::share('auth.user.webhook_url', fn () => $request->user()->webhook_url);
-        //     Inertia::share('auth.user.webhook_secret', function () use ($request) {
-        //         if (! $request->routeIs('profile.show')) {
-        //             return null;
-        //         }
+            if (! $user) {
+                return null;
+            }
 
-        //         return $request->user()->webhook_secret;
-        //     });
-        // }
+            return [
+                'webhook_url' => $user->webhook_url,
+                'webhook_secret' => $request->routeIs('profile.show') ? $user->webhook_secret : null,
+            ];
+        });
 
-        // return parent::share($request);
-
-        $authedShare = $request->user() 
-            ? [
-                'auth' => [
-                    'hasApiAccess' => fn () => $request->user()?->hasApiAccess() ?? false,
-                    'user' => [
-                        'webhook_url' => fn() => $request->user()->webhook_url,
-                        'webhook_secret' => fn() => $request->routeIs('profile.show') ? $request->user()?->webhook_secret : null,
-                    ]
-                ]
-            ]
-            : [];
-
-
-        return array_merge(parent::share($request), $authedShare);
+        return parent::share($request);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,6 +37,8 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         Inertia::share('auth.hasApiAccess', fn () => $request->user()?->hasApiAccess() ?? false);
+        Inertia::share('auth.user.webhook_url', fn () => $request->user()?->webhook_url);
+        Inertia::share('auth.user.webhook_secret', fn () => $request->user()?->webhook_secret);
 
         return parent::share($request);
     }

--- a/app/Http/Requests/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateNotificationPreferencesRequest.php
@@ -12,7 +12,7 @@ class UpdateNotificationPreferencesRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return $this->user()->planSupportsEmailNotifications();
     }
 
     /**

--- a/app/Http/Requests/UpdateWebhookSettingsRequest.php
+++ b/app/Http/Requests/UpdateWebhookSettingsRequest.php
@@ -13,7 +13,7 @@ class UpdateWebhookSettingsRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return $this->user()->planSupportsWebhook();
     }
 
     /**

--- a/app/Http/Requests/UpdateWebhookSettingsRequest.php
+++ b/app/Http/Requests/UpdateWebhookSettingsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\NotPrivateUrl;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWebhookSettingsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'webhook_url' => ['nullable', 'url:https', 'max:2048', new NotPrivateUrl],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'webhook_url.url' => 'The webhook URL must be a valid HTTPS URL.',
+        ];
+    }
+}

--- a/app/Http/Resources/WebhookResource.php
+++ b/app/Http/Resources/WebhookResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WebhookResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'webhook_url' => $this->webhook_url,
+            'webhook_secret' => $this->maskedWebhookSecret(),
+            'configured' => $this->hasWebhookConfigured(),
+        ];
+    }
+
+    private function maskedWebhookSecret(): ?string
+    {
+        if (blank($this->webhook_secret)) {
+            return null;
+        }
+
+        return str_repeat('*', 56).substr($this->webhook_secret, -8);
+    }
+}

--- a/app/Jobs/SendWebhookNotification.php
+++ b/app/Jobs/SendWebhookNotification.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SendWebhookNotification implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 0;
+
+    public function __construct(
+        public string $webhookUrl,
+        public string $webhookSecret,
+        public string $hashId,
+        public string $createdAt,
+        public string $retrievedAt,
+        public string $event = 'retrieved',
+    ) {}
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [30, 60, 120, 300, 900, 1800, 3600, 7200, 14400, 28800];
+    }
+
+    public function retryUntil(): \DateTime
+    {
+        return now()->addHours(24);
+    }
+
+    public function handle(): void
+    {
+        $payload = json_encode([
+            'event' => $this->event,
+            'hash_id' => $this->hashId,
+            'created_at' => $this->createdAt,
+            'retrieved_at' => $this->retrievedAt,
+        ], JSON_THROW_ON_ERROR);
+
+        $signature = 'sha256='.hash_hmac('sha256', $payload, $this->webhookSecret);
+
+        $response = Http::timeout(10)
+            ->withOptions([
+                'allow_redirects' => [
+                    'max' => 3,
+                    'protocols' => ['https'],
+                ],
+            ])
+            ->withHeaders([
+                'X-Signature-256' => $signature,
+                'User-Agent' => 'FlashView-Webhook/1.0',
+            ])
+            ->withBody($payload, 'application/json')
+            ->post($this->webhookUrl);
+
+        if ($response->failed()) {
+            throw new \RuntimeException(
+                "Webhook delivery failed with status {$response->status()}"
+            );
+        }
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::warning('Webhook delivery permanently failed', [
+            'webhook_url' => Str::mask($this->webhookUrl, '*', 15),
+            'hash_id' => $this->hashId,
+            'event' => $this->event,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Jobs\SendWebhookNotification;
 use App\Models\Scopes\ActiveScope;
 use App\Notifications\SecretRetrievedNotification;
 use App\Traits\HasHashId;
@@ -99,8 +100,19 @@ class Secret extends Model
                      * @var User $user
                      */
                     if (isset($plan['id'])) {
-                        if ($plan['settings']['notification']['notifications'] && $user->notify_secret_retrieved) {
+                        if (($plan['settings']['notification']['email'] ?? false) && $user->notify_secret_retrieved) {
                             $user->notify(new SecretRetrievedNotification($secret));
+                        }
+
+                        $planSupportsWebhook = ($plan['settings']['notification']['webhook'] ?? false);
+                        if ($planSupportsWebhook && $user->hasWebhookConfigured()) {
+                            dispatch(new SendWebhookNotification(
+                                webhookUrl: $user->webhook_url,
+                                webhookSecret: $user->webhook_secret,
+                                hashId: $secret->hash_id,
+                                createdAt: $secret->created_at->toIso8601String(),
+                                retrievedAt: now()->toIso8601String(),
+                            ));
                         }
                     }
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -110,6 +110,20 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return $plan && ($plan->features['api']['type'] ?? 'missing') === 'feature';
     }
 
+    /**
+     * Check if the user's plan supports email notifications.
+     */
+    public function planSupportsEmailNotifications(): bool
+    {
+        if (! $this->subscribed()) {
+            return false;
+        }
+
+        $plan = $this->resolvePlan();
+
+        return $plan && ($plan->features['notification']['config']['email'] ?? false);
+    }
+
     public function getPlanAttribute(): PlanResource
     {
         return new PlanResource($this->resolvePlan());

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -124,6 +124,20 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return $plan && ($plan->features['notification']['config']['email'] ?? false);
     }
 
+    /**
+     * Check if the user's plan supports webhook notifications.
+     */
+    public function planSupportsWebhook(): bool
+    {
+        if (! $this->subscribed()) {
+            return false;
+        }
+
+        $plan = $this->resolvePlan();
+
+        return $plan && ($plan->features['notification']['config']['webhook'] ?? false);
+    }
+
     public function getPlanAttribute(): PlanResource
     {
         return new PlanResource($this->resolvePlan());

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,8 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'email',
         'password',
         'notify_secret_retrieved',
+        'webhook_url',
+        'webhook_secret',
     ];
 
     /**
@@ -53,6 +55,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'remember_token',
         'two_factor_recovery_codes',
         'two_factor_secret',
+        'webhook_secret',
     ];
 
     /**
@@ -135,7 +138,13 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'notify_secret_retrieved' => 'boolean',
+            'webhook_secret' => 'encrypted',
         ];
+    }
+
+    public function hasWebhookConfigured(): bool
+    {
+        return filled($this->webhook_url) && filled($this->webhook_secret);
     }
 
     public function secrets(): HasMany

--- a/app/Observers/SubscriptionObserver.php
+++ b/app/Observers/SubscriptionObserver.php
@@ -13,12 +13,28 @@ class SubscriptionObserver
 
             if (! $user->hasApiAccess()) {
                 $user->tokens()->delete();
+
+                if ($user->hasWebhookConfigured()) {
+                    $user->updateQuietly([
+                        'webhook_url' => null,
+                        'webhook_secret' => null,
+                    ]);
+                }
             }
         }
     }
 
     public function deleted(Subscription $subscription): void
     {
-        $subscription->user->tokens()->delete();
+        $user = $subscription->user;
+
+        $user->tokens()->delete();
+
+        if ($user->hasWebhookConfigured()) {
+            $user->updateQuietly([
+                'webhook_url' => null,
+                'webhook_secret' => null,
+            ]);
+        }
     }
 }

--- a/app/Observers/SubscriptionObserver.php
+++ b/app/Observers/SubscriptionObserver.php
@@ -21,6 +21,12 @@ class SubscriptionObserver
                     ]);
                 }
             }
+
+            if (! $user->planSupportsEmailNotifications() && $user->notify_secret_retrieved) {
+                $user->updateQuietly([
+                    'notify_secret_retrieved' => false,
+                ]);
+            }
         }
     }
 
@@ -34,6 +40,12 @@ class SubscriptionObserver
             $user->updateQuietly([
                 'webhook_url' => null,
                 'webhook_secret' => null,
+            ]);
+        }
+
+        if ($user->notify_secret_retrieved) {
+            $user->updateQuietly([
+                'notify_secret_retrieved' => false,
             ]);
         }
     }

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -40,6 +40,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'secrets:create',
             'secrets:list',
             'secrets:delete',
+            'webhook:manage',
         ]);
     }
 }

--- a/app/Rules/NotPrivateUrl.php
+++ b/app/Rules/NotPrivateUrl.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class NotPrivateUrl implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (blank($value)) {
+            return;
+        }
+
+        $host = parse_url($value, PHP_URL_HOST);
+
+        if (! $host) {
+            $fail('The :attribute must contain a valid host.');
+
+            return;
+        }
+
+        if (in_array(strtolower($host), ['localhost', '127.0.0.1', '::1', '0.0.0.0'])) {
+            $fail('The :attribute must not point to a local address.');
+
+            return;
+        }
+
+        $ips = gethostbynamel($host);
+
+        if ($ips === false) {
+            $fail('The :attribute hostname could not be resolved.');
+
+            return;
+        }
+
+        foreach ($ips as $ip) {
+            if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                $fail('The :attribute must not point to a private or reserved IP address.');
+
+                return;
+            }
+        }
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -61,6 +61,17 @@ class UserFactory extends Factory
     }
 
     /**
+     * Indicate that the user has a webhook configured.
+     */
+    public function withWebhook(string $url = 'https://example.com/webhook', ?string $secret = null): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'webhook_url' => $url,
+            'webhook_secret' => $secret ?? bin2hex(random_bytes(32)),
+        ]);
+    }
+
+    /**
      * Indicate that the user should have a personal team.
      */
     public function withPersonalTeam(?callable $callback = null): static

--- a/database/migrations/2026_03_25_110140_add_webhook_fields_to_users_table.php
+++ b/database/migrations/2026_03_25_110140_add_webhook_fields_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('webhook_url', 2048)->nullable()->after('notify_secret_retrieved');
+            $table->text('webhook_secret')->nullable()->after('webhook_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['webhook_url', 'webhook_secret']);
+        });
+    }
+};

--- a/database/migrations/2026_03_25_110212_rename_notifications_to_email_in_plan_features.php
+++ b/database/migrations/2026_03_25_110212_rename_notifications_to_email_in_plan_features.php
@@ -16,7 +16,13 @@ return new class extends Migration
             if (isset($features['notification']['config']['notifications'])) {
                 $features['notification']['config']['email'] = $features['notification']['config']['notifications'];
                 unset($features['notification']['config']['notifications']);
+            }
 
+            if (isset($features['notification']['config']) && ! isset($features['notification']['config']['webhook'])) {
+                $features['notification']['config']['webhook'] = false;
+            }
+
+            if ($features !== $plan->features) {
                 $plan->update(['features' => $features]);
             }
         });
@@ -33,7 +39,13 @@ return new class extends Migration
             if (isset($features['notification']['config']['email'])) {
                 $features['notification']['config']['notifications'] = $features['notification']['config']['email'];
                 unset($features['notification']['config']['email']);
+            }
 
+            if (isset($features['notification']['config']['webhook'])) {
+                unset($features['notification']['config']['webhook']);
+            }
+
+            if ($features !== $plan->features) {
                 $plan->update(['features' => $features]);
             }
         });

--- a/database/migrations/2026_03_25_110212_rename_notifications_to_email_in_plan_features.php
+++ b/database/migrations/2026_03_25_110212_rename_notifications_to_email_in_plan_features.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\Plan;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (isset($features['notification']['config']['notifications'])) {
+                $features['notification']['config']['email'] = $features['notification']['config']['notifications'];
+                unset($features['notification']['config']['notifications']);
+
+                $plan->update(['features' => $features]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (isset($features['notification']['config']['email'])) {
+                $features['notification']['config']['notifications'] = $features['notification']['config']['email'];
+                unset($features['notification']['config']['email']);
+
+                $plan->update(['features' => $features]);
+            }
+        });
+    }
+};

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -53,7 +53,7 @@ class PlanSeederLocal extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Get notified when a message is retrieved',
                         'config' => [
                             'email' => false,
                             'webhook' => false,

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -53,9 +53,10 @@ class PlanSeederLocal extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email when a message is retrieved',
                         'config' => [
-                            'notifications' => false,
+                            'email' => false,
+                            'webhook' => false,
                         ],
                         'type' => 'missing',
                     ],
@@ -113,9 +114,10 @@ class PlanSeederLocal extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email when a message is retrieved',
                         'config' => [
-                            'notifications' => true,
+                            'email' => true,
+                            'webhook' => false,
                         ],
                         'type' => 'feature',
                     ],
@@ -173,9 +175,10 @@ class PlanSeederLocal extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email or webhook when a message is retrieved',
                         'config' => [
-                            'notifications' => true,
+                            'email' => true,
+                            'webhook' => true,
                         ],
                         'type' => 'feature',
                     ],

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -53,7 +53,7 @@ class PlanSeederProd extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Get notified when a message is retrieved',
                         'config' => [
                             'email' => false,
                             'webhook' => false,

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -53,9 +53,10 @@ class PlanSeederProd extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email when a message is retrieved',
                         'config' => [
-                            'notifications' => false,
+                            'email' => false,
+                            'webhook' => false,
                         ],
                         'type' => 'missing',
                     ],
@@ -113,9 +114,10 @@ class PlanSeederProd extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email when a message is retrieved',
                         'config' => [
-                            'notifications' => true,
+                            'email' => true,
+                            'webhook' => false,
                         ],
                         'type' => 'feature',
                     ],
@@ -173,9 +175,10 @@ class PlanSeederProd extends Seeder
                     ],
                     'notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Get notified via email or webhook when a message is retrieved',
                         'config' => [
-                            'notifications' => true,
+                            'email' => true,
+                            'webhook' => true,
                         ],
                         'type' => 'feature',
                     ],

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { useForm, usePage } from '@inertiajs/vue3';
+import { Link, useForm, usePage } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
 import FormSection from '@/Components/FormSection.vue';
@@ -74,9 +74,9 @@ const updateNotificationPreferences = () => {
         <template #content>
             <p class="text-sm text-gray-600 dark:text-gray-400">
                 Secret retrieval notifications are available on paid plans.
-                <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                <Link :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
                     View plans
-                </a>
+                </Link>
             </p>
         </template>
     </ActionSection>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -11,7 +11,7 @@ const page = usePage();
 const user = computed(() => page.props.auth.user);
 
 const planSupportsNotifications = computed(() =>
-    user.value.plan?.settings?.notification?.notifications ?? false
+    user.value.plan?.settings?.notification?.email ?? false
 );
 
 const form = useForm({

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -13,15 +13,15 @@ import TextInput from '@/Components/TextInput.vue';
 import ConfirmationModal from '@/Components/ConfirmationModal.vue';
 
 const page = usePage();
-const user = computed(() => page.props.auth.user);
 const hasApiAccess = computed(() => page.props.auth?.hasApiAccess ?? false);
+const webhook = computed(() => page.props.auth?.webhook);
 
 const showSecret = ref(false);
 const confirmingSecretRegeneration = ref(false);
 const secretCopied = ref(false);
 
 const form = useForm({
-    webhook_url: user.value.webhook_url ?? '',
+    webhook_url: webhook.value?.webhook_url ?? '',
 });
 
 const updateWebhookSettings = () => {
@@ -31,8 +31,8 @@ const updateWebhookSettings = () => {
 };
 
 const copySecret = () => {
-    if (user.value.webhook_secret) {
-        navigator.clipboard.writeText(user.value.webhook_secret);
+    if (webhook.value?.webhook_secret) {
+        navigator.clipboard.writeText(webhook.value.webhook_secret);
         secretCopied.value = true;
         setTimeout(() => { secretCopied.value = false; }, 2000);
     }
@@ -75,11 +75,11 @@ const regenerateSecret = () => {
                 </p>
             </div>
 
-            <div v-if="user.webhook_secret" class="col-span-6">
+            <div v-if="webhook?.webhook_secret" class="col-span-6">
                 <InputLabel value="Webhook Secret" />
                 <div class="mt-1 flex items-center gap-3">
                     <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                        {{ showSecret ? user.webhook_secret : '••••••••••••••••••••••••••••••••' }}
+                        {{ showSecret ? webhook.webhook_secret : '••••••••••••••••••••••••••••••••' }}
                     </code>
                     <SecondaryButton type="button" @click="showSecret = !showSecret">
                         {{ showSecret ? 'Hide' : 'Show' }}

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -17,7 +17,7 @@ const page = usePage();
 const hasApiAccess = computed(() => page.props.auth?.hasApiAccess ?? false);
 const webhook = computed(() => page.props.auth?.webhook);
 
-const showSecret = ref(false);
+const revealedSecret = ref(null);
 const confirmingSecretRegeneration = ref(false);
 const secretCopied = ref(false);
 
@@ -28,16 +28,28 @@ const form = useForm({
 const updateWebhookSettings = () => {
     form.put(route('user.webhook-settings.update'), {
         preserveScroll: true,
+        onSuccess: () => {
+            revealedSecret.value = null;
+        },
     });
 };
 
 const revealSecret = () => {
-    showSecret.value = true;
+    router.post(route('user.webhook-settings.reveal-secret'), {}, {
+        preserveScroll: true,
+        onSuccess: () => {
+            revealedSecret.value = page.props.jetstream.flash.webhookSecret;
+        },
+    });
+};
+
+const hideSecret = () => {
+    revealedSecret.value = null;
 };
 
 const copySecret = () => {
-    if (webhook.value?.webhook_secret) {
-        navigator.clipboard.writeText(webhook.value.webhook_secret);
+    if (revealedSecret.value) {
+        navigator.clipboard.writeText(revealedSecret.value);
         secretCopied.value = true;
         setTimeout(() => { secretCopied.value = false; }, 2000);
     }
@@ -48,7 +60,7 @@ const regenerateSecret = () => {
         preserveScroll: true,
         onSuccess: () => {
             confirmingSecretRegeneration.value = false;
-            showSecret.value = true;
+            revealedSecret.value = page.props.jetstream.flash.webhookSecret;
         },
     });
 };
@@ -80,25 +92,28 @@ const regenerateSecret = () => {
                 </p>
             </div>
 
-            <div v-if="webhook?.webhook_secret" class="col-span-6">
+            <div v-if="webhook?.webhook_url" class="col-span-6">
                 <InputLabel value="Webhook Secret" />
                 <div class="mt-1 flex items-center gap-3">
                     <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                        {{ showSecret ? webhook.webhook_secret : '••••••••••••••••••••••••••••••••' }}
+                        {{ revealedSecret ?? '••••••••••••••••••••••••••••••••' }}
                     </code>
-                    <ConfirmsPasswordOrPasskey v-if="!showSecret" @confirmed="revealSecret">
+                    <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
                         <SecondaryButton type="button">
                             Show
                         </SecondaryButton>
                     </ConfirmsPasswordOrPasskey>
-                    <SecondaryButton v-else type="button" @click="showSecret = false">
+                    <SecondaryButton v-else type="button" @click="hideSecret">
                         Hide
                     </SecondaryButton>
-                    <ConfirmsPasswordOrPasskey @confirmed="copySecret">
+                    <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
                         <SecondaryButton type="button">
-                            {{ secretCopied ? 'Copied!' : 'Copy' }}
+                            Copy
                         </SecondaryButton>
                     </ConfirmsPasswordOrPasskey>
+                    <SecondaryButton v-else type="button" @click="copySecret">
+                        {{ secretCopied ? 'Copied!' : 'Copy' }}
+                    </SecondaryButton>
                 </div>
                 <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
                     Use this secret to verify webhook signatures via the <code class="text-xs">X-Signature-256</code> header.

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -19,6 +19,7 @@ const webhook = computed(() => page.props.auth?.webhook);
 
 const revealedSecret = ref(null);
 const confirmingSecretRegeneration = ref(false);
+const regenerating = ref(false);
 const secretCopied = ref(false);
 
 const form = useForm({
@@ -56,11 +57,16 @@ const copySecret = () => {
 };
 
 const regenerateSecret = () => {
+    regenerating.value = true;
+
     router.post(route('user.webhook-settings.regenerate-secret'), {}, {
         preserveScroll: true,
         onSuccess: () => {
             confirmingSecretRegeneration.value = false;
             revealedSecret.value = page.props.jetstream.flash.webhookSecret;
+        },
+        onFinish: () => {
+            regenerating.value = false;
         },
     });
 };
@@ -99,7 +105,7 @@ const regenerateSecret = () => {
                         {{ revealedSecret ?? '••••••••••••••••••••••••••••••••' }}
                     </code>
                     <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
-                        <SecondaryButton type="button">
+                        <SecondaryButton type="button" :class="{ 'opacity-25': regenerating }" :disabled="regenerating">
                             Show
                         </SecondaryButton>
                     </ConfirmsPasswordOrPasskey>
@@ -120,7 +126,7 @@ const regenerateSecret = () => {
                 </p>
 
                 <div class="mt-4">
-                    <DangerButton type="button" @click="confirmingSecretRegeneration = true">
+                    <DangerButton type="button" :class="{ 'opacity-25': regenerating }" :disabled="regenerating" @click="confirmingSecretRegeneration = true">
                         Regenerate Secret
                     </DangerButton>
                 </div>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -3,14 +3,15 @@ import { computed, ref } from 'vue';
 import { Link, useForm, usePage, router } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
+import DangerButton from '@/Components/DangerButton.vue';
 import FormSection from '@/Components/FormSection.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
-import DangerButton from '@/Components/DangerButton.vue';
 import TextInput from '@/Components/TextInput.vue';
-import ConfirmationModal from '@/Components/ConfirmationModal.vue';
 
 const page = usePage();
 const hasApiAccess = computed(() => page.props.auth?.hasApiAccess ?? false);
@@ -28,6 +29,10 @@ const updateWebhookSettings = () => {
     form.put(route('user.webhook-settings.update'), {
         preserveScroll: true,
     });
+};
+
+const revealSecret = () => {
+    showSecret.value = true;
 };
 
 const copySecret = () => {
@@ -81,12 +86,19 @@ const regenerateSecret = () => {
                     <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
                         {{ showSecret ? webhook.webhook_secret : '••••••••••••••••••••••••••••••••' }}
                     </code>
-                    <SecondaryButton type="button" @click="showSecret = !showSecret">
-                        {{ showSecret ? 'Hide' : 'Show' }}
+                    <ConfirmsPasswordOrPasskey v-if="!showSecret" @confirmed="revealSecret">
+                        <SecondaryButton type="button">
+                            Show
+                        </SecondaryButton>
+                    </ConfirmsPasswordOrPasskey>
+                    <SecondaryButton v-else type="button" @click="showSecret = false">
+                        Hide
                     </SecondaryButton>
-                    <SecondaryButton type="button" @click="copySecret">
-                        {{ secretCopied ? 'Copied!' : 'Copy' }}
-                    </SecondaryButton>
+                    <ConfirmsPasswordOrPasskey @confirmed="copySecret">
+                        <SecondaryButton type="button">
+                            {{ secretCopied ? 'Copied!' : 'Copy' }}
+                        </SecondaryButton>
+                    </ConfirmsPasswordOrPasskey>
                 </div>
                 <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
                     Use this secret to verify webhook signatures via the <code class="text-xs">X-Signature-256</code> header.
@@ -144,9 +156,11 @@ const regenerateSecret = () => {
                 Cancel
             </SecondaryButton>
 
-            <DangerButton class="ms-3" @click="regenerateSecret">
-                Regenerate Secret
-            </DangerButton>
+            <ConfirmsPasswordOrPasskey @confirmed="regenerateSecret">
+                <DangerButton class="ms-3">
+                    Regenerate Secret
+                </DangerButton>
+            </ConfirmsPasswordOrPasskey>
         </template>
     </ConfirmationModal>
 </template>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue';
-import { useForm, usePage, router } from '@inertiajs/vue3';
+import { Link, useForm, usePage, router } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
 import FormSection from '@/Components/FormSection.vue';
@@ -123,9 +123,9 @@ const regenerateSecret = () => {
         <template #content>
             <p class="text-sm text-gray-600 dark:text-gray-400">
                 Webhook notifications are available on the Prime plan.
-                <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                <Link :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
                     View plans
-                </a>
+                </Link>
             </p>
         </template>
     </ActionSection>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useForm, usePage, router } from '@inertiajs/vue3';
+import ActionMessage from '@/Components/ActionMessage.vue';
+import ActionSection from '@/Components/ActionSection.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+
+const page = usePage();
+const user = computed(() => page.props.auth.user);
+const hasApiAccess = computed(() => page.props.auth?.hasApiAccess ?? false);
+
+const showSecret = ref(false);
+const confirmingSecretRegeneration = ref(false);
+const secretCopied = ref(false);
+
+const form = useForm({
+    webhook_url: user.value.webhook_url ?? '',
+});
+
+const updateWebhookSettings = () => {
+    form.put(route('user.webhook-settings.update'), {
+        preserveScroll: true,
+    });
+};
+
+const copySecret = () => {
+    if (user.value.webhook_secret) {
+        navigator.clipboard.writeText(user.value.webhook_secret);
+        secretCopied.value = true;
+        setTimeout(() => { secretCopied.value = false; }, 2000);
+    }
+};
+
+const regenerateSecret = () => {
+    router.post(route('user.webhook-settings.regenerate-secret'), {}, {
+        preserveScroll: true,
+        onSuccess: () => {
+            confirmingSecretRegeneration.value = false;
+            showSecret.value = true;
+        },
+    });
+};
+</script>
+
+<template>
+    <FormSection v-if="hasApiAccess" @submitted="updateWebhookSettings">
+        <template #title>
+            Webhook Settings
+        </template>
+
+        <template #description>
+            Configure a webhook URL to receive HTTP POST notifications when your secrets are retrieved.
+        </template>
+
+        <template #form>
+            <div class="col-span-6">
+                <InputLabel for="webhook_url" value="Webhook URL" />
+                <TextInput
+                    id="webhook_url"
+                    v-model="form.webhook_url"
+                    type="url"
+                    class="mt-1 block w-full"
+                    placeholder="https://example.com/webhook"
+                />
+                <InputError :message="form.errors.webhook_url" class="mt-2" />
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
+                    We will send a signed HTTP POST to this URL when your secrets are retrieved. Must be HTTPS.
+                </p>
+            </div>
+
+            <div v-if="user.webhook_secret" class="col-span-6">
+                <InputLabel value="Webhook Secret" />
+                <div class="mt-1 flex items-center gap-3">
+                    <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+                        {{ showSecret ? user.webhook_secret : '••••••••••••••••••••••••••••••••' }}
+                    </code>
+                    <SecondaryButton type="button" @click="showSecret = !showSecret">
+                        {{ showSecret ? 'Hide' : 'Show' }}
+                    </SecondaryButton>
+                    <SecondaryButton type="button" @click="copySecret">
+                        {{ secretCopied ? 'Copied!' : 'Copy' }}
+                    </SecondaryButton>
+                </div>
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
+                    Use this secret to verify webhook signatures via the <code class="text-xs">X-Signature-256</code> header.
+                </p>
+
+                <div class="mt-4">
+                    <DangerButton type="button" @click="confirmingSecretRegeneration = true">
+                        Regenerate Secret
+                    </DangerButton>
+                </div>
+            </div>
+        </template>
+
+        <template #actions>
+            <ActionMessage :on="form.recentlySuccessful" class="me-3">
+                Saved.
+            </ActionMessage>
+
+            <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                Save
+            </PrimaryButton>
+        </template>
+    </FormSection>
+
+    <ActionSection v-else>
+        <template #title>
+            Webhook Settings
+        </template>
+
+        <template #description>
+            Configure webhook notifications for secret retrieval events.
+        </template>
+
+        <template #content>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+                Webhook notifications are available on the Prime plan.
+                <a :href="route('plans.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                    View plans
+                </a>
+            </p>
+        </template>
+    </ActionSection>
+
+    <ConfirmationModal :show="confirmingSecretRegeneration" @close="confirmingSecretRegeneration = false">
+        <template #title>
+            Regenerate Webhook Secret
+        </template>
+
+        <template #content>
+            Are you sure you want to regenerate your webhook secret? Your existing integration will stop verifying correctly until you update the new secret on your receiving server.
+        </template>
+
+        <template #footer>
+            <SecondaryButton @click="confirmingSecretRegeneration = false">
+                Cancel
+            </SecondaryButton>
+
+            <DangerButton class="ms-3" @click="regenerateSecret">
+                Regenerate Secret
+            </DangerButton>
+        </template>
+    </ConfirmationModal>
+</template>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -19,6 +19,7 @@ const webhook = computed(() => page.props.auth?.webhook);
 
 const revealedSecret = ref(null);
 const confirmingSecretRegeneration = ref(false);
+const revealing = ref(false);
 const regenerating = ref(false);
 const secretCopied = ref(false);
 
@@ -36,10 +37,15 @@ const updateWebhookSettings = () => {
 };
 
 const revealSecret = () => {
+    revealing.value = true;
+
     router.post(route('user.webhook-settings.reveal-secret'), {}, {
         preserveScroll: true,
         onSuccess: () => {
             revealedSecret.value = page.props.jetstream.flash.webhookSecret;
+        },
+        onFinish: () => {
+            revealing.value = false;
         },
     });
 };
@@ -105,7 +111,7 @@ const regenerateSecret = () => {
                         {{ revealedSecret ?? '••••••••••••••••••••••••••••••••' }}
                     </code>
                     <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
-                        <SecondaryButton type="button" :class="{ 'opacity-25': regenerating }" :disabled="regenerating">
+                        <SecondaryButton type="button" :class="{ 'opacity-25': revealing }" :disabled="revealing">
                             Show
                         </SecondaryButton>
                     </ConfirmsPasswordOrPasskey>

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -7,6 +7,7 @@ import TwoFactorAuthenticationForm from '@/Pages/Profile/Partials/TwoFactorAuthe
 import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue';
 import NotificationPreferencesForm from './Partials/NotificationPreferencesForm.vue';
+import WebhookSettingsForm from './Partials/WebhookSettingsForm.vue';
 import PassKeyForm from './Partials/PassKeyForm.vue';
 import Page from '../Page.vue';
 
@@ -52,6 +53,10 @@ defineProps({
                 <SectionBorder />
 
                 <NotificationPreferencesForm class="mt-10 sm:mt-0" />
+
+                <SectionBorder />
+
+                <WebhookSettingsForm class="mt-10 sm:mt-0" />
 
                 <SectionBorder />
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\ConfigController;
 use App\Http\Controllers\Api\SecretController;
+use App\Http\Controllers\Api\WebhookController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -11,7 +12,7 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 
 Route::prefix('v1')->as('api.v1.')->group(function () {
-    
+
     Route::middleware(['auth:sanctum', EnsurePlanHasApiAccess::class])->group(function () {
         Route::get('config', ConfigController::class)
             ->name('config');
@@ -21,5 +22,12 @@ Route::prefix('v1')->as('api.v1.')->group(function () {
 
         Route::get('secrets/{secret}/retrieve', [SecretController::class, 'retrieve'])
             ->name('secrets.retrieve');
+
+        Route::middleware('ability:webhook:manage')->group(function () {
+            Route::get('webhook', [WebhookController::class, 'show'])->name('webhook.show');
+            Route::put('webhook', [WebhookController::class, 'update'])->name('webhook.update');
+            Route::post('webhook/regenerate-secret', [WebhookController::class, 'regenerateSecret'])->name('webhook.regenerate-secret');
+            Route::delete('webhook', [WebhookController::class, 'destroy'])->name('webhook.destroy');
+        });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,11 @@ Route::middleware([
 
         Route::put('/user/webhook-settings', [WebhookSettingsController::class, 'update'])
             ->name('user.webhook-settings.update');
+        Route::post('/user/webhook-settings/reveal-secret', [WebhookSettingsController::class, 'revealSecret'])
+            ->middleware('password.confirm')
+            ->name('user.webhook-settings.reveal-secret');
         Route::post('/user/webhook-settings/regenerate-secret', [WebhookSettingsController::class, 'regenerateSecret'])
+            ->middleware('password.confirm')
             ->name('user.webhook-settings.regenerate-secret');
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\MarkdownDocumentController;
 use App\Http\Controllers\NotificationPreferencesController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
+use App\Http\Controllers\WebhookSettingsController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
@@ -88,6 +89,11 @@ Route::middleware([
         Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
         Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
         Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+
+        Route::put('/user/webhook-settings', [WebhookSettingsController::class, 'update'])
+            ->name('user.webhook-settings.update');
+        Route::post('/user/webhook-settings/regenerate-secret', [WebhookSettingsController::class, 'regenerateSecret'])
+            ->name('user.webhook-settings.regenerate-secret');
     });
 
     Route::get('/billing', function (Request $request) {

--- a/tests/Feature/Api/SecretApiTest.php
+++ b/tests/Feature/Api/SecretApiTest.php
@@ -44,7 +44,7 @@ class SecretApiTest extends TestCase
                 'notification' => [
                     'order' => 4.5,
                     'label' => 'Get notified when a message is retrieved',
-                    'config' => ['notifications' => true],
+                    'config' => ['email' => true],
                     'type' => 'feature',
                 ],
                 'api' => [

--- a/tests/Feature/Api/SecretMetadataApiTest.php
+++ b/tests/Feature/Api/SecretMetadataApiTest.php
@@ -44,7 +44,7 @@ class SecretMetadataApiTest extends TestCase
                 'notification' => [
                     'order' => 4.5,
                     'label' => 'Get notified when a message is retrieved',
-                    'config' => ['notifications' => true],
+                    'config' => ['email' => true],
                     'type' => 'feature',
                 ],
                 'api' => [

--- a/tests/Feature/Api/SecretRetrievalTest.php
+++ b/tests/Feature/Api/SecretRetrievalTest.php
@@ -48,7 +48,7 @@ class SecretRetrievalTest extends TestCase
                 'notification' => [
                     'order' => 4.5,
                     'label' => 'Get notified when a message is retrieved',
-                    'config' => ['notifications' => true],
+                    'config' => ['email' => true],
                     'type' => 'feature',
                 ],
                 'api' => [

--- a/tests/Feature/Api/WebhookApiTest.php
+++ b/tests/Feature/Api/WebhookApiTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class WebhookApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Plan $primePlan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->primePlan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => true, 'webhook' => true],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $this->user = User::factory()->withPersonalTeam()->create();
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+    }
+
+    public function test_can_get_webhook_config(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->getJson('/api/v1/webhook');
+
+        $response->assertOk()
+            ->assertJsonStructure(['webhook_url', 'webhook_secret', 'configured']);
+    }
+
+    public function test_can_update_webhook_url(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->putJson('/api/v1/webhook', [
+            'webhook_url' => 'https://example.com/webhook',
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'webhook_url' => 'https://example.com/webhook',
+                'configured' => true,
+                'message' => 'Webhook settings updated.',
+            ]);
+
+        $this->user->refresh();
+        $this->assertEquals('https://example.com/webhook', $this->user->webhook_url);
+        $this->assertNotNull($this->user->webhook_secret);
+    }
+
+    public function test_can_regenerate_webhook_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $oldSecret = $this->user->webhook_secret;
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->postJson('/api/v1/webhook/regenerate-secret');
+
+        $response->assertOk()
+            ->assertJsonStructure(['webhook_secret', 'message']);
+
+        $this->user->refresh();
+        $this->assertNotEquals($oldSecret, $this->user->webhook_secret);
+    }
+
+    public function test_regenerate_returns_full_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->postJson('/api/v1/webhook/regenerate-secret');
+
+        $newSecret = $response->json('webhook_secret');
+        $this->assertEquals(64, strlen($newSecret));
+        $this->assertStringNotContainsString('*', $newSecret);
+    }
+
+    public function test_cannot_regenerate_without_webhook_configured(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->postJson('/api/v1/webhook/regenerate-secret');
+
+        $response->assertStatus(422);
+    }
+
+    public function test_can_delete_webhook(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->deleteJson('/api/v1/webhook');
+
+        $response->assertOk()
+            ->assertJson(['message' => 'Webhook configuration removed.']);
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_rejects_token_without_webhook_manage_ability(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['secrets:create']);
+
+        $response = $this->getJson('/api/v1/webhook');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_rejects_user_without_api_plan(): void
+    {
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free',
+            'stripe_monthly_price_id' => 'price_monthly_free',
+            'stripe_yearly_price_id' => 'price_yearly_free',
+            'stripe_product_id' => 'prod_free',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $this->subscribeUserToPlan($this->user, $freePlan);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->getJson('/api/v1/webhook');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_validation_rejects_non_https_url_via_api(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->putJson('/api/v1/webhook', [
+            'webhook_url' => 'http://example.com/webhook',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('webhook_url');
+    }
+
+    public function test_show_returns_masked_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        ]);
+        Sanctum::actingAs($this->user, ['webhook:manage']);
+
+        $response = $this->getJson('/api/v1/webhook');
+
+        $maskedSecret = $response->json('webhook_secret');
+        $this->assertStringContainsString('*', $maskedSecret);
+        $this->assertStringEndsWith('34567890', $maskedSecret);
+    }
+}

--- a/tests/Feature/GuestInertiaPropsTest.php
+++ b/tests/Feature/GuestInertiaPropsTest.php
@@ -2,17 +2,36 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
 class GuestInertiaPropsTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_guest_does_not_have_auth_user_in_inertia_props(): void
     {
         $response = $this->get('/');
 
         $response->assertInertia(fn (AssertableInertia $page) => $page
             ->where('auth.user', null)
+        );
+    }
+
+    public function test_authenticated_user_has_full_user_data_in_inertia_props(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/dashboard');
+
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('auth.user.id')
+            ->has('auth.user.name')
+            ->has('auth.user.email')
+            ->where('auth.user.id', $user->id)
         );
     }
 }

--- a/tests/Feature/GuestInertiaPropsTest.php
+++ b/tests/Feature/GuestInertiaPropsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class GuestInertiaPropsTest extends TestCase
+{
+    public function test_guest_does_not_have_auth_user_in_inertia_props(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('auth.user', null)
+        );
+    }
+}

--- a/tests/Feature/NotificationPreferencesTest.php
+++ b/tests/Feature/NotificationPreferencesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -58,5 +59,99 @@ class NotificationPreferencesTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors('notify_secret_retrieved');
+    }
+
+    public function test_notification_preference_cleared_when_plan_downgraded(): void
+    {
+        $basicPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic',
+            'stripe_yearly_price_id' => 'price_yearly_basic',
+            'stripe_product_id' => 'prod_basic',
+            'price_per_month' => 25,
+            'price_per_year' => 250,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => true, 'webhook' => false],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => $basicPlan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $this->assertTrue($user->fresh()->notify_secret_retrieved);
+
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free',
+            'stripe_monthly_price_id' => 'price_monthly_free',
+            'stripe_yearly_price_id' => 'price_yearly_free',
+            'stripe_product_id' => 'prod_free',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => false, 'webhook' => false],
+                    'type' => 'missing',
+                ],
+            ],
+        ]);
+
+        $subscription = $user->subscriptions()->first();
+        $subscription->update([
+            'stripe_price' => $freePlan->stripe_monthly_price_id,
+        ]);
+
+        $this->assertFalse($user->fresh()->notify_secret_retrieved);
+    }
+
+    public function test_notification_preference_cleared_when_subscription_cancelled(): void
+    {
+        $basicPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic_cancel',
+            'stripe_yearly_price_id' => 'price_yearly_basic_cancel',
+            'stripe_product_id' => 'prod_basic_cancel',
+            'price_per_month' => 25,
+            'price_per_year' => 250,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => true, 'webhook' => false],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_cancel_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => $basicPlan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $this->assertTrue($user->fresh()->notify_secret_retrieved);
+
+        $subscription = $user->subscriptions()->first();
+        $subscription->update([
+            'stripe_status' => 'canceled',
+            'ends_at' => now(),
+        ]);
+
+        $this->assertFalse($user->fresh()->notify_secret_retrieved);
     }
 }

--- a/tests/Feature/NotificationPreferencesTest.php
+++ b/tests/Feature/NotificationPreferencesTest.php
@@ -11,59 +11,13 @@ class NotificationPreferencesTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_guest_cannot_update_notification_preferences(): void
+    private Plan $basicPlan;
+
+    protected function setUp(): void
     {
-        $response = $this->put('/user/notification-preferences', [
-            'notify_secret_retrieved' => true,
-        ]);
+        parent::setUp();
 
-        $response->assertRedirect('/login');
-    }
-
-    public function test_user_can_enable_secret_retrieved_notification(): void
-    {
-        $user = User::factory()->create();
-
-        $this->actingAs($user);
-
-        $response = $this->put('/user/notification-preferences', [
-            'notify_secret_retrieved' => true,
-        ]);
-
-        $response->assertSessionHasNoErrors();
-        $this->assertTrue($user->fresh()->notify_secret_retrieved);
-    }
-
-    public function test_user_can_disable_secret_retrieved_notification(): void
-    {
-        $user = User::factory()->withSecretRetrievedNotifications()->create();
-
-        $this->actingAs($user);
-
-        $response = $this->put('/user/notification-preferences', [
-            'notify_secret_retrieved' => false,
-        ]);
-
-        $response->assertSessionHasNoErrors();
-        $this->assertFalse($user->fresh()->notify_secret_retrieved);
-    }
-
-    public function test_validation_requires_boolean(): void
-    {
-        $user = User::factory()->create();
-
-        $this->actingAs($user);
-
-        $response = $this->put('/user/notification-preferences', [
-            'notify_secret_retrieved' => 'not-a-boolean',
-        ]);
-
-        $response->assertSessionHasErrors('notify_secret_retrieved');
-    }
-
-    public function test_notification_preference_cleared_when_plan_downgraded(): void
-    {
-        $basicPlan = Plan::factory()->create([
+        $this->basicPlan = Plan::factory()->create([
             'name' => 'Basic',
             'stripe_monthly_price_id' => 'price_monthly_basic',
             'stripe_yearly_price_id' => 'price_yearly_basic',
@@ -79,23 +33,111 @@ class NotificationPreferencesTest extends TestCase
                 ],
             ],
         ]);
+    }
 
-        $user = User::factory()->withSecretRetrievedNotifications()->create();
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
         $user->subscriptions()->create([
             'type' => 'default',
-            'stripe_id' => 'sub_test_'.$user->id,
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
             'stripe_status' => 'active',
-            'stripe_price' => $basicPlan->stripe_monthly_price_id,
+            'stripe_price' => $plan->stripe_monthly_price_id,
             'quantity' => 1,
         ]);
+    }
 
+    public function test_guest_cannot_update_notification_preferences(): void
+    {
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => true,
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_user_can_enable_secret_retrieved_notification(): void
+    {
+        $user = User::factory()->create();
+        $this->subscribeUserToPlan($user, $this->basicPlan);
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => true,
+        ]);
+
+        $response->assertSessionHasNoErrors();
         $this->assertTrue($user->fresh()->notify_secret_retrieved);
+    }
 
+    public function test_user_can_disable_secret_retrieved_notification(): void
+    {
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $this->subscribeUserToPlan($user, $this->basicPlan);
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => false,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertFalse($user->fresh()->notify_secret_retrieved);
+    }
+
+    public function test_validation_requires_boolean(): void
+    {
+        $user = User::factory()->create();
+        $this->subscribeUserToPlan($user, $this->basicPlan);
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => 'not-a-boolean',
+        ]);
+
+        $response->assertSessionHasErrors('notify_secret_retrieved');
+    }
+
+    public function test_user_without_email_plan_cannot_update_notification_preferences(): void
+    {
         $freePlan = Plan::factory()->create([
             'name' => 'Free',
             'stripe_monthly_price_id' => 'price_monthly_free',
             'stripe_yearly_price_id' => 'price_yearly_free',
             'stripe_product_id' => 'prod_free',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => false, 'webhook' => false],
+                    'type' => 'missing',
+                ],
+            ],
+        ]);
+
+        $user = User::factory()->create();
+        $this->subscribeUserToPlan($user, $freePlan);
+        $this->actingAs($user);
+
+        $response = $this->put('/user/notification-preferences', [
+            'notify_secret_retrieved' => true,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_notification_preference_cleared_when_plan_downgraded(): void
+    {
+        $user = User::factory()->withSecretRetrievedNotifications()->create();
+        $this->subscribeUserToPlan($user, $this->basicPlan);
+
+        $this->assertTrue($user->fresh()->notify_secret_retrieved);
+
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free Downgrade',
+            'stripe_monthly_price_id' => 'price_monthly_free_downgrade',
+            'stripe_yearly_price_id' => 'price_yearly_free_downgrade',
+            'stripe_product_id' => 'prod_free_downgrade',
             'price_per_month' => 0,
             'price_per_year' => 0,
             'features' => [
@@ -118,31 +160,8 @@ class NotificationPreferencesTest extends TestCase
 
     public function test_notification_preference_cleared_when_subscription_cancelled(): void
     {
-        $basicPlan = Plan::factory()->create([
-            'name' => 'Basic',
-            'stripe_monthly_price_id' => 'price_monthly_basic_cancel',
-            'stripe_yearly_price_id' => 'price_yearly_basic_cancel',
-            'stripe_product_id' => 'prod_basic_cancel',
-            'price_per_month' => 25,
-            'price_per_year' => 250,
-            'features' => [
-                'notification' => [
-                    'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => false],
-                    'type' => 'feature',
-                ],
-            ],
-        ]);
-
         $user = User::factory()->withSecretRetrievedNotifications()->create();
-        $user->subscriptions()->create([
-            'type' => 'default',
-            'stripe_id' => 'sub_test_cancel_'.$user->id,
-            'stripe_status' => 'active',
-            'stripe_price' => $basicPlan->stripe_monthly_price_id,
-            'quantity' => 1,
-        ]);
+        $this->subscribeUserToPlan($user, $this->basicPlan);
 
         $this->assertTrue($user->fresh()->notify_secret_retrieved);
 

--- a/tests/Feature/SecretRetrievedNotificationTest.php
+++ b/tests/Feature/SecretRetrievedNotificationTest.php
@@ -106,7 +106,7 @@ class SecretRetrievedNotificationTest extends TestCase
                 'notification' => [
                     'order' => 4.5,
                     'label' => 'Get notified when a message is retrieved',
-                    'config' => ['notifications' => $enabled],
+                    'config' => ['email' => $enabled],
                     'type' => $enabled ? 'feature' : 'missing',
                 ],
             ],

--- a/tests/Feature/WebhookNotificationTest.php
+++ b/tests/Feature/WebhookNotificationTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SendWebhookNotification;
+use App\Models\Plan;
+use App\Models\Secret;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class WebhookNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $reflection = new \ReflectionProperty($this->app, 'isRunningInConsole');
+        $reflection->setValue($this->app, false);
+    }
+
+    public function test_webhook_dispatched_when_plan_supports_webhook_and_user_has_webhook(): void
+    {
+        Bus::fake();
+
+        $plan = $this->createPlanWithWebhook(true);
+        $user = User::factory()->withWebhook()->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret) {
+            return $job->hashId === $secret->hash_id
+                && $job->event === 'retrieved';
+        });
+    }
+
+    public function test_webhook_not_dispatched_when_plan_does_not_support_webhook(): void
+    {
+        Bus::fake();
+
+        $plan = $this->createPlanWithWebhook(false);
+        $user = User::factory()->withWebhook()->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertNotDispatched(SendWebhookNotification::class);
+    }
+
+    public function test_webhook_not_dispatched_when_user_has_no_webhook_configured(): void
+    {
+        Bus::fake();
+
+        $plan = $this->createPlanWithWebhook(true);
+        $user = User::factory()->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertNotDispatched(SendWebhookNotification::class);
+    }
+
+    public function test_webhook_not_dispatched_for_guest_secrets(): void
+    {
+        Bus::fake();
+
+        $secret = $this->createActiveSecret();
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertNotDispatched(SendWebhookNotification::class);
+    }
+
+    public function test_webhook_not_dispatched_for_user_without_plan(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->withWebhook()->create();
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertNotDispatched(SendWebhookNotification::class);
+    }
+
+    public function test_webhook_payload_contains_correct_fields(): void
+    {
+        Bus::fake();
+
+        $plan = $this->createPlanWithWebhook(true);
+        $user = User::factory()->withWebhook('https://example.com/hook', 'test-secret-123')->create();
+        $this->createSubscriptionForUser($user, $plan);
+
+        $secret = $this->createActiveSecret($user);
+        $url = URL::signedRoute('secret.decrypt', ['secret' => $secret->hash_id]);
+
+        $this->get($url);
+
+        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret) {
+            return $job->webhookUrl === 'https://example.com/hook'
+                && $job->webhookSecret === 'test-secret-123'
+                && $job->hashId === $secret->hash_id
+                && $job->event === 'retrieved'
+                && ! empty($job->createdAt)
+                && ! empty($job->retrievedAt);
+        });
+    }
+
+    private function createPlanWithWebhook(bool $webhookEnabled): Plan
+    {
+        return Plan::factory()->create([
+            'name' => $webhookEnabled ? 'Prime' : 'Basic',
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => [
+                        'email' => true,
+                        'webhook' => $webhookEnabled,
+                    ],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
+            'stripe_product_id' => 'prod_test',
+            'stripe_monthly_price_id' => 'price_monthly_test_'.($webhookEnabled ? 'prime' : 'basic'),
+            'stripe_yearly_price_id' => 'price_yearly_test',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+        ]);
+    }
+
+    private function createActiveSecret(?User $user = null): Secret
+    {
+        return Secret::withoutGlobalScopes()->create([
+            'message' => 'test-secret-message',
+            'user_id' => $user?->id,
+            'expires_at' => now()->addHour(),
+        ]);
+    }
+
+    private function createSubscriptionForUser(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+        ]);
+    }
+}

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -173,7 +173,8 @@ class WebhookSettingsTest extends TestCase
         ]);
         $this->actingAs($this->user);
 
-        $response = $this->post('/user/webhook-settings/regenerate-secret');
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/regenerate-secret');
 
         $response->assertRedirect();
 
@@ -182,12 +183,75 @@ class WebhookSettingsTest extends TestCase
         $this->assertEquals(64, strlen($this->user->webhook_secret));
     }
 
+    public function test_regenerate_secret_returns_secret_via_flash(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/regenerate-secret');
+
+        $response->assertSessionHas('flash.webhookSecret');
+    }
+
+    public function test_reveal_secret_returns_secret_via_flash(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $secret = bin2hex(random_bytes(32));
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => $secret,
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/reveal-secret');
+
+        $response->assertSessionHas('flash.webhookSecret', $secret);
+    }
+
+    public function test_reveal_secret_requires_password_confirmation(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->post('/user/webhook-settings/reveal-secret');
+
+        $response->assertRedirect();
+        $response->assertSessionMissing('flash.webhookSecret');
+    }
+
+    public function test_regenerate_secret_requires_password_confirmation(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $oldSecret = bin2hex(random_bytes(32));
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => $oldSecret,
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->post('/user/webhook-settings/regenerate-secret');
+
+        $response->assertRedirect();
+        $this->assertEquals($oldSecret, $this->user->fresh()->webhook_secret);
+    }
+
     public function test_cannot_regenerate_secret_without_webhook_configured(): void
     {
         $this->subscribeUserToPlan($this->user, $this->primePlan);
         $this->actingAs($this->user);
 
-        $response = $this->post('/user/webhook-settings/regenerate-secret');
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/regenerate-secret');
 
         $response->assertStatus(422);
     }

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Plan $primePlan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->primePlan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => [
+                'notification' => [
+                    'order' => 4.5,
+                    'label' => 'Notifications',
+                    'config' => ['email' => true, 'webhook' => true],
+                    'type' => 'feature',
+                ],
+                'api' => [
+                    'order' => 6,
+                    'label' => 'API Access',
+                    'config' => [],
+                    'type' => 'feature',
+                ],
+            ],
+        ]);
+
+        $this->user = User::factory()->withPersonalTeam()->create();
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+    }
+
+    public function test_guest_cannot_update_webhook_settings(): void
+    {
+        $response = $this->put('/user/webhook-settings', [
+            'webhook_url' => 'https://example.com/webhook',
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_user_without_api_plan_cannot_update_webhook_settings(): void
+    {
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free',
+            'stripe_monthly_price_id' => 'price_monthly_free',
+            'stripe_yearly_price_id' => 'price_yearly_free',
+            'stripe_product_id' => 'prod_free',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $this->subscribeUserToPlan($this->user, $freePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->put('/user/webhook-settings', [
+            'webhook_url' => 'https://example.com/webhook',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_can_save_webhook_url(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->put('/user/webhook-settings', [
+            'webhook_url' => 'https://example.com/webhook',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        $this->user->refresh();
+        $this->assertEquals('https://example.com/webhook', $this->user->webhook_url);
+        $this->assertNotNull($this->user->webhook_secret);
+    }
+
+    public function test_webhook_secret_auto_generated_on_first_url_save(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $this->assertNull($this->user->webhook_secret);
+
+        $this->put('/user/webhook-settings', [
+            'webhook_url' => 'https://example.com/webhook',
+        ]);
+
+        $this->user->refresh();
+        $this->assertNotNull($this->user->webhook_secret);
+        $this->assertEquals(64, strlen($this->user->webhook_secret));
+    }
+
+    public function test_clearing_webhook_url_clears_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $this->put('/user/webhook-settings', [
+            'webhook_url' => '',
+        ]);
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_validation_rejects_non_https_url(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->put('/user/webhook-settings', [
+            'webhook_url' => 'http://example.com/webhook',
+        ]);
+
+        $response->assertSessionHasErrors('webhook_url');
+    }
+
+    public function test_validation_rejects_invalid_url(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->put('/user/webhook-settings', [
+            'webhook_url' => 'not-a-url',
+        ]);
+
+        $response->assertSessionHasErrors('webhook_url');
+    }
+
+    public function test_user_can_regenerate_webhook_secret(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $oldSecret = bin2hex(random_bytes(32));
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => $oldSecret,
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->post('/user/webhook-settings/regenerate-secret');
+
+        $response->assertRedirect();
+
+        $this->user->refresh();
+        $this->assertNotEquals($oldSecret, $this->user->webhook_secret);
+        $this->assertEquals(64, strlen($this->user->webhook_secret));
+    }
+
+    public function test_cannot_regenerate_secret_without_webhook_configured(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->post('/user/webhook-settings/regenerate-secret');
+
+        $response->assertStatus(422);
+    }
+}

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -191,4 +191,53 @@ class WebhookSettingsTest extends TestCase
 
         $response->assertStatus(422);
     }
+
+    public function test_webhook_cleared_when_subscription_cancelled(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+
+        $subscription = $this->user->subscriptions()->first();
+        $subscription->update([
+            'stripe_status' => 'canceled',
+            'ends_at' => now(),
+        ]);
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_webhook_cleared_when_plan_downgraded_to_non_api(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+
+        $basicPlan = Plan::factory()->create([
+            'name' => 'Basic',
+            'stripe_monthly_price_id' => 'price_monthly_basic_downgrade',
+            'stripe_yearly_price_id' => 'price_yearly_basic_downgrade',
+            'stripe_product_id' => 'prod_basic_downgrade',
+            'price_per_month' => 25,
+            'price_per_year' => 250,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $subscription = $this->user->subscriptions()->first();
+        $subscription->update([
+            'stripe_price' => $basicPlan->stripe_monthly_price_id,
+        ]);
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
 }

--- a/tests/Unit/Rules/NotPrivateUrlTest.php
+++ b/tests/Unit/Rules/NotPrivateUrlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\NotPrivateUrl;
+use Tests\TestCase;
+
+class NotPrivateUrlTest extends TestCase
+{
+    private NotPrivateUrl $rule;
+
+    private bool $failed;
+
+    private string $failMessage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule = new NotPrivateUrl;
+        $this->failed = false;
+        $this->failMessage = '';
+    }
+
+    private function validate(string $value): void
+    {
+        $this->failed = false;
+        $this->failMessage = '';
+
+        $this->rule->validate('webhook_url', $value, function ($message) {
+            $this->failed = true;
+            $this->failMessage = $message;
+        });
+    }
+
+    public function test_rejects_localhost(): void
+    {
+        $this->validate('https://localhost/webhook');
+
+        $this->assertTrue($this->failed);
+    }
+
+    public function test_rejects_127_0_0_1(): void
+    {
+        $this->validate('https://127.0.0.1/webhook');
+
+        $this->assertTrue($this->failed);
+    }
+
+    public function test_rejects_ipv6_loopback(): void
+    {
+        $this->validate('https://::1/webhook');
+
+        $this->assertTrue($this->failed);
+    }
+
+    public function test_rejects_0_0_0_0(): void
+    {
+        $this->validate('https://0.0.0.0/webhook');
+
+        $this->assertTrue($this->failed);
+    }
+
+    public function test_rejects_url_without_host(): void
+    {
+        $this->validate('not-a-url');
+
+        $this->assertTrue($this->failed);
+    }
+
+    public function test_allows_blank_value(): void
+    {
+        $this->validate('');
+
+        $this->assertFalse($this->failed);
+    }
+
+    public function test_allows_public_url(): void
+    {
+        $this->validate('https://example.com/webhook');
+
+        $this->assertFalse($this->failed);
+    }
+}

--- a/tests/Unit/SendWebhookNotificationTest.php
+++ b/tests/Unit/SendWebhookNotificationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\SendWebhookNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SendWebhookNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $webhookUrl = 'https://example.com/webhook';
+
+    private string $webhookSecret = 'test-webhook-secret-key-for-hmac';
+
+    public function test_sends_correct_json_payload(): void
+    {
+        Http::fake(['*' => Http::response('', 200)]);
+
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $job->handle();
+
+        Http::assertSent(function ($request) {
+            $body = json_decode($request->body(), true);
+
+            return $request->url() === $this->webhookUrl
+                && $body['event'] === 'retrieved'
+                && $body['hash_id'] === 'abc123'
+                && $body['created_at'] === '2026-03-25T10:00:00+00:00'
+                && $body['retrieved_at'] === '2026-03-25T12:00:00+00:00';
+        });
+    }
+
+    public function test_sends_valid_hmac_signature(): void
+    {
+        Http::fake(['*' => Http::response('', 200)]);
+
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $job->handle();
+
+        Http::assertSent(function ($request) {
+            $payload = $request->body();
+            $expectedSignature = 'sha256='.hash_hmac('sha256', $payload, $this->webhookSecret);
+
+            return $request->hasHeader('X-Signature-256', $expectedSignature);
+        });
+    }
+
+    public function test_sends_correct_user_agent(): void
+    {
+        Http::fake(['*' => Http::response('', 200)]);
+
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $job->handle();
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('User-Agent', 'FlashView-Webhook/1.0');
+        });
+    }
+
+    public function test_throws_on_failed_response(): void
+    {
+        Http::fake(['*' => Http::response('', 500)]);
+
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Webhook delivery failed with status 500');
+
+        $job->handle();
+    }
+
+    public function test_backoff_returns_exponential_delays(): void
+    {
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $backoff = $job->backoff();
+
+        $this->assertCount(10, $backoff);
+        $this->assertEquals(30, $backoff[0]);
+        $this->assertEquals(28800, $backoff[9]);
+    }
+
+    public function test_retry_until_returns_future_datetime(): void
+    {
+        $job = new SendWebhookNotification(
+            webhookUrl: $this->webhookUrl,
+            webhookSecret: $this->webhookSecret,
+            hashId: 'abc123',
+            createdAt: '2026-03-25T10:00:00+00:00',
+            retrievedAt: '2026-03-25T12:00:00+00:00',
+        );
+
+        $retryUntil = $job->retryUntil();
+
+        $this->assertGreaterThan(now(), $retryUntil);
+        $this->assertLessThanOrEqual(now()->addHours(24)->addMinute(), $retryUntil);
+    }
+}


### PR DESCRIPTION
## Summary

- Add webhook-based notifications as an alternative delivery channel for secret retrieval events (PIO-24)
- API customers on the Prime plan can configure a webhook URL to receive HMAC-signed HTTP POST callbacks when their secrets are retrieved
- Webhook URL configurable via both the Profile page UI and REST API endpoints
- Exponential backoff retry (30s to 8h) over a 24-hour window for failed deliveries
- SSRF protection via NotPrivateUrl validation rule (rejects private/reserved IPs, localhost)
- Plan differentiation: Free (no notifications), Basic (email only), Prime (email + webhook)
- Webhook and email notification settings automatically cleared when user loses access via plan downgrade or cancellation
- Rename plan feature config key `notification.config.notifications` to `notification.config.email` for clarity, with data migration for existing records

## Test plan

- [x] Verify Free/Basic users see upgrade prompt (not webhook form) on Profile page
- [x] Verify Prime user can configure webhook URL and secret is auto-generated
- [x] Verify webhook fires on secret retrieval (use webhook.site to confirm payload/signature)
- [x] Verify HTTPS-only and SSRF validation rejects invalid URLs
- [x] Verify API CRUD endpoints work with `webhook:manage` Sanctum ability
- [x] Verify tokens without `webhook:manage` get 403
- [x] Verify webhook settings cleared on plan downgrade/cancellation
- [x] Verify email notification preference cleared on plan downgrade/cancellation
- [x] Verify regenerate secret shows confirmation modal with warning
- [x] Verify webhook secret only visible on Profile page (not leaked to other pages)
- [x] Verify plan labels updated on /plans page
- [x] Run full test suite (160 tests, 0 failures)

## Deployment notes

- Run migrations atomically with code deployment (data migration renames JSON key in plans table)
- Consider re-seeding plans in production to add `webhook` config key to existing records