### PR TITLE
Add self-update command and version notice to FlashView CLI

### DIFF
--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { hostname } from 'node:os';
@@ -8,9 +9,10 @@ import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { encryptMessage, decryptMessage } from './crypto.js';
 import { FlashViewClient, ApiError } from './api.js';
-import { getConfig, getConfigInfo, setConfig, clearConfig } from './config.js';
+import { getConfig, getConfigInfo, setConfig, clearConfig, getCachedLatestVersion } from './config.js';
 import { parseExpiry, getServerConfig, FALLBACK_EXPIRY_OPTIONS } from './expiry.js';
 import { renameHashIdKey } from './transform.js';
+import { fetchLatestVersion, isNewerVersion, refreshVersionCache } from './version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -496,6 +498,105 @@ program
             server.close();
         }
     });
+// --- Update ---
+
+program
+    .command('update')
+    .description('Update FlashView CLI to the latest version')
+    .option('--json', 'Output as JSON (for scripting)')
+    .action(async (options) => {
+        const currentVersion = pkg.version;
+
+        const latestVersion = await fetchLatestVersion();
+
+        if (!latestVersion) {
+            if (options.json) {
+                console.log(JSON.stringify({ error: 'Could not check for updates. Check your network connection.' }));
+            } else {
+                console.error('Could not check for updates. Check your network connection.');
+            }
+            process.exit(1);
+        }
+
+        if (!isNewerVersion(currentVersion, latestVersion)) {
+            if (options.json) {
+                console.log(JSON.stringify({ message: 'Already up to date.', version: currentVersion }));
+            } else {
+                console.log(`Already up to date (v${currentVersion}).`);
+            }
+            return;
+        }
+
+        if (!options.json) {
+            console.log(`Updating FlashView CLI: v${currentVersion} → v${latestVersion}...`);
+        }
+
+        try {
+            execSync('npm install -g @pioneer-dynamics/flashview-cli@latest', {
+                stdio: options.json ? 'pipe' : 'inherit',
+            });
+        } catch (err) {
+            const stderr = err.stderr?.toString() || '';
+            let message;
+            if (process.platform === 'win32' && (stderr.includes('EPERM') || stderr.includes('Access is denied'))) {
+                message = 'Permission denied. Try running as Administrator or use a Node version manager (nvm-windows, fnm).';
+            } else if (stderr.includes('EACCES')) {
+                message = 'Permission denied. Try running with sudo or use a Node version manager (nvm, fnm).';
+            } else {
+                message = 'Update failed. Try manually: npm install -g @pioneer-dynamics/flashview-cli@latest';
+            }
+
+            if (options.json) {
+                console.log(JSON.stringify({ error: message }));
+            } else {
+                console.error(message);
+            }
+            process.exit(1);
+        }
+
+        let newVersion;
+        try {
+            newVersion = execSync('flashview --version', { encoding: 'utf-8' }).trim();
+        } catch {
+            newVersion = latestVersion;
+        }
+
+        if (options.json) {
+            console.log(JSON.stringify({
+                message: 'Updated successfully.',
+                previous_version: currentVersion,
+                current_version: newVersion,
+            }));
+        } else {
+            console.log(`\nUpdated successfully: v${currentVersion} → v${newVersion}`);
+        }
+    });
+
+// --- Update Notice (post-action hook) ---
+
+program.hook('postAction', async (thisCommand) => {
+    if (thisCommand.name() === 'update') return;
+
+    const opts = thisCommand.opts?.() || {};
+    if (opts.json) return;
+
+    try {
+        const cached = getCachedLatestVersion();
+
+        if (cached && isNewerVersion(pkg.version, cached)) {
+            process.stderr.write(
+                `\nUpdate available: v${pkg.version} → v${cached}. Run \`flashview update\` to upgrade.\n`
+            );
+        }
+
+        if (!cached) {
+            refreshVersionCache();
+        }
+    } catch {
+        // Never block on version check errors
+    }
+});
+
 export function run() {
     program.parse();
 }

--- a/tools/flashview-cli/src/config.js
+++ b/tools/flashview-cli/src/config.js
@@ -9,6 +9,8 @@ const config = new Conf({
         token: { type: 'string' },
         serverConfig: { type: 'object' },
         serverConfigFetchedAt: { type: 'number' },
+        latestVersion: { type: 'string' },
+        latestVersionCheckedAt: { type: 'number' },
     },
 });
 
@@ -103,4 +105,32 @@ export function setConfig({ url, token }) {
  */
 export function clearConfig() {
     config.clear();
+}
+
+const VERSION_CHECK_TTL = 60 * 60 * 1000; // 1 hour in milliseconds
+
+/**
+ * Get cached latest version if still valid.
+ *
+ * @returns {string|null}
+ */
+export function getCachedLatestVersion() {
+    const checkedAt = config.get('latestVersionCheckedAt');
+    const version = config.get('latestVersion');
+
+    if (version && checkedAt && (Date.now() - checkedAt) < VERSION_CHECK_TTL) {
+        return version;
+    }
+
+    return null;
+}
+
+/**
+ * Store latest version in cache.
+ *
+ * @param {string} version
+ */
+export function setCachedLatestVersion(version) {
+    config.set('latestVersion', version);
+    config.set('latestVersionCheckedAt', Date.now());
 }

--- a/tools/flashview-cli/src/version.js
+++ b/tools/flashview-cli/src/version.js
@@ -1,0 +1,77 @@
+import { getCachedLatestVersion, setCachedLatestVersion } from './config.js';
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@pioneer-dynamics/flashview-cli/latest';
+const FETCH_TIMEOUT = 5000;
+
+/**
+ * Fetch the latest version from the npm registry.
+ * Returns null on any error (network, timeout, parse).
+ *
+ * @returns {Promise<string|null>}
+ */
+export async function fetchLatestVersion() {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+    try {
+        const response = await fetch(NPM_REGISTRY_URL, {
+            headers: { 'Accept': 'application/json' },
+            signal: controller.signal,
+        });
+
+        if (!response.ok) return null;
+
+        const data = await response.json();
+        return data.version || null;
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+/**
+ * Get the latest version, using cache-first strategy.
+ * Returns null if unavailable.
+ *
+ * @returns {Promise<string|null>}
+ */
+export async function getLatestVersion() {
+    const cached = getCachedLatestVersion();
+    if (cached) return cached;
+
+    const latest = await fetchLatestVersion();
+    if (latest) {
+        setCachedLatestVersion(latest);
+    }
+    return latest;
+}
+
+/**
+ * Compare two semver strings. Returns true if latest > current.
+ *
+ * @param {string} current
+ * @param {string} latest
+ * @returns {boolean}
+ */
+export function isNewerVersion(current, latest) {
+    const parse = (v) => v.replace(/^v/, '').split('.').map(Number);
+    const [cMajor, cMinor, cPatch] = parse(current);
+    const [lMajor, lMinor, lPatch] = parse(latest);
+
+    if (lMajor !== cMajor) return lMajor > cMajor;
+    if (lMinor !== cMinor) return lMinor > cMinor;
+    return lPatch > cPatch;
+}
+
+/**
+ * Refresh the version cache in the background (fire-and-forget).
+ * Does not block, does not throw.
+ */
+export function refreshVersionCache() {
+    fetchLatestVersion()
+        .then((version) => {
+            if (version) setCachedLatestVersion(version);
+        })
+        .catch(() => {});
+}

--- a/tools/flashview-cli/tests/version.test.js
+++ b/tools/flashview-cli/tests/version.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isNewerVersion } from '../src/version.js';
+
+describe('isNewerVersion', () => {
+    it('returns true when latest is a higher major version', () => {
+        assert.strictEqual(isNewerVersion('1.0.0', '2.0.0'), true);
+    });
+
+    it('returns true when latest is a higher minor version', () => {
+        assert.strictEqual(isNewerVersion('1.2.0', '1.3.0'), true);
+    });
+
+    it('returns true when latest is a higher patch version', () => {
+        assert.strictEqual(isNewerVersion('1.2.3', '1.2.4'), true);
+    });
+
+    it('returns false when versions are equal', () => {
+        assert.strictEqual(isNewerVersion('1.3.1', '1.3.1'), false);
+    });
+
+    it('returns false when current is newer (higher major)', () => {
+        assert.strictEqual(isNewerVersion('2.0.0', '1.9.9'), false);
+    });
+
+    it('returns false when current is newer (higher minor)', () => {
+        assert.strictEqual(isNewerVersion('1.4.0', '1.3.9'), false);
+    });
+
+    it('returns false when current is newer (higher patch)', () => {
+        assert.strictEqual(isNewerVersion('1.3.2', '1.3.1'), false);
+    });
+
+    it('handles v prefix on current version', () => {
+        assert.strictEqual(isNewerVersion('v1.3.1', '1.4.0'), true);
+    });
+
+    it('handles v prefix on latest version', () => {
+        assert.strictEqual(isNewerVersion('1.3.1', 'v1.4.0'), true);
+    });
+
+    it('handles v prefix on both versions', () => {
+        assert.strictEqual(isNewerVersion('v1.3.1', 'v1.3.1'), false);
+    });
+
+    it('handles major version jump correctly', () => {
+        assert.strictEqual(isNewerVersion('1.9.9', '2.0.0'), true);
+    });
+
+    it('handles minor version jump correctly', () => {
+        assert.strictEqual(isNewerVersion('1.9.9', '1.10.0'), true);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `flashview update` command that checks npm registry for the latest version and runs `npm install -g` to self-update, with platform-aware error handling (Unix/Windows)
- Adds post-action hook that displays an update notice on stderr when a newer version is available, suppressed with `--json`
- Uses cache-only reads with fire-and-forget background refresh for zero latency impact on normal commands

## Changes

| File | Change |
|------|--------|
| `tools/flashview-cli/src/version.js` | New module — npm registry fetch, semver comparison, cache helpers |
| `tools/flashview-cli/src/config.js` | Added `latestVersion`/`latestVersionCheckedAt` schema keys and cache helpers |
| `tools/flashview-cli/src/cli.js` | Added `update` command and `postAction` hook for update notice |
| `tools/flashview-cli/tests/version.test.js` | 12 tests for `isNewerVersion()` semver comparison |

## Regression notes

- Post-action hook runs after all commands but only reads cached data (no network delay)
- All changes isolated to `tools/flashview-cli/` — no impact to the Laravel application

## Test plan

- [x] All 62 tests pass (`npm test`)
- [x] Run `flashview update` when already on latest — verify "Already up to date" message
- [x] Run `flashview update` when newer version exists — verify download and version transition
- [x] Run `flashview update --json` — verify JSON output format
- [x] Run `flashview list` with stale/no cache — verify no delay, cache refreshes in background
- [x] Run `flashview list` with cached newer version — verify update notice on stderr
- [x] Run `flashview list --json` — verify no update notice
- [x] Run `flashview update` without permissions — verify helpful error message