### PR TITLE
Fix CLI version showing 0.0.0-dev after npm install

### DIFF
--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -9,10 +9,13 @@ import { FlashViewClient, ApiError } from './api.js';
 import { getConfig, getConfigInfo, setConfig, clearConfig, getCachedLatestVersion } from './config.js';
 import { parseExpiry, getServerConfig, FALLBACK_EXPIRY_OPTIONS } from './expiry.js';
 import { renameHashIdKey } from './transform.js';
+import { createRequire } from 'node:module';
 import { fetchLatestVersion, isNewerVersion, refreshVersionCache } from './version.js';
 
 /* eslint-disable no-undef */
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : '0.0.0-dev';
+const VERSION = typeof __VERSION__ !== 'undefined'
+    ? __VERSION__
+    : createRequire(import.meta.url)('../package.json').version;
 /* eslint-enable no-undef */
 
 let isSea = false;

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
 import { hostname } from 'node:os';
 import { createInterface } from 'node:readline';
 import { encryptMessage, decryptMessage } from './crypto.js';
@@ -9,7 +10,6 @@ import { FlashViewClient, ApiError } from './api.js';
 import { getConfig, getConfigInfo, setConfig, clearConfig, getCachedLatestVersion } from './config.js';
 import { parseExpiry, getServerConfig, FALLBACK_EXPIRY_OPTIONS } from './expiry.js';
 import { renameHashIdKey } from './transform.js';
-import { createRequire } from 'node:module';
 import { fetchLatestVersion, isNewerVersion, refreshVersionCache } from './version.js';
 
 /* eslint-disable no-undef */

--- a/tools/flashview-cli/tests/cli.test.js
+++ b/tools/flashview-cli/tests/cli.test.js
@@ -11,12 +11,12 @@ const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
 describe('CLI version', () => {
-    it('outputs the dev version when run without esbuild', () => {
+    it('outputs the package.json version when run from source', () => {
         const output = execSync('node bin/flashview.js --version', {
             cwd: join(__dirname, '..'),
             encoding: 'utf-8',
         });
-        assert.strictEqual(output.trim(), '0.0.0-dev');
+        assert.strictEqual(output.trim(), pkg.version);
     });
 
     it('outputs the package version when run via esbuild bundle', () => {

--- a/tools/flashview-cli/tests/regression-pio40.test.js
+++ b/tools/flashview-cli/tests/regression-pio40.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+
+/**
+ * PIO-40 Regression: CLI shows 0.0.0-dev after npm update instead of actual version
+ *
+ * When installed via npm, bin/flashview.js imports raw source where __VERSION__
+ * (injected by esbuild) is never defined. The fallback was hardcoded to '0.0.0-dev'
+ * instead of reading from package.json.
+ */
+describe('PIO-40 Regression: CLI version from source is not 0.0.0-dev', () => {
+    it('does not report 0.0.0-dev when run from source', () => {
+        const output = execSync('node bin/flashview.js --version', {
+            cwd: join(__dirname, '..'),
+            encoding: 'utf-8',
+        });
+        assert.notStrictEqual(output.trim(), '0.0.0-dev',
+            'CLI should not report 0.0.0-dev when run from source files');
+    });
+
+    it('reports the version from package.json when run from source', () => {
+        const output = execSync('node bin/flashview.js --version', {
+            cwd: join(__dirname, '..'),
+            encoding: 'utf-8',
+        });
+        assert.strictEqual(output.trim(), pkg.version);
+    });
+});


### PR DESCRIPTION
## Summary

- Fix `flashview --version` reporting `0.0.0-dev` when installed via npm (raw source without esbuild bundle)
- Read version from `package.json` at runtime via `createRequire` when `__VERSION__` is not injected by esbuild
- SEA binaries are unaffected — `__VERSION__` is always injected at build time

## Changes

| File | Change |
|------|--------|
| `tools/flashview-cli/src/cli.js` | Add `createRequire` import, replace `'0.0.0-dev'` fallback with `package.json` read |
| `tools/flashview-cli/tests/cli.test.js` | Update version test to expect `pkg.version` instead of `'0.0.0-dev'` |
| `tools/flashview-cli/tests/regression-pio40.test.js` | New regression test asserting version is not `0.0.0-dev` |

## Test plan

- [ ] `node bin/flashview.js --version` outputs `1.6.0` (not `0.0.0-dev`)
- [ ] `npm run build:bundle && node dist/flashview.cjs --version` outputs `1.6.0`
- [ ] `npm test` passes all 74 tests
- [ ] `npm install -g . && flashview --version` outputs `1.6.0`

Closes PIO-40