### PR TITLE
Fix CLI version update notice appearing in --json output

### DIFF
--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -574,10 +574,12 @@ program
 
 // --- Update Notice (post-action hook) ---
 
-program.hook('postAction', async (thisCommand) => {
-    if (thisCommand.name() === 'update') return;
+// thisCommand = command the hook is registered on (root program)
+// actionCommand = the subcommand that actually executed
+program.hook('postAction', async (thisCommand, actionCommand) => {
+    if (actionCommand.name() === 'update') return;
 
-    const opts = thisCommand.opts?.() || {};
+    const opts = actionCommand.opts?.() || {};
     if (opts.json) return;
 
     try {

--- a/tools/flashview-cli/tests/regression-pio39.test.js
+++ b/tools/flashview-cli/tests/regression-pio39.test.js
@@ -1,0 +1,92 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Conf from 'conf';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cli = join(__dirname, '..', 'bin', 'flashview.js');
+
+/**
+ * PIO-39 Regression: --json suppresses version update notice
+ *
+ * The postAction hook was reading the --json option from `thisCommand`
+ * (the root program) instead of `actionCommand` (the executed subcommand).
+ * Since --json is defined on subcommands, the guard never triggered,
+ * causing the version update notice to appear alongside JSON output.
+ */
+describe('PIO-39 Regression: --json suppresses version update notice', () => {
+    const UPDATE_NOTICE_PATTERN = /Update available:.*Run.*flashview update/;
+
+    const config = new Conf({ projectName: 'flashview-cli' });
+    const savedKeys = [
+        'latestVersion',
+        'latestVersionCheckedAt',
+        'serverConfig',
+        'serverConfigFetchedAt',
+    ];
+    const originalValues = {};
+
+    before(() => {
+        for (const key of savedKeys) {
+            originalValues[key] = config.get(key);
+        }
+
+        // Set a fake newer version so the update notice would trigger
+        config.set('latestVersion', '99.0.0');
+        config.set('latestVersionCheckedAt', Date.now());
+
+        // Ensure server config is cached so the CLI doesn't try to fetch it
+        config.set('serverConfig', {
+            expiry_options: [{ label: '5 minutes', value: 5 }],
+            max_expiry: 5,
+            max_message_length: 10000,
+        });
+        config.set('serverConfigFetchedAt', Date.now());
+    });
+
+    after(() => {
+        for (const key of savedKeys) {
+            if (originalValues[key] !== undefined) {
+                config.set(key, originalValues[key]);
+            } else {
+                config.delete(key);
+            }
+        }
+    });
+
+    /**
+     * Runs the CLI with the given arguments and returns { stdout, stderr }.
+     */
+    function runCli(args) {
+        const result = spawnSync(process.execPath, [cli, ...args], {
+            cwd: join(__dirname, '..'),
+            encoding: 'utf-8',
+            timeout: 10000,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return {
+            stdout: result.stdout || '',
+            stderr: result.stderr || '',
+        };
+    }
+
+    it('suppresses the version update notice when --json is passed', () => {
+        const result = runCli(['create', '--message', 'test', '--json']);
+
+        assert.ok(
+            !UPDATE_NOTICE_PATTERN.test(result.stderr),
+            `Version notice should be suppressed with --json, but stderr contained:\n${result.stderr}`
+        );
+    });
+
+    it('stdout does not contain the version update notice when --json is passed', () => {
+        const result = runCli(['create', '--message', 'test', '--json']);
+
+        assert.ok(
+            !UPDATE_NOTICE_PATTERN.test(result.stdout),
+            `Version notice should not appear in stdout with --json, but got:\n${result.stdout}`
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Fixed the `postAction` hook in the FlashView CLI reading the `--json` flag from the wrong Commander.js parameter (`thisCommand` instead of `actionCommand`), which caused the version update notice to appear alongside JSON output
- The same fix also corrects the `update` command name guard, which was checking the root program name instead of the subcommand name
- Added regression test verifying `--json` suppresses the version notice in both stdout and stderr

## Regression Risk

**Low.** Change is confined to the CLI tool's postAction hook — zero impact on the Laravel application. All 6 subcommands with `--json` benefit from the fix.

## Test plan

- [x] Regression test (`regression-pio39.test.js`) passes — verifies notice is suppressed with `--json`
- [x] Full CLI test suite passes (64/64 tests)
- [x] Manual: Run `flashview create --message test --json` with an outdated cached version and confirm no update notice appears
- [x] Manual: Run same command without `--json` and confirm the notice still appears

Closes PIO-39