### PR TITLE
Add auto-tag workflow for release/hotfix merges

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,56 @@
+name: Auto-tag on release/hotfix merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from branch name
+        id: extract
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$BRANCH" =~ ^(release|hotfix)/(v.+)$ ]]; then
+            VERSION="${BASH_REMATCH[2]}"
+            # Normalize: strip extra dot after v (e.g., v.4.6.0 -> v4.6.0)
+            VERSION="${VERSION/#v./v}"
+            # Validate: must start with v followed by a digit
+            if [[ "$VERSION" =~ ^v[0-9] ]]; then
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+              echo "Detected version: $VERSION from branch: $BRANCH"
+            else
+              echo "::warning::Version '$VERSION' from branch '$BRANCH' does not match expected format vX.Y.Z. Skipping."
+              echo "version=" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Branch '$BRANCH' is not a release or hotfix branch. Skipping."
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.extract.outputs.version != ''
+        env:
+          TAG: ${{ steps.extract.outputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          echo "Tagging commit $MERGE_SHA as $TAG"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git tag "$TAG" "$MERGE_SHA" 2>/dev/null; then
+            git push origin "$TAG"
+            echo "Successfully created and pushed tag: $TAG"
+          else
+            echo "::warning::Tag '$TAG' already exists. Skipping."
+          fi

--- a/resources/markdown/cli.md
+++ b/resources/markdown/cli.md
@@ -4,14 +4,49 @@ The {CONFIG:app.name} CLI lets you create and manage encrypted secrets directly 
 
 The CLI requires a {CONFIG:app.name} account with API access (available on paid plans). See [Pricing]({ROUTE:plans.index}) for plan details.
 
-## Requirements
-
-- Node.js 18 or later
-- A {CONFIG:app.name} account with a plan that includes API access
-
 ## Installation
 
-Install the CLI globally via npm:
+### Option 1: Download pre-built binary (recommended if you don't have Node.js)
+
+Download the latest binary for your platform from the <a href="https://github.com/pioneer-dynamics/FlashView/releases" target="_blank" rel="noopener noreferrer">GitHub Releases</a> page.
+
+The binary includes a bundled Node.js runtime and is approximately 70-90MB depending on your platform.
+
+**macOS (Apple Silicon):**
+```
+chmod +x flashview-darwin-arm64
+sudo mv flashview-darwin-arm64 /usr/local/bin/flashview
+```
+
+**Linux (x64):**
+```
+chmod +x flashview-linux-x64
+sudo mv flashview-linux-x64 /usr/local/bin/flashview
+```
+
+**Linux (arm64):**
+```
+chmod +x flashview-linux-arm64
+sudo mv flashview-linux-arm64 /usr/local/bin/flashview
+```
+
+**Windows:**
+Rename `flashview-windows-x64.exe` to `flashview.exe` and add its directory to your PATH.
+
+**Verify download integrity:**
+Each release includes a `checksums-sha256.txt` file. Verify your download:
+```
+sha256sum --check checksums-sha256.txt
+```
+
+**macOS Gatekeeper:** If you see "this app is from an unidentified developer", right-click the binary and select "Open", or run:
+```
+xattr -d com.apple.quarantine /usr/local/bin/flashview
+```
+
+**Windows SmartScreen:** If Windows Defender SmartScreen blocks the binary, click "More info" then "Run anyway". The binary is a modified Node.js executable which may trigger false positives.
+
+### Option 2: Install via npm (requires Node.js 20+)
 
 ```
 npm install -g @pioneer-dynamics/flashview-cli
@@ -21,6 +56,15 @@ Or run it without installing using npx:
 
 ```
 npx @pioneer-dynamics/flashview-cli --help
+```
+
+### How to upgrade
+
+**Binary users:** Download the latest release from the <a href="https://github.com/pioneer-dynamics/FlashView/releases" target="_blank" rel="noopener noreferrer">Releases</a> page and replace your existing binary. Run `flashview --version` to check your current version, or run `flashview update` to see if a newer version is available.
+
+**npm users:**
+```
+flashview update
 ```
 
 ## Setup
@@ -46,6 +90,18 @@ flashview login --url https://your-server.com
 flashview config set --token your-api-token --url https://your-server.com
 ```
 
+### View current configuration
+
+```
+flashview config show
+```
+
+### Clear stored configuration
+
+```
+flashview config clear
+```
+
 ## Usage
 
 ### Create a Secret
@@ -60,6 +116,9 @@ echo "my secret" | flashview create
 # With custom expiry (default: 1 day)
 flashview create -m "secret" --expires-in 7d
 
+# With a specific passphrase
+flashview create -m "secret" --passphrase "my-custom-passphrase"
+
 # JSON output for scripting
 flashview create -m "secret" --json
 ```
@@ -72,21 +131,31 @@ After creating a secret, save the URL and passphrase immediately — they cannot
 
 ```
 flashview list
+
+# Paginated
 flashview list --page 2
+
+# JSON output
+flashview list --json
 ```
 
 ### Burn (Delete) a Secret
 
 ```
 flashview burn <message_id>
-flashview burn <message_id> --yes   # skip confirmation
+
+# Skip confirmation
+flashview burn <message_id> --yes
+
+# JSON output
+flashview burn <message_id> --json
 ```
 
 ## Security
 
 - **End-to-end encryption:** Secrets are encrypted locally using AES-256-GCM with PBKDF2 key derivation (SHA-512, 64,000 iterations). The server never sees your plaintext.
 - **Passphrases stay local:** Encryption passphrases are never sent to the server.
-- **Token storage:** API tokens are stored in your OS config directory. On shared systems, set appropriate file permissions.
+- **Token storage:** API tokens are stored in plaintext in your OS config directory (e.g., `~/.config/flashview-cli/config.json`). On shared systems, set appropriate file permissions: `chmod 600 ~/.config/flashview-cli/config.json`.
 
 ## Source Code
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-tag.yml` that automatically creates a git tag on master when a PR from a `release/v*` or `hotfix/v*` branch is merged
- Extracts version from the source branch name and tags the merge commit
- Normalizes `v.X.Y.Z` → `vX.Y.Z` to match existing tag convention
- Gracefully skips if the tag already exists

## Details

- Triggers on `pull_request: closed` with `merged == true` guard
- Uses `env:` blocks for context values (script injection prevention)
- Lightweight tags on `merge_commit_sha`
- Permissions scoped to `contents: write` only
- Bot identity matches existing workflows (`github-actions[bot]`)

## Test plan

- [ ] Merge a `release/vX.Y.Z` PR into master → tag `vX.Y.Z` is created on the merge commit
- [ ] Merge a `hotfix/vX.Y.Z` PR into master → tag `vX.Y.Z` is created on the merge commit
- [ ] Merge a `release/v.X.Y.Z` PR (extra dot) → tag is normalized to `vX.Y.Z`
- [ ] Merge a `feature/*` PR into master → no tag is created
- [ ] Close a `release/vX.Y.Z` PR without merging → no tag is created
- [ ] Merge when tag already exists → workflow logs a warning and succeeds

Resolves PIO-38