### PR TITLE
Fix CLI auth device name not read-only for existing devices (PIO-41)

### DIFF
--- a/app/Http/Controllers/CliAuthController.php
+++ b/app/Http/Controllers/CliAuthController.php
@@ -22,7 +22,16 @@ class CliAuthController extends Controller
     {
         $user = $request->user();
 
-        $latestCliToken = $user->tokens()
+        $tokenId = $request->validated('token_id');
+
+        $existingToken = $tokenId
+            ? $user->tokens()
+                ->where('type', 'cli')
+                ->where('id', $tokenId)
+                ->first()
+            : null;
+
+        $latestCliToken = $existingToken ?? $user->tokens()
             ->where('type', 'cli')
             ->latest('id')
             ->first();
@@ -38,6 +47,7 @@ class CliAuthController extends Controller
             'hasApiAccess' => $user->hasApiAccess(),
             'availablePermissions' => Jetstream::$permissions,
             'defaultPermissions' => $defaultPermissions,
+            'existingDeviceName' => $existingToken?->name,
         ]);
     }
 

--- a/app/Http/Requests/CliAuthorizeRequest.php
+++ b/app/Http/Requests/CliAuthorizeRequest.php
@@ -21,6 +21,7 @@ class CliAuthorizeRequest extends FormRequest
             'port' => ['required', 'integer', 'min:1024', 'max:65535'],
             'state' => ['required', 'string', 'min:16'],
             'name' => ['nullable', 'string', 'max:255'],
+            'token_id' => ['nullable', 'integer'],
         ];
     }
 }

--- a/resources/js/Pages/Cli/Authorize.vue
+++ b/resources/js/Pages/Cli/Authorize.vue
@@ -16,12 +16,16 @@ const props = defineProps({
     hasApiAccess: Boolean,
     availablePermissions: Array,
     defaultPermissions: Array,
+    existingDeviceName: {
+        type: String,
+        default: null,
+    },
 })
 
 const page = usePage()
 const processing = ref(false)
 const selectedPermissions = ref([...props.defaultPermissions])
-const installationName = ref(props.name || '')
+const installationName = ref(props.existingDeviceName || props.name || '')
 
 function submit(action) {
     processing.value = true
@@ -73,22 +77,41 @@ function submit(action) {
                 The FlashView CLI is requesting access to create an API token
                 for your account ({{ page.props.auth.user.email }}).
             </p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 text-center">
+            <p v-if="existingDeviceName" class="mt-1 text-xs text-gray-500 dark:text-gray-400 text-center">
+                Re-authorizing your existing CLI installation. Your token will be refreshed with the selected permissions.
+            </p>
+            <p v-else class="mt-1 text-xs text-gray-500 dark:text-gray-400 text-center">
                 This will create a new CLI installation. Your existing CLI connections will not be affected.
             </p>
 
             <div class="mt-4">
                 <InputLabel for="installation-name" value="Installation Name" />
-                <TextInput
-                    id="installation-name"
-                    v-model="installationName"
-                    type="text"
-                    class="mt-1 block w-full"
-                    placeholder="e.g., Work Laptop, CI Server"
-                />
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Give this device a name so you can identify it later.
-                </p>
+
+                <!-- Existing device: read-only display -->
+                <div v-if="existingDeviceName" class="mt-1">
+                    <p class="px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100">
+                        {{ existingDeviceName }}
+                    </p>
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        This device was previously authorized. To use a different name, remove the existing installation from your
+                        <Link :href="route('api-tokens.index')" class="underline hover:text-gray-700 dark:hover:text-gray-200">API Tokens</Link>
+                        page first.
+                    </p>
+                </div>
+
+                <!-- New device: editable input -->
+                <div v-else>
+                    <TextInput
+                        id="installation-name"
+                        v-model="installationName"
+                        type="text"
+                        class="mt-1 block w-full"
+                        placeholder="e.g., Work Laptop, CI Server"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Give this device a name so you can identify it later.
+                    </p>
+                </div>
             </div>
 
             <div v-if="availablePermissions?.length" class="mt-4 rounded-md bg-gray-50 dark:bg-gray-800 p-3">
@@ -119,6 +142,7 @@ function submit(action) {
                     :disabled="processing || selectedPermissions.length === 0"
                 >
                     <span v-if="processing">Authorizing...</span>
+                    <span v-else-if="existingDeviceName">Re-authorize</span>
                     <span v-else>Approve</span>
                 </PrimaryButton>
             </div>

--- a/tests/Feature/CliAuthTest.php
+++ b/tests/Feature/CliAuthTest.php
@@ -385,4 +385,154 @@ class CliAuthTest extends TestCase
             ->where('defaultPermissions', Jetstream::$defaultPermissions)
         );
     }
+
+    public function test_authorize_page_returns_existing_device_name_when_valid_token_id_sent(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $token = $user->createToken('My Laptop', ['secrets:create']);
+        $token->accessToken->update(['type' => 'cli']);
+        $tokenId = $token->accessToken->id;
+
+        $response = $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&token_id={$tokenId}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', 'My Laptop')
+        );
+    }
+
+    public function test_authorize_page_returns_null_existing_device_name_when_token_id_not_found(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $response = $this->actingAs($user)
+            ->get('/cli/authorize?port=12345&state=abcdef1234567890&token_id=99999');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', null)
+        );
+    }
+
+    public function test_authorize_page_returns_null_existing_device_name_when_token_id_not_provided(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        $response = $this->actingAs($user)
+            ->get('/cli/authorize?port=12345&state=abcdef1234567890');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', null)
+        );
+    }
+
+    public function test_authorize_page_returns_null_existing_device_name_for_non_cli_token(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        // Create a non-CLI (api) token
+        $token = $user->createToken('API Token', ['secrets:create']);
+        $tokenId = $token->accessToken->id;
+
+        $response = $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&token_id={$tokenId}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', null)
+        );
+    }
+
+    public function test_authorize_page_shows_stored_name_even_when_user_renamed_token(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        // Create CLI token with original name, then rename it (simulating rename via API tokens page)
+        $token = $user->createToken('Original Name', ['secrets:create']);
+        $token->accessToken->update(['type' => 'cli', 'name' => 'Renamed Device']);
+        $tokenId = $token->accessToken->id;
+
+        // CLI sends hostname, but token_id points to the renamed token
+        $response = $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&name=some-hostname&token_id={$tokenId}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', 'Renamed Device')
+        );
+    }
+
+    public function test_authorize_page_does_not_leak_other_users_token(): void
+    {
+        $user = $this->createUserWithApiAccess();
+        $otherUser = $this->createUserWithApiAccess();
+
+        $token = $otherUser->createToken('Other User Laptop', ['secrets:create']);
+        $token->accessToken->update(['type' => 'cli']);
+        $tokenId = $token->accessToken->id;
+
+        $response = $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&token_id={$tokenId}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            ->where('existingDeviceName', null)
+        );
+    }
+
+    public function test_end_to_end_reauthorization_with_token_id(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        // Step 1: Create existing CLI token (simulates first authorization)
+        $existingToken = $user->createToken('MyMachine', ['secrets:create']);
+        $existingToken->accessToken->update(['type' => 'cli']);
+        $tokenId = $existingToken->accessToken->id;
+
+        // Step 2: GET authorize with token_id — verify existing device detected
+        $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&name=MyMachine.local&token_id={$tokenId}")
+            ->assertInertia(fn ($page) => $page
+                ->where('existingDeviceName', 'MyMachine')
+            );
+
+        // Step 3: POST authorize with the stored name (as the frontend would submit)
+        $response = $this->actingAs($user)
+            ->post('/cli/authorize', [
+                'port' => 12345,
+                'state' => 'abcdef1234567890',
+                'action' => 'approve',
+                'permissions' => ['secrets:create', 'secrets:list'],
+                'name' => 'MyMachine',
+            ]);
+
+        $response->assertRedirect();
+        $location = $response->headers->get('Location');
+        $parsed = parse_url($location);
+        parse_str($parsed['query'], $query);
+        $code = $query['code'];
+
+        // Step 4: Exchange the code for a new token
+        $exchangeResponse = $this->postJson('/cli/token', [
+            'code' => $code,
+            'state' => 'abcdef1234567890',
+        ]);
+
+        $exchangeResponse->assertOk();
+        $exchangeResponse->assertJsonPath('installation_name', 'MyMachine');
+
+        // Step 5: Verify old token was replaced and new token has the stored name
+        $tokens = $user->fresh()->tokens()->where('type', 'cli')->get();
+        $this->assertCount(1, $tokens);
+        $this->assertEquals('MyMachine', $tokens->first()->name);
+    }
 }

--- a/tests/Feature/Regressions/PIO41Test.php
+++ b/tests/Feature/Regressions/PIO41Test.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * PIO-41: When a CLI token already exists for a device, the authorize page
+ * should display the stored device name as read-only text instead of an
+ * editable field pre-filled with the CLI-sent hostname.
+ */
+class PIO41Test extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createUserWithApiAccess(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_pio41_'.uniqid(),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * @see https://linear.app/pioneer-dynamics/issue/PIO-41
+     *
+     * Bug: Re-authorizing an existing CLI device shows an editable name field
+     * pre-filled with the CLI-sent hostname instead of the stored device name
+     * as read-only text.
+     */
+    public function test_existing_device_shows_stored_name_as_read_only(): void
+    {
+        $user = $this->createUserWithApiAccess();
+
+        // Create an existing CLI token with a custom name (simulating first authorization
+        // where the user renamed "MyMachine.local" to "MyMachine")
+        $token = $user->createToken('MyMachine', ['secrets:create']);
+        $token->accessToken->update(['type' => 'cli']);
+        $tokenId = $token->accessToken->id;
+
+        // Second login: CLI sends hostname again, but also sends the stored token ID
+        $response = $this->actingAs($user)
+            ->get("/cli/authorize?port=12345&state=abcdef1234567890&name=MyMachine.local&token_id={$tokenId}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Cli/Authorize')
+            // The stored name "MyMachine" should be returned, not the CLI-sent "MyMachine.local"
+            ->where('existingDeviceName', 'MyMachine')
+        );
+    }
+}

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -465,7 +465,16 @@ program
 
         const { server, port } = await startCallbackServer();
 
-        const authorizeUrl = `${serverUrl}/cli/authorize?port=${port}&state=${state}&name=${encodeURIComponent(hostname())}`;
+        let authorizeUrl = `${serverUrl}/cli/authorize?port=${port}&state=${state}&name=${encodeURIComponent(hostname())}`;
+
+        // If we have an existing token, send its ID so the server can identify the device
+        const { token: existingToken } = getConfigInfo();
+        if (existingToken) {
+            const tokenId = existingToken.split('|')[0];
+            if (tokenId) {
+                authorizeUrl += `&token_id=${encodeURIComponent(tokenId)}`;
+            }
+        }
 
         const opened = await openBrowser(authorizeUrl);
         if (opened) {


### PR DESCRIPTION
## Summary

- When re-authorizing an existing CLI device, the device name field is now displayed as **read-only text** showing the stored name, instead of an editable input pre-filled with the hostname
- Uses the **token ID** (from Sanctum's `{id}|{plaintext}` format) as a stable device identifier, robust against name edits and hostname changes
- Older CLI versions without `token_id` gracefully fall back to the editable new-device flow

## Changes

- **CLI** (`tools/flashview-cli/src/cli.js`): Extracts token ID from stored config and appends `&token_id={id}` to the authorize URL on subsequent logins
- **Backend** (`CliAuthorizeRequest.php`, `CliAuthController.php`): Adds `token_id` validation; looks up existing CLI token by ID scoped to the authenticated user; passes `existingDeviceName` Inertia prop
- **Frontend** (`Authorize.vue`): Conditionally renders read-only device name with guidance link to API Tokens page, or editable input for new devices; button changes to "Re-authorize" for returning devices

## Regression risks

- Shared `CliAuthorizeRequest` accepts `token_id` in both GET and POST (harmless — only `show()` reads it)
- Sanctum `{id}|{plaintext}` token format is a stable convention but not a formal contract
- All direct consumers verified unaffected

## Test plan

- [x] Regression test: existing device returns `existingDeviceName` prop (TDD — failed before fix, passes after)
- [x] Valid `token_id` returns stored device name
- [x] Missing/invalid `token_id` returns null (new device flow)
- [x] Non-CLI token ID returns null
- [x] Renamed token returns updated stored name
- [x] Cross-user token isolation (no leakage)
- [x] End-to-end re-authorization flow with token exchange
- [x] All 42 existing CLI auth tests still pass
- [ ] Manual: verify read-only display and editable input toggle in browser