### PR TITLE
Update CLI online docs to reflect native binary support

### DIFF
--- a/resources/markdown/cli.md
+++ b/resources/markdown/cli.md
@@ -4,14 +4,49 @@ The {CONFIG:app.name} CLI lets you create and manage encrypted secrets directly 
 
 The CLI requires a {CONFIG:app.name} account with API access (available on paid plans). See [Pricing]({ROUTE:plans.index}) for plan details.
 
-## Requirements
-
-- Node.js 18 or later
-- A {CONFIG:app.name} account with a plan that includes API access
-
 ## Installation
 
-Install the CLI globally via npm:
+### Option 1: Download pre-built binary (recommended if you don't have Node.js)
+
+Download the latest binary for your platform from the <a href="https://github.com/pioneer-dynamics/FlashView/releases" target="_blank" rel="noopener noreferrer">GitHub Releases</a> page.
+
+The binary includes a bundled Node.js runtime and is approximately 70-90MB depending on your platform.
+
+**macOS (Apple Silicon):**
+```
+chmod +x flashview-darwin-arm64
+sudo mv flashview-darwin-arm64 /usr/local/bin/flashview
+```
+
+**Linux (x64):**
+```
+chmod +x flashview-linux-x64
+sudo mv flashview-linux-x64 /usr/local/bin/flashview
+```
+
+**Linux (arm64):**
+```
+chmod +x flashview-linux-arm64
+sudo mv flashview-linux-arm64 /usr/local/bin/flashview
+```
+
+**Windows:**
+Rename `flashview-windows-x64.exe` to `flashview.exe` and add its directory to your PATH.
+
+**Verify download integrity:**
+Each release includes a `checksums-sha256.txt` file. Verify your download:
+```
+sha256sum --check checksums-sha256.txt
+```
+
+**macOS Gatekeeper:** If you see "this app is from an unidentified developer", right-click the binary and select "Open", or run:
+```
+xattr -d com.apple.quarantine /usr/local/bin/flashview
+```
+
+**Windows SmartScreen:** If Windows Defender SmartScreen blocks the binary, click "More info" then "Run anyway". The binary is a modified Node.js executable which may trigger false positives.
+
+### Option 2: Install via npm (requires Node.js 20+)
 
 ```
 npm install -g @pioneer-dynamics/flashview-cli
@@ -21,6 +56,15 @@ Or run it without installing using npx:
 
 ```
 npx @pioneer-dynamics/flashview-cli --help
+```
+
+### How to upgrade
+
+**Binary users:** Download the latest release from the <a href="https://github.com/pioneer-dynamics/FlashView/releases" target="_blank" rel="noopener noreferrer">Releases</a> page and replace your existing binary. Run `flashview --version` to check your current version, or run `flashview update` to see if a newer version is available.
+
+**npm users:**
+```
+flashview update
 ```
 
 ## Setup
@@ -46,6 +90,18 @@ flashview login --url https://your-server.com
 flashview config set --token your-api-token --url https://your-server.com
 ```
 
+### View current configuration
+
+```
+flashview config show
+```
+
+### Clear stored configuration
+
+```
+flashview config clear
+```
+
 ## Usage
 
 ### Create a Secret
@@ -60,6 +116,9 @@ echo "my secret" | flashview create
 # With custom expiry (default: 1 day)
 flashview create -m "secret" --expires-in 7d
 
+# With a specific passphrase
+flashview create -m "secret" --passphrase "my-custom-passphrase"
+
 # JSON output for scripting
 flashview create -m "secret" --json
 ```
@@ -72,21 +131,31 @@ After creating a secret, save the URL and passphrase immediately — they cannot
 
 ```
 flashview list
+
+# Paginated
 flashview list --page 2
+
+# JSON output
+flashview list --json
 ```
 
 ### Burn (Delete) a Secret
 
 ```
 flashview burn <message_id>
-flashview burn <message_id> --yes   # skip confirmation
+
+# Skip confirmation
+flashview burn <message_id> --yes
+
+# JSON output
+flashview burn <message_id> --json
 ```
 
 ## Security
 
 - **End-to-end encryption:** Secrets are encrypted locally using AES-256-GCM with PBKDF2 key derivation (SHA-512, 64,000 iterations). The server never sees your plaintext.
 - **Passphrases stay local:** Encryption passphrases are never sent to the server.
-- **Token storage:** API tokens are stored in your OS config directory. On shared systems, set appropriate file permissions.
+- **Token storage:** API tokens are stored in plaintext in your OS config directory (e.g., `~/.config/flashview-cli/config.json`). On shared systems, set appropriate file permissions: `chmod 600 ~/.config/flashview-cli/config.json`.
 
 ## Source Code
 


### PR DESCRIPTION
Sync resources/markdown/cli.md with the CLI README after PIO-17. Adds binary installation instructions, upgrade guide, config show/clear commands, --passphrase and --json flags, and updated Node.js requirement to 20+.