### PR TITLE
Move notification settings to dedicated page and add delete/test webhook (PIO-36)

### DIFF
--- a/app/Http/Controllers/MarkdownDocumentController.php
+++ b/app/Http/Controllers/MarkdownDocumentController.php
@@ -95,7 +95,7 @@ class MarkdownDocumentController extends Controller
 
     private function getRoutePatternToMatch()
     {
-        return "/{ROUTE:([\w.]+)}/";
+        return "/{ROUTE:([\w.\-]+)}/";
     }
 
     /**

--- a/app/Http/Controllers/MarkdownDocumentController.php
+++ b/app/Http/Controllers/MarkdownDocumentController.php
@@ -179,4 +179,9 @@ class MarkdownDocumentController extends Controller
     {
         return $this->baseMarkdownRender('markdown/cli.md', 'CLI Tool', false);
     }
+
+    public function webhooks()
+    {
+        return $this->baseMarkdownRender('markdown/webhooks.md', 'Webhooks', false);
+    }
 }

--- a/app/Http/Controllers/NotificationSettingsController.php
+++ b/app/Http/Controllers/NotificationSettingsController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationSettingsController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('NotificationSettings/Index');
+    }
+}

--- a/app/Http/Controllers/WebhookSettingsController.php
+++ b/app/Http/Controllers/WebhookSettingsController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdateWebhookSettingsRequest;
+use App\Jobs\SendWebhookNotification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class WebhookSettingsController extends Controller
 {
@@ -52,5 +54,38 @@ class WebhookSettingsController extends Controller
         return back()->with('flash', [
             'webhookSecret' => $user->fresh()->webhook_secret,
         ]);
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user->planSupportsWebhook(), 403);
+
+        $user->updateQuietly([
+            'webhook_url' => null,
+            'webhook_secret' => null,
+        ]);
+
+        return back();
+    }
+
+    public function test(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user->planSupportsWebhook(), 403);
+        abort_unless($user->hasWebhookConfigured(), 422);
+
+        SendWebhookNotification::dispatch(
+            webhookUrl: $user->webhook_url,
+            webhookSecret: $user->webhook_secret,
+            hashId: 'test-'.Str::random(5),
+            createdAt: now()->toIso8601String(),
+            retrievedAt: now()->toIso8601String(),
+            event: 'ping',
+        );
+
+        return back();
     }
 }

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -61,10 +61,6 @@ const logout = () => {
                                             :active="route().current('secrets.index')">
                                             My Secrets
                                         </NavLink>
-                                        <NavLink :href="route('user.notification-settings.index')"
-                                            :active="route().current('user.notification-settings.index')">
-                                            Notification Settings
-                                        </NavLink>
                                     </template>
                                     <template v-else>
                                         <NavLink :href="route('welcome')" :active="route().current('welcome')">
@@ -268,10 +264,6 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('secrets.index')"
                                     :active="route().current('secrets.index')">
                                     My Secrets
-                                </ResponsiveNavLink>
-                                <ResponsiveNavLink :href="route('user.notification-settings.index')"
-                                    :active="route().current('user.notification-settings.index')">
-                                    Notification Settings
                                 </ResponsiveNavLink>
                             </template>
                             <template v-else>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -437,6 +437,9 @@ const logout = () => {
                                     <li>
                                         <Link :href="route('cli.index')" class="hover:underline">CLI Tool</Link>
                                     </li>
+                                    <li>
+                                        <Link :href="route('webhooks.index')" class="hover:underline">Webhooks</Link>
+                                    </li>
                                 </ul>
                             </div>
                             <div>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -61,6 +61,10 @@ const logout = () => {
                                             :active="route().current('secrets.index')">
                                             My Secrets
                                         </NavLink>
+                                        <NavLink :href="route('user.notification-settings.index')"
+                                            :active="route().current('user.notification-settings.index')">
+                                            Notification Settings
+                                        </NavLink>
                                     </template>
                                     <template v-else>
                                         <NavLink :href="route('welcome')" :active="route().current('welcome')">
@@ -193,6 +197,10 @@ const logout = () => {
                                                 Profile
                                             </DropdownLink>
 
+                                            <DropdownLink :href="route('user.notification-settings.index')">
+                                                Notification Settings
+                                            </DropdownLink>
+
                                             <DropdownLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"
                                                 :href="route('api-tokens.index')">
                                                 API Tokens
@@ -261,6 +269,10 @@ const logout = () => {
                                     :active="route().current('secrets.index')">
                                     My Secrets
                                 </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('user.notification-settings.index')"
+                                    :active="route().current('user.notification-settings.index')">
+                                    Notification Settings
+                                </ResponsiveNavLink>
                             </template>
                             <template v-else>
                                 <ResponsiveNavLink :href="route('welcome')" :active="route().current('welcome')">
@@ -303,6 +315,11 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('profile.show')"
                                     :active="route().current('profile.show')">
                                     Profile
+                                </ResponsiveNavLink>
+
+                                <ResponsiveNavLink :href="route('user.notification-settings.index')"
+                                    :active="route().current('user.notification-settings.index')">
+                                    Notification Settings
                                 </ResponsiveNavLink>
 
                                 <ResponsiveNavLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"

--- a/resources/js/Pages/NotificationSettings/Index.vue
+++ b/resources/js/Pages/NotificationSettings/Index.vue
@@ -1,0 +1,27 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NotificationPreferencesForm from '@/Pages/Profile/Partials/NotificationPreferencesForm.vue';
+import WebhookSettingsForm from '@/Pages/Profile/Partials/WebhookSettingsForm.vue';
+import SectionBorder from '@/Components/SectionBorder.vue';
+import Page from '../Page.vue';
+</script>
+
+<template>
+    <AppLayout title="Notification Settings">
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                Notification Settings
+            </h2>
+        </template>
+
+        <Page>
+            <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+                <NotificationPreferencesForm />
+
+                <SectionBorder />
+
+                <WebhookSettingsForm class="mt-10 sm:mt-0" />
+            </div>
+        </Page>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -19,8 +19,12 @@ const webhook = computed(() => page.props.auth?.webhook);
 
 const revealedSecret = ref(null);
 const confirmingSecretRegeneration = ref(false);
+const confirmingWebhookDeletion = ref(false);
 const revealing = ref(false);
 const regenerating = ref(false);
+const deleting = ref(false);
+const testing = ref(false);
+const testDispatched = ref(false);
 const secretCopied = ref(false);
 
 const form = useForm({
@@ -76,6 +80,37 @@ const regenerateSecret = () => {
         },
     });
 };
+
+const deleteWebhook = () => {
+    deleting.value = true;
+
+    router.delete(route('user.webhook-settings.destroy'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            confirmingWebhookDeletion.value = false;
+            form.webhook_url = '';
+            revealedSecret.value = null;
+        },
+        onFinish: () => {
+            deleting.value = false;
+        },
+    });
+};
+
+const testWebhook = () => {
+    testing.value = true;
+
+    router.post(route('user.webhook-settings.test'), {}, {
+        preserveScroll: true,
+        onSuccess: () => {
+            testDispatched.value = true;
+            setTimeout(() => { testDispatched.value = false; }, 5000);
+        },
+        onFinish: () => {
+            testing.value = false;
+        },
+    });
+};
 </script>
 
 <template>
@@ -101,6 +136,9 @@ const regenerateSecret = () => {
                 <InputError :message="form.errors.webhook_url" class="mt-2" />
                 <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
                     We will send a signed HTTP POST to this URL when your secrets are retrieved. Must be HTTPS.
+                    <Link :href="route('webhooks.index')" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                        Learn more
+                    </Link>
                 </p>
             </div>
 
@@ -131,10 +169,21 @@ const regenerateSecret = () => {
                     Use this secret to verify webhook signatures via the <code class="text-xs">X-Signature-256</code> header.
                 </p>
 
-                <div class="mt-4">
+                <div class="mt-4 flex items-center gap-3">
                     <DangerButton type="button" :class="{ 'opacity-25': regenerating }" :disabled="regenerating" @click="confirmingSecretRegeneration = true">
                         Regenerate Secret
                     </DangerButton>
+                    <DangerButton type="button" @click="confirmingWebhookDeletion = true">
+                        Delete Webhook
+                    </DangerButton>
+                    <ConfirmsPasswordOrPasskey @confirmed="testWebhook">
+                        <SecondaryButton type="button" :class="{ 'opacity-25': testing }" :disabled="testing">
+                            Send Test
+                        </SecondaryButton>
+                    </ConfirmsPasswordOrPasskey>
+                    <ActionMessage :on="testDispatched">
+                        Test webhook sent — check your endpoint to confirm it was received.
+                    </ActionMessage>
                 </div>
             </div>
         </template>
@@ -186,6 +235,28 @@ const regenerateSecret = () => {
             <ConfirmsPasswordOrPasskey @confirmed="regenerateSecret">
                 <DangerButton class="ms-3">
                     Regenerate Secret
+                </DangerButton>
+            </ConfirmsPasswordOrPasskey>
+        </template>
+    </ConfirmationModal>
+
+    <ConfirmationModal :show="confirmingWebhookDeletion" @close="confirmingWebhookDeletion = false">
+        <template #title>
+            Delete Webhook
+        </template>
+
+        <template #content>
+            Are you sure you want to delete your webhook configuration? You will stop receiving HTTP notifications for secret retrievals.
+        </template>
+
+        <template #footer>
+            <SecondaryButton @click="confirmingWebhookDeletion = false">
+                Cancel
+            </SecondaryButton>
+
+            <ConfirmsPasswordOrPasskey @confirmed="deleteWebhook">
+                <DangerButton class="ms-3" :class="{ 'opacity-25': deleting }" :disabled="deleting">
+                    Delete Webhook
                 </DangerButton>
             </ConfirmsPasswordOrPasskey>
         </template>

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -6,8 +6,6 @@ import SectionBorder from '@/Components/SectionBorder.vue';
 import TwoFactorAuthenticationForm from '@/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue';
 import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue';
-import NotificationPreferencesForm from './Partials/NotificationPreferencesForm.vue';
-import WebhookSettingsForm from './Partials/WebhookSettingsForm.vue';
 import PassKeyForm from './Partials/PassKeyForm.vue';
 import Page from '../Page.vue';
 
@@ -49,14 +47,6 @@ defineProps({
                 </div>
 
                 <PassKeyForm class="mt-10 sm:mt-0" />
-
-                <SectionBorder />
-
-                <NotificationPreferencesForm class="mt-10 sm:mt-0" />
-
-                <SectionBorder />
-
-                <WebhookSettingsForm class="mt-10 sm:mt-0" />
 
                 <SectionBorder />
 

--- a/resources/markdown/webhooks.md
+++ b/resources/markdown/webhooks.md
@@ -1,0 +1,119 @@
+# Webhooks
+
+{CONFIG:app.name} can send HTTP POST notifications to your server when events occur, such as a secret being retrieved. Webhooks are available on plans that include API access. See [Pricing]({ROUTE:plans.index}) for plan details.
+
+## Setup
+
+1. Go to [Notification Settings]({ROUTE:user.notification-settings.index}) and enter your HTTPS endpoint URL in the **Webhook URL** field.
+2. A signing secret is automatically generated when you save your webhook URL. Use this secret to verify that incoming requests are genuinely from {CONFIG:app.name}.
+3. Click **Send Test** to dispatch a `ping` event and confirm your endpoint is receiving requests.
+
+## Events
+
+| Event | Trigger | Description |
+|-------|---------|-------------|
+| `retrieved` | A secret is opened by a recipient | Sent automatically when any of your secrets is accessed via its share link |
+| `ping` | Manual test from Notification Settings | Sent when you click **Send Test** — useful for verifying your endpoint |
+
+## Payload Format
+
+All webhook payloads are sent as JSON via HTTP POST:
+
+```json
+{
+  "event": "retrieved",
+  "hash_id": "abc123def456",
+  "created_at": "2026-01-15T10:30:00+00:00",
+  "retrieved_at": "2026-01-15T14:22:00+00:00"
+}
+```
+
+For `ping` events, the `hash_id` will be prefixed with `test-` (e.g., `test-xK3mQ`) and both timestamps will be the current time.
+
+### Headers
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `X-Signature-256` | HMAC-SHA256 signature of the raw JSON body |
+| `User-Agent` | `FlashView-Webhook/1.0` |
+
+## Signature Verification
+
+Every webhook request includes an `X-Signature-256` header containing an HMAC-SHA256 signature. You should verify this signature to ensure the request is authentic and has not been tampered with.
+
+The signature format is: `sha256=<hex-digest>`
+
+### PHP
+
+```php
+$payload = file_get_contents('php://input');
+$signature = $_SERVER['HTTP_X_SIGNATURE_256'] ?? '';
+$expected = 'sha256=' . hash_hmac('sha256', $payload, $webhookSecret);
+
+if (! hash_equals($expected, $signature)) {
+    http_response_code(401);
+    exit('Invalid signature');
+}
+```
+
+### Node.js
+
+```javascript
+const crypto = require('crypto');
+
+function verifySignature(payload, signature, secret) {
+  const expected = 'sha256=' + crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+
+  return crypto.timingSafeEqual(
+    Buffer.from(expected),
+    Buffer.from(signature)
+  );
+}
+```
+
+### Python
+
+```python
+import hmac
+import hashlib
+
+def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
+    expected = 'sha256=' + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+## Retry Policy
+
+If your endpoint returns a non-2xx status code or the request times out (10 seconds), {CONFIG:app.name} will retry delivery using exponential backoff:
+
+| Attempt | Delay |
+|---------|-------|
+| 1 | 30 seconds |
+| 2 | 1 minute |
+| 3 | 2 minutes |
+| 4 | 5 minutes |
+| 5 | 15 minutes |
+| 6 | 30 minutes |
+| 7 | 1 hour |
+| 8 | 2 hours |
+| 9 | 4 hours |
+| 10 | 8 hours |
+
+Retries stop after 24 hours. After that, the delivery is marked as permanently failed and no further attempts are made.
+
+## Requirements
+
+- Your endpoint must be HTTPS.
+- Your endpoint must respond within 10 seconds.
+- Your endpoint must return a 2xx status code to acknowledge receipt.
+- Redirects are followed (up to 3 hops, HTTPS only).
+
+## Testing
+
+Use the **Send Test** button on the [Notification Settings]({ROUTE:user.notification-settings.index}) page to send a `ping` event to your configured URL. This uses your real webhook secret for signing, so you can verify your signature validation logic with a live request.

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\MarkdownDocumentController;
 use App\Http\Controllers\NotificationPreferencesController;
+use App\Http\Controllers\NotificationSettingsController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
 use App\Http\Controllers\WebhookSettingsController;
@@ -75,6 +76,9 @@ Route::middleware([
     Route::get('plans/{plan}/{period}', [PlanController::class, 'subscribe'])->name('plans.subscribe');
     Route::post('plans/cancel', [PlanController::class, 'unsubscribe'])->name('plans.unsubscribe');
     Route::post('plans/resume', [PlanController::class, 'resume'])->name('plans.resume');
+
+    Route::get('/user/notification-settings', [NotificationSettingsController::class, 'index'])
+        ->name('user.notification-settings.index');
 
     Route::put('/user/notification-preferences', [NotificationPreferencesController::class, 'update'])
         ->name('user.notification-preferences.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,6 +102,12 @@ Route::middleware([
         Route::post('/user/webhook-settings/regenerate-secret', [WebhookSettingsController::class, 'regenerateSecret'])
             ->middleware('password.confirm')
             ->name('user.webhook-settings.regenerate-secret');
+        Route::delete('/user/webhook-settings', [WebhookSettingsController::class, 'destroy'])
+            ->middleware('password.confirm')
+            ->name('user.webhook-settings.destroy');
+        Route::post('/user/webhook-settings/test', [WebhookSettingsController::class, 'test'])
+            ->middleware('password.confirm')
+            ->name('user.webhook-settings.test');
     });
 
     Route::get('/billing', function (Request $request) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ Route::controller(MarkdownDocumentController::class)->group(function () {
     Route::get('/about', 'about')->name('about.index');
     Route::get('/use-cases', 'useCases')->name('useCases.index');
     Route::get('/cli', 'cli')->name('cli.index');
+    Route::get('/webhooks', 'webhooks')->name('webhooks.index');
 });
 
 Route::middleware(config('fortify.middleware', ['web']))->group(function () {

--- a/tests/Feature/NotificationSettingsPageTest.php
+++ b/tests/Feature/NotificationSettingsPageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotificationSettingsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_access_notification_settings_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)
+            ->get('/user/notification-settings');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('NotificationSettings/Index'));
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $response = $this->get('/user/notification-settings');
+
+        $response->assertRedirect('/login');
+    }
+}

--- a/tests/Feature/Web/MarkdownDocumentControllerTest.php
+++ b/tests/Feature/Web/MarkdownDocumentControllerTest.php
@@ -73,6 +73,14 @@ class MarkdownDocumentControllerTest extends TestCase
         $response->assertInertia(fn ($page) => $page->component('Doc/Page'));
     }
 
+    public function test_webhooks_page_renders_successfully(): void
+    {
+        $response = $this->get(route('webhooks.index'));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page->component('Doc/Page'));
+    }
+
     public function test_markdown_pages_replace_config_variables(): void
     {
         $response = $this->get(route('terms.show'));

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Jobs\SendWebhookNotification;
 use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class WebhookSettingsTest extends TestCase
@@ -303,5 +305,152 @@ class WebhookSettingsTest extends TestCase
         $this->user->refresh();
         $this->assertNull($this->user->webhook_url);
         $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_user_can_delete_webhook(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/webhook-settings');
+
+        $response->assertRedirect();
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_delete_webhook_requires_api_plan(): void
+    {
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free',
+            'stripe_monthly_price_id' => 'price_monthly_free_del',
+            'stripe_yearly_price_id' => 'price_yearly_free_del',
+            'stripe_product_id' => 'prod_free_del',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $this->subscribeUserToPlan($this->user, $freePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/webhook-settings');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_delete_webhook_requires_password_confirmation(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->delete('/user/webhook-settings');
+
+        $response->assertRedirect();
+        $this->assertNotNull($this->user->fresh()->webhook_url);
+    }
+
+    public function test_delete_webhook_when_none_configured(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/webhook-settings');
+
+        $response->assertRedirect();
+
+        $this->user->refresh();
+        $this->assertNull($this->user->webhook_url);
+        $this->assertNull($this->user->webhook_secret);
+    }
+
+    public function test_user_can_send_test_webhook(): void
+    {
+        Queue::fake();
+
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/test');
+
+        $response->assertRedirect();
+
+        Queue::assertPushed(SendWebhookNotification::class, function ($job) {
+            return $job->event === 'ping'
+                && str_starts_with($job->hashId, 'test-')
+                && $job->webhookUrl === 'https://example.com/webhook';
+        });
+    }
+
+    public function test_test_webhook_requires_password_confirmation(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->post('/user/webhook-settings/test');
+
+        $response->assertRedirect();
+    }
+
+    public function test_test_webhook_requires_webhook_configured(): void
+    {
+        $this->subscribeUserToPlan($this->user, $this->primePlan);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/test');
+
+        $response->assertStatus(422);
+    }
+
+    public function test_test_webhook_requires_api_plan(): void
+    {
+        $freePlan = Plan::factory()->create([
+            'name' => 'Free',
+            'stripe_monthly_price_id' => 'price_monthly_free_test',
+            'stripe_yearly_price_id' => 'price_yearly_free_test',
+            'stripe_product_id' => 'prod_free_test',
+            'price_per_month' => 0,
+            'price_per_year' => 0,
+            'features' => [
+                'api' => ['order' => 6, 'label' => 'API', 'config' => [], 'type' => 'missing'],
+            ],
+        ]);
+
+        $this->subscribeUserToPlan($this->user, $freePlan);
+        $this->user->updateQuietly([
+            'webhook_url' => 'https://example.com/webhook',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+        ]);
+        $this->actingAs($this->user);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/webhook-settings/test');
+
+        $response->assertStatus(403);
     }
 }


### PR DESCRIPTION
## Summary

- Add dedicated **Notification Settings** page at `/user/notification-settings` with both email notification preferences and webhook settings forms (removed from Profile page)
- Add **"Notification Settings"** links to desktop nav, mobile nav, settings dropdown, and responsive settings section
- Add **Delete Webhook** button with confirmation modal and password confirmation — clears `webhook_url` and `webhook_secret`
- Add **Send Test** button that dispatches a `ping` event via `SendWebhookNotification` job with synthetic data, gated by password confirmation
- Add **Webhook documentation** page at `/webhooks` with payload format, signature verification examples (PHP/Node/Python), retry policy, and testing instructions
- Add **"Learn more"** link in webhook settings form pointing to webhook docs

## Regression Risks

- `AppLayout.vue` is a shared layout (7+ pages) — new nav links use `route('user.notification-settings.index')` which requires Ziggy route resolution; stale route cache could cause JS errors
- Profile page no longer contains notification/webhook forms — users with muscle memory will need to find the new location via nav
- `SendWebhookNotification` job now accepts `event: 'ping'` (new event type for external integrators)

## Test plan

- [x] 11 new automated tests across 3 files (all passing)
- [ ] Navigate to Notification Settings from desktop nav, mobile nav, and settings dropdown
- [ ] Verify both email notification and webhook forms render correctly on new page
- [ ] Verify Profile page no longer shows notification/webhook sections
- [ ] Configure webhook URL → verify secret auto-generated
- [ ] Send test webhook → verify ping event received at endpoint
- [ ] Delete webhook → verify URL and secret cleared
- [ ] Access `/webhooks` documentation page and verify content renders
- [ ] Test as guest — redirected to login for `/user/notification-settings`
- [ ] Test without API plan — webhook actions return 403