### PR TITLE
Fix toggle contrast & split notification features (PIO-59)

### DIFF
--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -100,11 +100,11 @@ class Secret extends Model
                      * @var User $user
                      */
                     if (isset($plan['id'])) {
-                        if (($plan['settings']['notification']['email'] ?? false) && $user->notify_secret_retrieved) {
+                        if (($plan['settings']['email_notification']['email'] ?? false) && $user->notify_secret_retrieved) {
                             $user->notify(new SecretRetrievedNotification($secret));
                         }
 
-                        $planSupportsWebhook = ($plan['settings']['notification']['webhook'] ?? false);
+                        $planSupportsWebhook = ($plan['settings']['webhook_notification']['webhook'] ?? false);
                         if ($planSupportsWebhook && $user->hasWebhookConfigured()) {
                             dispatch(new SendWebhookNotification(
                                 webhookUrl: $user->webhook_url,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -121,7 +121,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
 
         $plan = $this->resolvePlan();
 
-        return $plan && ($plan->features['notification']['config']['email'] ?? false);
+        return $plan && ($plan->features['email_notification']['config']['email'] ?? false);
     }
 
     /**
@@ -135,7 +135,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
 
         $plan = $this->resolvePlan();
 
-        return $plan && ($plan->features['notification']['config']['webhook'] ?? false);
+        return $plan && ($plan->features['webhook_notification']['config']['webhook'] ?? false);
     }
 
     public function getPlanAttribute(): PlanResource

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -44,7 +44,6 @@ class PlanFactory extends Factory
                 apiType: 'missing',
                 notificationEmail: false,
                 notificationWebhook: false,
-                notificationType: 'missing',
             ),
         ]);
     }
@@ -89,7 +88,6 @@ class PlanFactory extends Factory
         string $apiType = 'feature',
         bool $notificationEmail = true,
         bool $notificationWebhook = true,
-        string $notificationType = 'feature',
     ): array {
         return [
             'untracked' => [
@@ -121,14 +119,21 @@ class PlanFactory extends Factory
                 'config' => [],
                 'type' => 'feature',
             ],
-            'notification' => [
+            'email_notification' => [
                 'order' => 4.5,
-                'label' => 'Get notified when a message is retrieved',
+                'label' => 'Email Notifications',
                 'config' => [
                     'email' => $notificationEmail,
+                ],
+                'type' => $notificationEmail ? 'feature' : 'missing',
+            ],
+            'webhook_notification' => [
+                'order' => 4.6,
+                'label' => 'Webhook Notifications',
+                'config' => [
                     'webhook' => $notificationWebhook,
                 ],
-                'type' => $notificationType,
+                'type' => $notificationWebhook ? 'feature' : 'missing',
             ],
             'support' => [
                 'order' => 5,

--- a/database/migrations/2026_04_03_111859_split_notification_into_email_and_webhook_features.php
+++ b/database/migrations/2026_04_03_111859_split_notification_into_email_and_webhook_features.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\Plan;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (! isset($features['notification'])) {
+                return;
+            }
+
+            $notification = $features['notification'];
+            $emailEnabled = $notification['config']['email'] ?? false;
+            $webhookEnabled = $notification['config']['webhook'] ?? false;
+            $baseOrder = $notification['order'] ?? 4.5;
+
+            $features['email_notification'] = [
+                'order' => $baseOrder,
+                'label' => 'Email Notifications',
+                'config' => ['email' => $emailEnabled],
+                'type' => $emailEnabled ? 'feature' : 'missing',
+            ];
+
+            $features['webhook_notification'] = [
+                'order' => $baseOrder + 0.1,
+                'label' => 'Webhook Notifications',
+                'config' => ['webhook' => $webhookEnabled],
+                'type' => $webhookEnabled ? 'feature' : 'missing',
+            ];
+
+            unset($features['notification']);
+
+            $plan->update(['features' => $features]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (! isset($features['email_notification']) && ! isset($features['webhook_notification'])) {
+                return;
+            }
+
+            $emailEnabled = $features['email_notification']['config']['email'] ?? false;
+            $webhookEnabled = $features['webhook_notification']['config']['webhook'] ?? false;
+            $order = $features['email_notification']['order'] ?? 4.5;
+
+            $type = ($emailEnabled || $webhookEnabled) ? 'feature' : 'missing';
+
+            if ($emailEnabled && $webhookEnabled) {
+                $label = 'Get notified via email or webhook when a message is retrieved';
+            } elseif ($emailEnabled) {
+                $label = 'Get notified via email when a message is retrieved';
+            } else {
+                $label = 'Get notified when a message is retrieved';
+            }
+
+            $features['notification'] = [
+                'order' => $order,
+                'label' => $label,
+                'config' => ['email' => $emailEnabled, 'webhook' => $webhookEnabled],
+                'type' => $type,
+            ];
+
+            unset($features['email_notification'], $features['webhook_notification']);
+
+            $plan->update(['features' => $features]);
+        });
+    }
+};

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -59,18 +59,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'missing',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Support',
-                        'config' => [],
-                        'type' => 'missing',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
                         ],
+                        'type' => 'missing',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Support',
+                        'config' => [],
                         'type' => 'missing',
                     ],
                     'api' => [
@@ -127,12 +127,6 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'feature',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Standard Support',
-                        'config' => [],
-                        'type' => 'feature',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
@@ -140,6 +134,12 @@ class PlanSeederLocal extends Seeder
                             'webhook' => false,
                         ],
                         'type' => 'missing',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Standard Support',
+                        'config' => [],
+                        'type' => 'feature',
                     ],
                     'api' => [
                         'order' => 6,
@@ -195,18 +195,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'feature',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Premium Support',
-                        'config' => [],
-                        'type' => 'feature',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,
                         ],
+                        'type' => 'feature',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Premium Support',
+                        'config' => [],
                         'type' => 'feature',
                     ],
                     'api' => [

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -51,11 +51,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'limit',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => false,
+                        ],
+                        'type' => 'missing',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => false,
                         ],
                         'type' => 'missing',
@@ -112,14 +119,21 @@ class PlanSeederLocal extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
-                            'webhook' => false,
                         ],
                         'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
+                            'webhook' => false,
+                        ],
+                        'type' => 'missing',
                     ],
                     'support' => [
                         'order' => 5,
@@ -173,11 +187,18 @@ class PlanSeederLocal extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email or webhook when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
+                        ],
+                        'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => true,
                         ],
                         'type' => 'feature',

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -60,7 +60,7 @@ class PlanSeederLocal extends Seeder
                         'type' => 'missing',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
@@ -128,7 +128,7 @@ class PlanSeederLocal extends Seeder
                         'type' => 'feature',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
@@ -196,7 +196,7 @@ class PlanSeederLocal extends Seeder
                         'type' => 'feature',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -59,18 +59,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'missing',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Support',
+                        'config' => [],
+                        'type' => 'missing',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
                         ],
-                        'type' => 'missing',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Support',
-                        'config' => [],
                         'type' => 'missing',
                     ],
                     'api' => [
@@ -127,6 +127,12 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'feature',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Standard Support',
+                        'config' => [],
+                        'type' => 'feature',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
@@ -134,12 +140,6 @@ class PlanSeederLocal extends Seeder
                             'webhook' => false,
                         ],
                         'type' => 'missing',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Standard Support',
-                        'config' => [],
-                        'type' => 'feature',
                     ],
                     'api' => [
                         'order' => 6,
@@ -195,18 +195,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'feature',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Premium Support',
+                        'config' => [],
+                        'type' => 'feature',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,
                         ],
-                        'type' => 'feature',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Premium Support',
-                        'config' => [],
                         'type' => 'feature',
                     ],
                     'api' => [

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -59,18 +59,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'missing',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Support',
-                        'config' => [],
-                        'type' => 'missing',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
                         ],
+                        'type' => 'missing',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Support',
+                        'config' => [],
                         'type' => 'missing',
                     ],
                     'api' => [
@@ -127,12 +127,6 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'feature',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Standard Support',
-                        'config' => [],
-                        'type' => 'feature',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
@@ -140,6 +134,12 @@ class PlanSeederProd extends Seeder
                             'webhook' => false,
                         ],
                         'type' => 'missing',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Standard Support',
+                        'config' => [],
+                        'type' => 'feature',
                     ],
                     'api' => [
                         'order' => 6,
@@ -195,18 +195,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'feature',
                     ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Premium Support',
-                        'config' => [],
-                        'type' => 'feature',
-                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,
                         ],
+                        'type' => 'feature',
+                    ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Premium Support',
+                        'config' => [],
                         'type' => 'feature',
                     ],
                     'api' => [

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -60,7 +60,7 @@ class PlanSeederProd extends Seeder
                         'type' => 'missing',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
@@ -128,7 +128,7 @@ class PlanSeederProd extends Seeder
                         'type' => 'feature',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
@@ -196,7 +196,7 @@ class PlanSeederProd extends Seeder
                         'type' => 'feature',
                     ],
                     'webhook_notification' => [
-                        'order' => 4.6,
+                        'order' => 5.5,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -59,18 +59,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'missing',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Support',
+                        'config' => [],
+                        'type' => 'missing',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => false,
                         ],
-                        'type' => 'missing',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Support',
-                        'config' => [],
                         'type' => 'missing',
                     ],
                     'api' => [
@@ -127,6 +127,12 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'feature',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Standard Support',
+                        'config' => [],
+                        'type' => 'feature',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
@@ -134,12 +140,6 @@ class PlanSeederProd extends Seeder
                             'webhook' => false,
                         ],
                         'type' => 'missing',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Standard Support',
-                        'config' => [],
-                        'type' => 'feature',
                     ],
                     'api' => [
                         'order' => 6,
@@ -195,18 +195,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'feature',
                     ],
+                    'support' => [
+                        'order' => 5,
+                        'label' => 'Premium Support',
+                        'config' => [],
+                        'type' => 'feature',
+                    ],
                     'webhook_notification' => [
                         'order' => 4.6,
                         'label' => 'Webhook Notifications',
                         'config' => [
                             'webhook' => true,
                         ],
-                        'type' => 'feature',
-                    ],
-                    'support' => [
-                        'order' => 5,
-                        'label' => 'Premium Support',
-                        'config' => [],
                         'type' => 'feature',
                     ],
                     'api' => [

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -51,11 +51,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'limit',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => false,
+                        ],
+                        'type' => 'missing',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => false,
                         ],
                         'type' => 'missing',
@@ -112,14 +119,21 @@ class PlanSeederProd extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
-                            'webhook' => false,
                         ],
                         'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
+                            'webhook' => false,
+                        ],
+                        'type' => 'missing',
                     ],
                     'support' => [
                         'order' => 5,
@@ -173,11 +187,18 @@ class PlanSeederProd extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email or webhook when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
+                        ],
+                        'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 4.6,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => true,
                         ],
                         'type' => 'feature',

--- a/resources/js/Components/ToggleButton.vue
+++ b/resources/js/Components/ToggleButton.vue
@@ -8,12 +8,14 @@
 </script>
 <template>
     <div class="flex flex-row mb-4">
-        <div class="flex flex-row gap-0 rounded-md bg-white">
-            <button 
-                v-for="option in options" 
-                @click="() => $emit('update:modelValue', option.value)" 
-                :class="{ 'bg-gamboge-300 dark:bg-gamboge-800': option.value == modelValue }"
-                class="inline-flex items-center px-4 py-2 border border-transparent rounded-md font-semibold text-xs text-gamboge-800 dark:text-gamboge-200 uppercase tracking-widest focus:outline-none disabled:opacity-50 transition ease-in-out duration-150 justify-center p-2 "
+        <div class="flex flex-row gap-0 rounded-md bg-gray-200 dark:bg-gray-700">
+            <button
+                v-for="option in options"
+                @click="() => $emit('update:modelValue', option.value)"
+                :class="option.value == modelValue
+                    ? 'bg-gamboge-500 text-white dark:bg-gamboge-600 dark:text-white'
+                    : 'text-gray-700 dark:text-gray-300'"
+                class="inline-flex items-center px-4 py-2 border border-transparent rounded-md font-semibold text-xs uppercase tracking-widest focus:outline-none disabled:opacity-50 transition ease-in-out duration-150 justify-center p-2"
                 >
                     {{ option.label }}
             </button>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -11,7 +11,7 @@ const page = usePage();
 const user = computed(() => page.props.auth.user);
 
 const planSupportsNotifications = computed(() =>
-    user.value.plan?.settings?.notification?.email ?? false
+    user.value.plan?.settings?.email_notification?.email ?? false
 );
 
 const form = useForm({

--- a/tests/Feature/Api/SecretApiTest.php
+++ b/tests/Feature/Api/SecretApiTest.php
@@ -41,11 +41,17 @@ class SecretApiTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/SecretMetadataApiTest.php
+++ b/tests/Feature/Api/SecretMetadataApiTest.php
@@ -41,11 +41,17 @@ class SecretMetadataApiTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/SecretRetrievalTest.php
+++ b/tests/Feature/Api/SecretRetrievalTest.php
@@ -45,11 +45,17 @@ class SecretRetrievalTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/WebhookApiTest.php
+++ b/tests/Feature/Api/WebhookApiTest.php
@@ -28,10 +28,16 @@ class WebhookApiTest extends TestCase
             'price_per_month' => 50,
             'price_per_year' => 500,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => true],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
+                    'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => true],
                     'type' => 'feature',
                 ],
                 'api' => [

--- a/tests/Feature/NotificationPreferencesTest.php
+++ b/tests/Feature/NotificationPreferencesTest.php
@@ -25,11 +25,17 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 25,
             'price_per_year' => 250,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
             ],
         ]);
@@ -106,10 +112,16 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 0,
             'price_per_year' => 0,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => false, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => false],
+                    'type' => 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
                     'type' => 'missing',
                 ],
             ],
@@ -141,10 +153,16 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 0,
             'price_per_year' => 0,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => false, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => false],
+                    'type' => 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
                     'type' => 'missing',
                 ],
             ],

--- a/tests/Feature/SecretRetrievedNotificationTest.php
+++ b/tests/Feature/SecretRetrievedNotificationTest.php
@@ -103,11 +103,17 @@ class SecretRetrievedNotificationTest extends TestCase
         return Plan::factory()->create([
             'name' => $enabled ? 'Pro' : 'Free',
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => $enabled],
                     'type' => $enabled ? 'feature' : 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
             ],
             'stripe_product_id' => 'prod_test',

--- a/tests/Feature/WebhookNotificationTest.php
+++ b/tests/Feature/WebhookNotificationTest.php
@@ -128,14 +128,21 @@ class WebhookNotificationTest extends TestCase
         return Plan::factory()->create([
             'name' => $webhookEnabled ? 'Prime' : 'Basic',
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
+                    'label' => 'Email Notifications',
                     'config' => [
                         'email' => true,
-                        'webhook' => $webhookEnabled,
                     ],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => [
+                        'webhook' => $webhookEnabled,
+                    ],
+                    'type' => $webhookEnabled ? 'feature' : 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -29,10 +29,16 @@ class WebhookSettingsTest extends TestCase
             'price_per_month' => 50,
             'price_per_year' => 500,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => true],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
+                    'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => true],
                     'type' => 'feature',
                 ],
                 'api' => [


### PR DESCRIPTION
## Summary

- Fix Monthly/Yearly toggle button contrast in both light and dark modes by updating container and active/inactive state styling
- Split single `notification` plan feature into separate `email_notification` and `webhook_notification` entries for clearer pricing page display
- Add data migration to transform existing plan data (reversible)
- Update all feature-gating consumers: User model, Secret model, NotificationPreferencesForm.vue
- Update seeders, factory, and 8 test files to match new structure

## Test plan

- [x] All 101 notification-related tests pass
- [x] Visual check: toggle button readable in light and dark modes
- [x] Visual check: pricing page shows two separate notification line items per plan
- [x] Verify notification preferences page works for subscribed users
- [x] Verify webhook settings page works for Prime plan users
- [x] Run `php artisan migrate` on existing database to confirm migration works