### PR TITLE
Remove Docs link from footer

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -423,9 +423,6 @@ const logout = () => {
                                         <Link :href="route('plans.index')" class="hover:underline">Pricing</Link>
                                     </li>
                                     <li>
-                                        <div class="flex flex-wrap gap-2"><a href="https://docs.flashview.link" target="_blank" class="hover:underline">Docs</a></div>
-                                    </li>
-                                    <li>
                                         <Link :href="route('cli.index')" class="hover:underline">CLI Tool</Link>
                                     </li>
                                     <li>


### PR DESCRIPTION
## Summary
- Remove the external Docs link (`docs.flashview.link`) from the footer Resources column in `AppLayout.vue`

## Changes
- **Modified:** `resources/js/Layouts/AppLayout.vue` — removed 3-line `<li>` block containing the Docs link

## Regression Risk
Low — purely subtractive change to a static link with no dynamic behavior, props, or route bindings.

## Test plan
- [ ] Visit the homepage as a guest and verify the Docs link is no longer in the footer
- [ ] Log in and verify the Docs link is no longer in the footer
- [ ] Verify remaining footer Resource links (F.A.Q, Use Cases, Pricing, CLI Tool, Webhooks) are intact and functional
- [ ] Spot-check the footer on other pages for consistency

Resolves: PIO-46