### PR TITLE
Add intermediary prompt before passkey confirmation (PIO-60)

### DIFF
--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -3,6 +3,7 @@ import { ref, reactive, computed, nextTick } from 'vue';
 import { usePage } from '@inertiajs/vue3';
 import DialogModal from './DialogModal.vue';
 import InputError from './InputError.vue';
+import PrimaryButton from './PrimaryButton.vue';
 import TextInput from './TextInput.vue';
 import ConfirmsPasskey from './ConfirmsPasskey.vue';
 
@@ -154,13 +155,13 @@ const closeModal = () => {
                         Authentication failed.
                     </div>
 
-                    <button
+                    <PrimaryButton
                         @click="usePasskey"
                         :disabled="passkeyVerifying"
-                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        class="mt-4 w-full justify-center py-3"
                     >
                         {{ passkeyVerifying ? 'Verifying...' : (passkeyFailed ? 'Retry passkey or security key' : 'Use passkey or security key') }}
-                    </button>
+                    </PrimaryButton>
                 </div>
             </template>
 
@@ -202,13 +203,13 @@ const closeModal = () => {
                         <InputError :message="form.error" class="mt-2" />
                     </div>
 
-                    <button
+                    <PrimaryButton
                         @click="confirmPassword"
                         :disabled="form.processing"
-                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        class="mt-4 w-full justify-center py-3"
                     >
                         {{ form.processing ? 'Confirming...' : button }}
-                    </button>
+                    </PrimaryButton>
 
                 </div>
             </template>

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -3,7 +3,6 @@ import { ref, reactive, computed, nextTick } from 'vue';
 import { usePage } from '@inertiajs/vue3';
 import DialogModal from './DialogModal.vue';
 import InputError from './InputError.vue';
-import SecondaryButton from './SecondaryButton.vue';
 import TextInput from './TextInput.vue';
 import ConfirmsPasskey from './ConfirmsPasskey.vue';
 
@@ -210,15 +209,14 @@ const closeModal = () => {
                     >
                         {{ form.processing ? 'Confirming...' : button }}
                     </button>
+
+                    <button @click="closeModal" class="mt-3 text-sm text-gray-500 dark:text-gray-400 hover:underline">
+                        Cancel
+                    </button>
                 </div>
             </template>
 
             <template #footer>
-                <div class="w-full text-center">
-                    <SecondaryButton @click="closeModal">
-                        Cancel
-                    </SecondaryButton>
-                </div>
             </template>
         </DialogModal>
     </span>

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -210,13 +210,15 @@ const closeModal = () => {
                         {{ form.processing ? 'Confirming...' : button }}
                     </button>
 
-                    <button @click="closeModal" class="mt-3 text-sm text-gray-500 dark:text-gray-400 hover:underline">
-                        Cancel
-                    </button>
                 </div>
             </template>
 
             <template #footer>
+                <div class="w-full text-center">
+                    <button @click="closeModal" class="text-sm text-gray-500 dark:text-gray-400 hover:underline">
+                        Cancel
+                    </button>
+                </div>
             </template>
         </DialogModal>
     </span>

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -3,7 +3,6 @@ import { ref, reactive, computed, nextTick } from 'vue';
 import { usePage } from '@inertiajs/vue3';
 import DialogModal from './DialogModal.vue';
 import InputError from './InputError.vue';
-import PrimaryButton from './PrimaryButton.vue';
 import SecondaryButton from './SecondaryButton.vue';
 import TextInput from './TextInput.vue';
 import ConfirmsPasskey from './ConfirmsPasskey.vue';
@@ -176,42 +175,50 @@ const closeModal = () => {
             </template>
         </DialogModal>
 
-        <DialogModal :show="confirmingPassword" @close="closeModal" ref="password">
+        <DialogModal :show="confirmingPassword" @close="closeModal" ref="password" max-width="sm">
             <template #title>
-                {{ title }}
+                <div class="flex flex-col items-center text-center">
+                    <svg class="w-12 h-12 text-gray-400 dark:text-gray-500 mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                    </svg>
+                    <span class="text-xl">{{ title }}</span>
+                </div>
             </template>
 
             <template #content>
-                {{ content }}
+                <div class="text-center">
+                    <p>{{ content }}</p>
 
-                <div class="mt-4">
-                    <TextInput
-                        ref="passwordInput"
-                        v-model="form.password"
-                        type="password"
-                        class="mt-1 block w-3/4"
-                        placeholder="Password"
-                        autocomplete="current-password"
-                        @keyup.enter="confirmPassword"
-                    />
+                    <div class="mt-4">
+                        <TextInput
+                            ref="passwordInput"
+                            v-model="form.password"
+                            type="password"
+                            class="w-full"
+                            placeholder="Password"
+                            autocomplete="current-password"
+                            @keyup.enter="confirmPassword"
+                        />
 
-                    <InputError :message="form.error" class="mt-2" />
+                        <InputError :message="form.error" class="mt-2" />
+                    </div>
+
+                    <button
+                        @click="confirmPassword"
+                        :disabled="form.processing"
+                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    >
+                        {{ form.processing ? 'Confirming...' : button }}
+                    </button>
                 </div>
             </template>
 
             <template #footer>
-                <SecondaryButton @click="closeModal">
-                    Cancel
-                </SecondaryButton>
-
-                <PrimaryButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                    @click="confirmPassword"
-                >
-                    {{ button }}
-                </PrimaryButton>
+                <div class="w-full text-center">
+                    <SecondaryButton @click="closeModal">
+                        Cancel
+                    </SecondaryButton>
+                </div>
             </template>
         </DialogModal>
     </span>

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -35,6 +35,7 @@ const props = defineProps({
 
 const confirmingPassword = ref(false);
 const showingAuthChoice = ref(false);
+const passkeyFailed = ref(false);
 
 const passkeyConfirmation = ref(null);
 
@@ -63,6 +64,7 @@ const startConfirmingPassword = () => {
             emit('confirmed');
         } else if (userHasPasskeys.value) {
             showingAuthChoice.value = true;
+            passkeyFailed.value = false;
         } else {
             askForPassword();
         }
@@ -70,17 +72,29 @@ const startConfirmingPassword = () => {
 };
 
 const usePasskey = () => {
-    showingAuthChoice.value = false;
+    passkeyFailed.value = false;
     passkeyConfirmation.value.start();
+};
+
+const onPasskeyConfirmed = () => {
+    showingAuthChoice.value = false;
+    passkeyFailed.value = false;
+    emit('confirmed');
+};
+
+const onPasskeyCancelled = () => {
+    passkeyFailed.value = true;
 };
 
 const usePassword = () => {
     showingAuthChoice.value = false;
+    passkeyFailed.value = false;
     askForPassword();
 };
 
 const closeAuthChoice = () => {
     showingAuthChoice.value = false;
+    passkeyFailed.value = false;
 };
 
 const confirmPassword = () => {
@@ -114,25 +128,49 @@ const closeModal = () => {
             <slot />
         </span>
 
-        <ConfirmsPasskey :email="$page.props.auth.user.email" ref="passkeyConfirmation" @confirmed="emit('confirmed')" @cancelled="askForPassword"/>
+        <ConfirmsPasskey :email="$page.props.auth.user.email" ref="passkeyConfirmation" @confirmed="onPasskeyConfirmed" @cancelled="onPasskeyCancelled"/>
 
-        <DialogModal :show="showingAuthChoice" @close="closeAuthChoice">
+        <DialogModal :show="showingAuthChoice" @close="closeAuthChoice" max-width="sm">
             <template #title>
-                {{ title }}
+                <div class="flex flex-col items-center text-center">
+                    <svg class="w-12 h-12 text-gray-400 dark:text-gray-500 mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+                    </svg>
+                    <span class="text-xl">Passkey or security key</span>
+                </div>
             </template>
 
             <template #content>
-                {{ content }}
+                <div class="text-center">
+                    <p>When you are ready, authenticate using the button below.</p>
+
+                    <div v-if="passkeyFailed" class="mt-4 flex items-center gap-2 rounded-md border border-red-300 dark:border-red-600 bg-red-50 dark:bg-red-900/30 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+                        <svg class="h-5 w-5 shrink-0 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+                        </svg>
+                        Authentication failed.
+                    </div>
+
+                    <button
+                        @click="usePasskey"
+                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition"
+                    >
+                        {{ passkeyFailed ? 'Retry passkey or security key' : 'Use passkey or security key' }}
+                    </button>
+                </div>
             </template>
 
             <template #footer>
-                <SecondaryButton @click="usePassword">
-                    Use Password
-                </SecondaryButton>
-
-                <PrimaryButton class="ms-3" @click="usePasskey">
-                    Use Passkey
-                </PrimaryButton>
+                <div class="w-full">
+                    <p class="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-2">Having problems?</p>
+                    <ul class="list-disc list-inside text-sm">
+                        <li>
+                            <button @click="usePassword" class="text-blue-600 dark:text-blue-400 hover:underline">
+                                Use your password
+                            </button>
+                        </li>
+                    </ul>
+                </div>
             </template>
         </DialogModal>
 

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, reactive, nextTick } from 'vue';
+import { ref, reactive, computed, nextTick } from 'vue';
+import { usePage } from '@inertiajs/vue3';
 import DialogModal from './DialogModal.vue';
 import InputError from './InputError.vue';
 import PrimaryButton from './PrimaryButton.vue';
@@ -33,8 +34,14 @@ const props = defineProps({
 });
 
 const confirmingPassword = ref(false);
+const showingAuthChoice = ref(false);
 
 const passkeyConfirmation = ref(null);
+
+const userHasPasskeys = computed(() => {
+    const user = usePage().props.auth?.user;
+    return user?.passkeys?.length > 0;
+});
 
 const form = reactive({
     password: '',
@@ -54,10 +61,26 @@ const startConfirmingPassword = () => {
     axios.get(route('password.confirmation', props.seconds > 0 ? {seconds: props.seconds} : {})).then(response => {
         if (response.data.confirmed && !props.mandatory) {
             emit('confirmed');
+        } else if (userHasPasskeys.value) {
+            showingAuthChoice.value = true;
         } else {
-            passkeyConfirmation.value.start();
+            askForPassword();
         }
     });
+};
+
+const usePasskey = () => {
+    showingAuthChoice.value = false;
+    passkeyConfirmation.value.start();
+};
+
+const usePassword = () => {
+    showingAuthChoice.value = false;
+    askForPassword();
+};
+
+const closeAuthChoice = () => {
+    showingAuthChoice.value = false;
 };
 
 const confirmPassword = () => {
@@ -92,6 +115,26 @@ const closeModal = () => {
         </span>
 
         <ConfirmsPasskey :email="$page.props.auth.user.email" ref="passkeyConfirmation" @confirmed="emit('confirmed')" @cancelled="askForPassword"/>
+
+        <DialogModal :show="showingAuthChoice" @close="closeAuthChoice">
+            <template #title>
+                {{ title }}
+            </template>
+
+            <template #content>
+                {{ content }}
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="usePassword">
+                    Use Password
+                </SecondaryButton>
+
+                <PrimaryButton class="ms-3" @click="usePasskey">
+                    Use Passkey
+                </PrimaryButton>
+            </template>
+        </DialogModal>
 
         <DialogModal :show="confirmingPassword" @close="closeModal" ref="password">
             <template #title>

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -36,6 +36,7 @@ const props = defineProps({
 const confirmingPassword = ref(false);
 const showingAuthChoice = ref(false);
 const passkeyFailed = ref(false);
+const passkeyVerifying = ref(false);
 
 const passkeyConfirmation = ref(null);
 
@@ -73,17 +74,20 @@ const startConfirmingPassword = () => {
 
 const usePasskey = () => {
     passkeyFailed.value = false;
+    passkeyVerifying.value = true;
     passkeyConfirmation.value.start();
 };
 
 const onPasskeyConfirmed = () => {
     showingAuthChoice.value = false;
     passkeyFailed.value = false;
+    passkeyVerifying.value = false;
     emit('confirmed');
 };
 
 const onPasskeyCancelled = () => {
     passkeyFailed.value = true;
+    passkeyVerifying.value = false;
 };
 
 const usePassword = () => {
@@ -95,6 +99,7 @@ const usePassword = () => {
 const closeAuthChoice = () => {
     showingAuthChoice.value = false;
     passkeyFailed.value = false;
+    passkeyVerifying.value = false;
 };
 
 const confirmPassword = () => {
@@ -153,23 +158,20 @@ const closeModal = () => {
 
                     <button
                         @click="usePasskey"
-                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition"
+                        :disabled="passkeyVerifying"
+                        class="mt-4 w-full rounded-md bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition"
                     >
-                        {{ passkeyFailed ? 'Retry passkey or security key' : 'Use passkey or security key' }}
+                        {{ passkeyVerifying ? 'Verifying...' : (passkeyFailed ? 'Retry passkey or security key' : 'Use passkey or security key') }}
                     </button>
                 </div>
             </template>
 
             <template #footer>
-                <div class="w-full">
-                    <p class="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-2">Having problems?</p>
-                    <ul class="list-disc list-inside text-sm">
-                        <li>
-                            <button @click="usePassword" class="text-blue-600 dark:text-blue-400 hover:underline">
-                                Use your password
-                            </button>
-                        </li>
-                    </ul>
+                <div class="w-full text-sm text-gray-600 dark:text-gray-400">
+                    Having problems?
+                    <button @click="usePassword" class="text-blue-600 dark:text-blue-400 hover:underline">
+                        Use your password
+                    </button>
                 </div>
             </template>
         </DialogModal>

--- a/tests/Feature/ConfirmsPasswordOrPasskeyTest.php
+++ b/tests/Feature/ConfirmsPasswordOrPasskeyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConfirmsPasswordOrPasskeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_with_passkeys_has_passkeys_in_page_props(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $user->passkeys()->create([
+            'credential_id' => 'test-credential-id',
+            'public_key' => 'test-public-key',
+            'name' => 'Test Passkey',
+        ]);
+
+        $user->load('passkeys');
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertStatus(200);
+        $response->assertInertia(function ($page) {
+            $passkeys = data_get($page->toArray(), 'props.auth.user.passkeys', []);
+            $this->assertNotEmpty($passkeys, 'User with passkeys should have passkeys in page props');
+        });
+    }
+
+    public function test_user_without_passkeys_has_empty_passkeys_in_page_props(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertStatus(200);
+        $response->assertInertia(function ($page) {
+            $passkeys = data_get($page->toArray(), 'props.auth.user.passkeys', []);
+            $this->assertEmpty($passkeys, 'User without passkeys should have empty passkeys array');
+        });
+    }
+
+    public function test_password_confirmation_status_returns_confirmed_state(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/user/confirmed-password-status');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['confirmed']);
+    }
+
+    public function test_password_confirmation_status_respects_seconds_parameter(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/user/confirmed-password-status?seconds=60');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['confirmed']);
+    }
+
+    public function test_password_can_be_confirmed_for_protected_actions(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/user/confirm-password', [
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_invalid_password_is_rejected_for_protected_actions(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/user/confirm-password', [
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertSessionHasErrors();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an intermediary modal to `ConfirmsPasswordOrPasskey` that appears when a user with passkeys triggers a protected action, offering "Use Passkey" or "Use Password" options instead of immediately launching the browser's WebAuthn prompt
- Users without passkeys skip the intermediary and go straight to the password form
- Zero changes to consumers — all 14 existing usages across `TwoFactorAuthenticationForm`, `WebhookSettingsForm`, and `PassKeyForm` work without modification

## Regression Notes

- **Medium risk** — 3 consumer files with 14 invocation points all rely on this component. The behavioral change (intermediary modal vs. immediate passkey prompt) affects all consumers equally.
- The `userHasPasskeys` computed relies on `$page.props.auth.user.passkeys`, which is always available because the `User` model eager-loads passkeys via `protected $with = ['passkeys']`.

## Test plan

- [x] 6 feature tests passing (passkey data in props, confirmation status endpoint, password validation)
- [x] Manual: User WITH passkeys sees intermediary modal with both options
- [x] Manual: "Use Passkey" initiates browser passkey prompt
- [x] Manual: "Use Password" shows password form
- [x] Manual: Dismissing intermediary modal cancels the action
- [x] Manual: User WITHOUT passkeys goes straight to password form
- [x] Manual: Passkey cancellation/failure falls back to password form
- [x] Manual: All consumers (2FA, Webhooks, Passkeys) work correctly
- [x] Manual: `mandatory` and `seconds` props continue to work