### PR TITLE
Prevent email enumeration on signup page (PIO-45)

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\CompleteRegistrationRequest;
+use App\Http\Requests\Auth\InitiateRegistrationRequest;
+use App\Models\User;
+use App\Notifications\DuplicateRegistrationAttemptNotification;
+use App\Notifications\RegistrationVerificationNotification;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class RegisterController extends Controller
+{
+    /**
+     * Step 1: Show email-only registration form.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('Auth/Register');
+    }
+
+    /**
+     * Step 1: Process email — send verification or alert, always redirect to success.
+     */
+    public function store(InitiateRegistrationRequest $request): RedirectResponse
+    {
+        $email = config('fortify.lowercase_usernames')
+            ? Str::lower($request->validated('email'))
+            : $request->validated('email');
+
+        $existingUser = User::where('email', $email)->first();
+
+        if ($existingUser) {
+            $existingUser->notify(new DuplicateRegistrationAttemptNotification($request->ip()));
+        } else {
+            $signedUrl = URL::temporarySignedRoute(
+                'register.complete',
+                now()->addMinutes(120),
+                ['email' => $email]
+            );
+
+            Notification::route('mail', $email)
+                ->notify(new RegistrationVerificationNotification($signedUrl));
+        }
+
+        return redirect()->route('register.success');
+    }
+
+    /**
+     * Generic success page — shown for both new and existing emails.
+     */
+    public function success(): Response
+    {
+        return Inertia::render('Auth/RegisterSuccess');
+    }
+
+    /**
+     * Step 2: Show full registration form (email pre-filled, read-only).
+     * Route has 'signed' middleware — invalid/expired signatures are rejected automatically.
+     */
+    public function complete(Request $request): Response|RedirectResponse
+    {
+        $email = $request->query('email');
+
+        if (User::where('email', $email)->exists()) {
+            return redirect()->route('login')
+                ->with('status', 'You already have an account. Please log in.');
+        }
+
+        return Inertia::render('Auth/RegisterComplete', [
+            'email' => $email,
+            'signedUrl' => $request->fullUrl(),
+        ]);
+    }
+
+    /**
+     * Step 2: Create the user account and log in.
+     */
+    public function storeComplete(CompleteRegistrationRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $email = config('fortify.lowercase_usernames')
+            ? Str::lower($validated['email'])
+            : $validated['email'];
+
+        try {
+            $user = User::create([
+                'name' => $validated['name'],
+                'email' => $email,
+                'password' => Hash::make($validated['password']),
+            ]);
+
+            $user->markEmailAsVerified();
+
+            event(new Registered($user));
+
+            Auth::login($user);
+
+            $request->session()->regenerate();
+
+            return redirect()->route('dashboard');
+        } catch (UniqueConstraintViolationException) {
+            return redirect()->route('login')
+                ->with('status', 'You already have an account. Please log in.');
+        }
+    }
+}

--- a/app/Http/Requests/Auth/CompleteRegistrationRequest.php
+++ b/app/Http/Requests/Auth/CompleteRegistrationRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use App\Actions\Fortify\PasswordValidationRules;
+use Illuminate\Foundation\Http\FormRequest;
+use Laravel\Jetstream\Jetstream;
+
+class CompleteRegistrationRequest extends FormRequest
+{
+    use PasswordValidationRules;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email:rfc,dns', 'max:255'],
+            'name' => ['required', 'string', 'max:255'],
+            'password' => $this->passwordRules(),
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/InitiateRegistrationRequest.php
+++ b/app/Http/Requests/Auth/InitiateRegistrationRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InitiateRegistrationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email:rfc,dns', 'max:255'],
+        ];
+    }
+}

--- a/app/Notifications/DuplicateRegistrationAttemptNotification.php
+++ b/app/Notifications/DuplicateRegistrationAttemptNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DuplicateRegistrationAttemptNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $ipAddress) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Already Have an Account?')
+            ->line('It looks like you (or someone else) tried to create an account with this email address. You already have an account with us.')
+            ->line('If you were trying to sign up again, you can log in instead.')
+            ->action('Log In', url('/login'))
+            ->line('Forgot your password? [Reset it here]('.url('/forgot-password').').')
+            ->line('If this was not you, no action is needed — your account is secure.');
+    }
+}

--- a/app/Notifications/DuplicateRegistrationAttemptNotification.php
+++ b/app/Notifications/DuplicateRegistrationAttemptNotification.php
@@ -27,8 +27,8 @@ class DuplicateRegistrationAttemptNotification extends Notification implements S
             ->subject('Already Have an Account?')
             ->line('It looks like you (or someone else) tried to create an account with this email address. You already have an account with us.')
             ->line('If you were trying to sign up again, you can log in instead.')
-            ->action('Log In', url('/login'))
-            ->line('Forgot your password? [Reset it here]('.url('/forgot-password').').')
+            ->action('Log In', route('login'))
+            ->line('Forgot your password? [Reset it here]('.route('password.request').').')
             ->line('If this was not you, no action is needed — your account is secure.');
     }
 }

--- a/app/Notifications/RegistrationVerificationNotification.php
+++ b/app/Notifications/RegistrationVerificationNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class RegistrationVerificationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $signedUrl) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Verify Your Email to Complete Registration')
+            ->line('Click the button below to verify your email address and complete your registration.')
+            ->action('Complete Registration', $this->signedUrl)
+            ->line('This link will expire in 2 hours.')
+            ->line('If you did not request this, no action is needed.');
+    }
+}

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -2,24 +2,17 @@
 import { Head, Link, useForm } from '@inertiajs/vue3';
 import AuthenticationCard from '@/Components/AuthenticationCard.vue';
 import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
-import Checkbox from '@/Components/Checkbox.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
 
 const form = useForm({
-    name: '',
     email: '',
-    password: '',
-    password_confirmation: '',
-    terms: false,
 });
 
 const submit = () => {
-    form.post(route('register'), {
-        onFinish: () => form.reset('password', 'password_confirmation'),
-    });
+    form.post(route('register.store'));
 };
 </script>
 
@@ -33,20 +26,6 @@ const submit = () => {
 
         <form @submit.prevent="submit">
             <div>
-                <InputLabel for="name" value="Name" />
-                <TextInput
-                    id="name"
-                    v-model="form.name"
-                    type="text"
-                    class="mt-1 block w-full"
-                    required
-                    autofocus
-                    autocomplete="name"
-                />
-                <InputError class="mt-2" :message="form.errors.name" />
-            </div>
-
-            <div class="mt-4">
                 <InputLabel for="email" value="Email" />
                 <TextInput
                     id="email"
@@ -54,48 +33,10 @@ const submit = () => {
                     type="email"
                     class="mt-1 block w-full"
                     required
+                    autofocus
                     autocomplete="username"
                 />
                 <InputError class="mt-2" :message="form.errors.email" />
-            </div>
-
-            <div class="mt-4">
-                <InputLabel for="password" value="Password" />
-                <TextInput
-                    id="password"
-                    v-model="form.password"
-                    type="password"
-                    class="mt-1 block w-full"
-                    required
-                    autocomplete="new-password"
-                />
-                <InputError class="mt-2" :message="form.errors.password" />
-            </div>
-
-            <div class="mt-4">
-                <InputLabel for="password_confirmation" value="Confirm Password" />
-                <TextInput
-                    id="password_confirmation"
-                    v-model="form.password_confirmation"
-                    type="password"
-                    class="mt-1 block w-full"
-                    required
-                    autocomplete="new-password"
-                />
-                <InputError class="mt-2" :message="form.errors.password_confirmation" />
-            </div>
-
-            <div v-if="$page.props.jetstream.hasTermsAndPrivacyPolicyFeature" class="mt-4">
-                <InputLabel for="terms">
-                    <div class="flex items-center">
-                        <Checkbox id="terms" v-model:checked="form.terms" name="terms" required />
-
-                        <div class="ms-2">
-                            I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">Privacy Policy</a>
-                        </div>
-                    </div>
-                    <InputError class="mt-2" :message="form.errors.terms" />
-                </InputLabel>
             </div>
 
             <div class="flex items-center justify-end mt-4">
@@ -104,7 +45,7 @@ const submit = () => {
                 </Link>
 
                 <PrimaryButton class="ms-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    Register
+                    Continue
                 </PrimaryButton>
             </div>
         </form>

--- a/resources/js/Pages/Auth/RegisterComplete.vue
+++ b/resources/js/Pages/Auth/RegisterComplete.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { Head, useForm } from '@inertiajs/vue3';
+import AuthenticationCard from '@/Components/AuthenticationCard.vue';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+
+const props = defineProps({
+    email: String,
+    signedUrl: String,
+});
+
+const form = useForm({
+    email: props.email,
+    name: '',
+    password: '',
+    password_confirmation: '',
+    terms: false,
+});
+
+const submit = () => {
+    // Build the POST URL with the signed query parameters preserved.
+    // Laravel's 'signed' middleware validates the signature from query params, not POST body.
+    const signed = new URL(props.signedUrl);
+    const postUrl = route('register.complete.store')
+        + '?email=' + encodeURIComponent(signed.searchParams.get('email'))
+        + '&expires=' + signed.searchParams.get('expires')
+        + '&signature=' + signed.searchParams.get('signature');
+
+    form.post(postUrl, {
+        onFinish: () => form.reset('password', 'password_confirmation'),
+    });
+};
+</script>
+
+<template>
+    <Head title="Complete Registration" />
+
+    <AuthenticationCard>
+        <template #logo>
+            <AuthenticationCardLogo />
+        </template>
+
+        <form @submit.prevent="submit">
+            <div>
+                <InputLabel for="email" value="Email" />
+                <TextInput
+                    id="email"
+                    :model-value="email"
+                    type="email"
+                    class="mt-1 block w-full bg-gray-100 dark:bg-gray-800"
+                    disabled
+                />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Email verified. This cannot be changed.
+                </p>
+            </div>
+
+            <div class="mt-4">
+                <InputLabel for="name" value="Name" />
+                <TextInput
+                    id="name"
+                    v-model="form.name"
+                    type="text"
+                    class="mt-1 block w-full"
+                    required
+                    autofocus
+                    autocomplete="name"
+                />
+                <InputError class="mt-2" :message="form.errors.name" />
+            </div>
+
+            <div class="mt-4">
+                <InputLabel for="password" value="Password" />
+                <TextInput
+                    id="password"
+                    v-model="form.password"
+                    type="password"
+                    class="mt-1 block w-full"
+                    required
+                    autocomplete="new-password"
+                />
+                <InputError class="mt-2" :message="form.errors.password" />
+            </div>
+
+            <div class="mt-4">
+                <InputLabel for="password_confirmation" value="Confirm Password" />
+                <TextInput
+                    id="password_confirmation"
+                    v-model="form.password_confirmation"
+                    type="password"
+                    class="mt-1 block w-full"
+                    required
+                    autocomplete="new-password"
+                />
+                <InputError class="mt-2" :message="form.errors.password_confirmation" />
+            </div>
+
+            <div v-if="$page.props.jetstream.hasTermsAndPrivacyPolicyFeature" class="mt-4">
+                <InputLabel for="terms">
+                    <div class="flex items-center">
+                        <Checkbox id="terms" v-model:checked="form.terms" name="terms" required />
+
+                        <div class="ms-2">
+                            I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">Privacy Policy</a>
+                        </div>
+                    </div>
+                    <InputError class="mt-2" :message="form.errors.terms" />
+                </InputLabel>
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <PrimaryButton class="ms-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Register
+                </PrimaryButton>
+            </div>
+        </form>
+    </AuthenticationCard>
+</template>

--- a/resources/js/Pages/Auth/RegisterSuccess.vue
+++ b/resources/js/Pages/Auth/RegisterSuccess.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import AuthenticationCard from '@/Components/AuthenticationCard.vue';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+</script>
+
+<template>
+    <Head title="Check Your Email" />
+
+    <AuthenticationCard>
+        <template #logo>
+            <AuthenticationCardLogo />
+        </template>
+
+        <div class="text-center">
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                Check your email
+            </h2>
+
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                We've sent a verification link to your email address.
+                Please check your inbox and click the link to continue your registration.
+            </p>
+
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-500">
+                Didn't receive it? Check your spam or junk folder, or
+                <Link :href="route('register')" class="underline hover:text-gray-700 dark:hover:text-gray-300">go back and try again</Link>.
+            </p>
+
+            <div class="mt-6">
+                <Link
+                    :href="route('login')"
+                    class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                >
+                    Back to Login
+                </Link>
+            </div>
+        </div>
+    </AuthenticationCard>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\CliInstallationController;
 use App\Http\Controllers\MarkdownDocumentController;
@@ -13,7 +14,6 @@ use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
-use Laravel\Fortify\Http\Controllers\RegisteredUserController;
 use Laravel\Fortify\RoutePath;
 use Laravel\Jetstream\Http\Controllers\Inertia\ApiTokenController;
 
@@ -43,10 +43,32 @@ Route::controller(MarkdownDocumentController::class)->group(function () {
     Route::get('/webhooks', 'webhooks')->name('webhooks.index');
 });
 
+// Intentional override of Fortify's registration routes to prevent email enumeration (PIO-45).
+// Two-step registration: email verification first, then complete registration via signed URL.
+// Fortify registers its own routes via routes/routes.php; these take precedence because
+// they are registered later. Do NOT remove without also addressing the email enumeration vulnerability.
 Route::middleware(config('fortify.middleware', ['web']))->group(function () {
-    Route::post(RoutePath::for('register', '/register'), [RegisteredUserController::class, 'store'])
+    // Step 1: Email collection
+    Route::get(RoutePath::for('register', '/register'), [RegisterController::class, 'create'])
+        ->middleware(['guest:'.config('fortify.guard')])
+        ->name('register');
+
+    Route::post(RoutePath::for('register', '/register'), [RegisterController::class, 'store'])
         ->middleware(['guest:'.config('fortify.guard'), 'throttle:signup'])
         ->name('register.store');
+
+    Route::get('/register/success', [RegisterController::class, 'success'])
+        ->middleware(['guest:'.config('fortify.guard')])
+        ->name('register.success');
+
+    // Step 2: Complete registration (signed URL from verification email)
+    Route::get('/register/complete', [RegisterController::class, 'complete'])
+        ->middleware(['guest:'.config('fortify.guard'), 'signed'])
+        ->name('register.complete');
+
+    Route::post('/register/complete', [RegisterController::class, 'storeComplete'])
+        ->middleware(['guest:'.config('fortify.guard'), 'signed', 'throttle:signup'])
+        ->name('register.complete.store');
 });
 
 // CLI Authorization Flow (auth required — Fortify handles redirect-to-login automatically)

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -2,7 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\Auth\RegisterController;
+use App\Models\User;
+use App\Notifications\DuplicateRegistrationAttemptNotification;
+use App\Notifications\RegistrationVerificationNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
@@ -33,15 +39,183 @@ class RegistrationTest extends TestCase
         $response->assertStatus(404);
     }
 
-    public function test_new_users_can_register(): void
+    public function test_step1_new_email_redirects_to_success(): void
     {
         if (! Features::enabled(Features::registration())) {
             $this->markTestSkipped('Registration support is not enabled.');
         }
 
+        Notification::fake();
+
         $response = $this->post('/register', [
-            'name' => 'Test User',
-            'email' => 'test@gmail.com',
+            'email' => 'newuser@gmail.com',
+        ]);
+
+        $response->assertRedirect(route('register.success'));
+
+        Notification::assertSentOnDemand(RegistrationVerificationNotification::class);
+    }
+
+    public function test_step1_existing_email_redirects_to_same_success(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'existing@gmail.com']);
+
+        $response = $this->post('/register', [
+            'email' => 'existing@gmail.com',
+        ]);
+
+        $response->assertRedirect(route('register.success'));
+
+        Notification::assertSentTo($user, DuplicateRegistrationAttemptNotification::class);
+    }
+
+    public function test_step1_responses_are_identical_for_new_and_existing_emails(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        Notification::fake();
+
+        User::factory()->create(['email' => 'existing@gmail.com']);
+
+        $responseExisting = $this->post('/register', [
+            'email' => 'existing@gmail.com',
+        ]);
+
+        $responseNew = $this->post('/register', [
+            'email' => 'brand-new@gmail.com',
+        ]);
+
+        $this->assertEquals($responseExisting->getStatusCode(), $responseNew->getStatusCode());
+        $this->assertEquals($responseExisting->headers->get('Location'), $responseNew->headers->get('Location'));
+    }
+
+    public function test_step2_valid_signed_url_shows_registration_form(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => 'newuser@gmail.com']
+        );
+
+        $response = $this->get($signedUrl);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_step2_expired_signed_url_is_rejected(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->subMinute(),
+            ['email' => 'newuser@gmail.com']
+        );
+
+        $response = $this->get($signedUrl);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_step2_tampered_signed_url_is_rejected(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => 'newuser@gmail.com']
+        );
+
+        // Tamper with the email parameter
+        $tamperedUrl = str_replace('newuser%40gmail.com', 'hacker%40gmail.com', $signedUrl);
+
+        $response = $this->get($tamperedUrl);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_step2_reused_link_after_registration_redirects_to_login(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $email = 'newuser@gmail.com';
+
+        User::factory()->create(['email' => $email]);
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => $email]
+        );
+
+        $response = $this->get($signedUrl);
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_step2_unsigned_url_is_rejected(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get('/register/complete?email=newuser@gmail.com');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_full_registration_flow(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        Notification::fake();
+
+        // Step 1: Submit email
+        $response = $this->post('/register', [
+            'email' => 'newuser@gmail.com',
+        ]);
+
+        $response->assertRedirect(route('register.success'));
+
+        // Step 2: Use signed URL to complete registration
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => 'newuser@gmail.com']
+        );
+
+        $parsedUrl = parse_url($signedUrl);
+        parse_str($parsedUrl['query'], $queryParams);
+
+        $postUrl = route('register.complete.store')
+            .'?email='.urlencode($queryParams['email'])
+            .'&expires='.$queryParams['expires']
+            .'&signature='.$queryParams['signature'];
+
+        $response = $this->post($postUrl, [
+            'email' => 'newuser@gmail.com',
+            'name' => 'New User',
             'password' => 'password',
             'password_confirmation' => 'password',
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
@@ -49,5 +223,62 @@ class RegistrationTest extends TestCase
 
         $this->assertAuthenticated();
         $response->assertRedirect(route('dashboard', absolute: false));
+
+        $user = User::where('email', 'newuser@gmail.com')->first();
+        $this->assertNotNull($user);
+        $this->assertNotNull($user->email_verified_at);
+    }
+
+    public function test_register_route_resolves_to_custom_controller(): void
+    {
+        $route = app('router')->getRoutes()->getByName('register.store');
+
+        $this->assertNotNull($route);
+        $this->assertStringContainsString(
+            RegisterController::class,
+            $route->getActionName()
+        );
+    }
+
+    public function test_success_page_can_be_rendered(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get(route('register.success'));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_step2_post_with_expired_signature_is_rejected(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->subMinute(),
+            ['email' => 'newuser@gmail.com']
+        );
+
+        $parsedUrl = parse_url($signedUrl);
+        parse_str($parsedUrl['query'], $queryParams);
+
+        $postUrl = route('register.complete.store')
+            .'?email='.urlencode($queryParams['email'])
+            .'&expires='.$queryParams['expires']
+            .'&signature='.$queryParams['signature'];
+
+        $response = $this->post($postUrl, [
+            'email' => 'newuser@gmail.com',
+            'name' => 'New User',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
+        ]);
+
+        $response->assertStatus(403);
     }
 }

--- a/tests/Feature/Regressions/PIO45Test.php
+++ b/tests/Feature/Regressions/PIO45Test.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
+use Laravel\Jetstream\Jetstream;
+use Tests\TestCase;
+
+/**
+ * PIO-45: Email enumeration on signup page — POST /register with an existing
+ * email returns "The email has already been taken", allowing attackers to
+ * enumerate registered users.
+ */
+class PIO45Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_does_not_reveal_existing_email(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        User::factory()->create(['email' => 'taken@gmail.com']);
+
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'taken@gmail.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
+        ]);
+
+        // The response must NOT expose validation errors revealing the email is taken.
+        // With Fortify + Inertia, duplicate email returns a redirect with session errors.
+        $response->assertSessionHasNoErrors();
+
+        // Should not return a 422 validation error for duplicate email
+        $this->assertNotEquals(422, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes email enumeration vulnerability on registration page ([GHSA-wvq5-2hpw-r6v3](https://github.com/pioneer-dynamics/FlashView/security/advisories/GHSA-wvq5-2hpw-r6v3))
- Replaces Fortify's single-step registration with a two-step flow: step 1 collects email only and returns a uniform "check your email" response regardless of whether the email exists; step 2 completes registration via a temporary signed URL that proves email ownership
- Both new and existing email submissions return identical responses, eliminating information leakage
- Auto-login preserved for new users after completing step 2; email marked as verified (signed URL = proof of ownership)

## Changes

**New files:**
- `RegisterController` — custom controller with 5 actions (`create`, `store`, `success`, `complete`, `storeComplete`)
- `InitiateRegistrationRequest` / `CompleteRegistrationRequest` — form request validation
- `RegistrationVerificationNotification` — sends signed URL to new emails
- `DuplicateRegistrationAttemptNotification` — alerts existing users of signup attempts
- `RegisterComplete.vue` / `RegisterSuccess.vue` — step 2 form and "check your email" page

**Modified files:**
- `Register.vue` — simplified to email-only form
- `routes/web.php` — overrides Fortify registration routes with documented comment

**Unchanged (by design):**
- `CreateNewUser` — retains `unique:users` as defense-in-depth against Fortify route regressions

## Regression risks

- **Team invitation email** links to `route('register')` which now shows the email-only step 1 instead of the full form. The link works but adds friction for invited users. Recommend a follow-up ticket to pass the invited email through to pre-fill step 1.
- **6 pages/components** link to `route('register')` — all links resolve correctly but destination UX has changed from single form to multi-step flow.

## Test plan

- [x] Regression test proves vulnerability existed and is now fixed (317 tests, 0 failures)
- [x] Step 1: new email → success page, verification notification sent
- [x] Step 1: existing email → identical success page, alert notification sent
- [x] Step 1: responses are identical for both paths (status code, redirect target)
- [x] Step 2: valid signed URL → shows full registration form
- [x] Step 2: expired signed URL → 403
- [x] Step 2: tampered signed URL → 403
- [x] Step 2: unsigned URL → 403
- [x] Step 2: reused link after registration → redirect to login
- [x] Step 2: POST with expired signature → 403
- [x] Full end-to-end flow → authenticated, redirected to dashboard, email verified
- [x] Route resolves to custom RegisterController, not Fortify's
- [x] Manual: verify email content for both notification types
- [x] Manual: verify frontend styling matches auth pages (dark mode)