### PR TITLE
Release/v4.7.0

### DIFF
--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -100,11 +100,11 @@ class Secret extends Model
                      * @var User $user
                      */
                     if (isset($plan['id'])) {
-                        if (($plan['settings']['notification']['email'] ?? false) && $user->notify_secret_retrieved) {
+                        if (($plan['settings']['email_notification']['email'] ?? false) && $user->notify_secret_retrieved) {
                             $user->notify(new SecretRetrievedNotification($secret));
                         }
 
-                        $planSupportsWebhook = ($plan['settings']['notification']['webhook'] ?? false);
+                        $planSupportsWebhook = ($plan['settings']['webhook_notification']['webhook'] ?? false);
                         if ($planSupportsWebhook && $user->hasWebhookConfigured()) {
                             dispatch(new SendWebhookNotification(
                                 webhookUrl: $user->webhook_url,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -121,7 +121,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
 
         $plan = $this->resolvePlan();
 
-        return $plan && ($plan->features['notification']['config']['email'] ?? false);
+        return $plan && ($plan->features['email_notification']['config']['email'] ?? false);
     }
 
     /**
@@ -135,7 +135,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
 
         $plan = $this->resolvePlan();
 
-        return $plan && ($plan->features['notification']['config']['webhook'] ?? false);
+        return $plan && ($plan->features['webhook_notification']['config']['webhook'] ?? false);
     }
 
     public function getPlanAttribute(): PlanResource

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -44,7 +44,6 @@ class PlanFactory extends Factory
                 apiType: 'missing',
                 notificationEmail: false,
                 notificationWebhook: false,
-                notificationType: 'missing',
             ),
         ]);
     }
@@ -89,7 +88,6 @@ class PlanFactory extends Factory
         string $apiType = 'feature',
         bool $notificationEmail = true,
         bool $notificationWebhook = true,
-        string $notificationType = 'feature',
     ): array {
         return [
             'untracked' => [
@@ -121,14 +119,21 @@ class PlanFactory extends Factory
                 'config' => [],
                 'type' => 'feature',
             ],
-            'notification' => [
+            'email_notification' => [
                 'order' => 4.5,
-                'label' => 'Get notified when a message is retrieved',
+                'label' => 'Email Notifications',
                 'config' => [
                     'email' => $notificationEmail,
+                ],
+                'type' => $notificationEmail ? 'feature' : 'missing',
+            ],
+            'webhook_notification' => [
+                'order' => 4.6,
+                'label' => 'Webhook Notifications',
+                'config' => [
                     'webhook' => $notificationWebhook,
                 ],
-                'type' => $notificationType,
+                'type' => $notificationWebhook ? 'feature' : 'missing',
             ],
             'support' => [
                 'order' => 5,

--- a/database/migrations/2026_04_03_111859_split_notification_into_email_and_webhook_features.php
+++ b/database/migrations/2026_04_03_111859_split_notification_into_email_and_webhook_features.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\Plan;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (! isset($features['notification'])) {
+                return;
+            }
+
+            $notification = $features['notification'];
+            $emailEnabled = $notification['config']['email'] ?? false;
+            $webhookEnabled = $notification['config']['webhook'] ?? false;
+            $baseOrder = $notification['order'] ?? 4.5;
+
+            $features['email_notification'] = [
+                'order' => $baseOrder,
+                'label' => 'Email Notifications',
+                'config' => ['email' => $emailEnabled],
+                'type' => $emailEnabled ? 'feature' : 'missing',
+            ];
+
+            $features['webhook_notification'] = [
+                'order' => $baseOrder + 0.1,
+                'label' => 'Webhook Notifications',
+                'config' => ['webhook' => $webhookEnabled],
+                'type' => $webhookEnabled ? 'feature' : 'missing',
+            ];
+
+            unset($features['notification']);
+
+            $plan->update(['features' => $features]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Plan::all()->each(function (Plan $plan) {
+            $features = $plan->features;
+
+            if (! isset($features['email_notification']) && ! isset($features['webhook_notification'])) {
+                return;
+            }
+
+            $emailEnabled = $features['email_notification']['config']['email'] ?? false;
+            $webhookEnabled = $features['webhook_notification']['config']['webhook'] ?? false;
+            $order = $features['email_notification']['order'] ?? 4.5;
+
+            $type = ($emailEnabled || $webhookEnabled) ? 'feature' : 'missing';
+
+            if ($emailEnabled && $webhookEnabled) {
+                $label = 'Get notified via email or webhook when a message is retrieved';
+            } elseif ($emailEnabled) {
+                $label = 'Get notified via email when a message is retrieved';
+            } else {
+                $label = 'Get notified when a message is retrieved';
+            }
+
+            $features['notification'] = [
+                'order' => $order,
+                'label' => $label,
+                'config' => ['email' => $emailEnabled, 'webhook' => $webhookEnabled],
+                'type' => $type,
+            ];
+
+            unset($features['email_notification'], $features['webhook_notification']);
+
+            $plan->update(['features' => $features]);
+        });
+    }
+};

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -51,11 +51,18 @@ class PlanSeederLocal extends Seeder
                         ],
                         'type' => 'limit',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => false,
+                        ],
+                        'type' => 'missing',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => false,
                         ],
                         'type' => 'missing',
@@ -112,14 +119,21 @@ class PlanSeederLocal extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
-                            'webhook' => false,
                         ],
                         'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
+                            'webhook' => false,
+                        ],
+                        'type' => 'missing',
                     ],
                     'support' => [
                         'order' => 5,
@@ -173,11 +187,18 @@ class PlanSeederLocal extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email or webhook when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
+                        ],
+                        'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => true,
                         ],
                         'type' => 'feature',

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -51,11 +51,18 @@ class PlanSeederProd extends Seeder
                         ],
                         'type' => 'limit',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => false,
+                        ],
+                        'type' => 'missing',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => false,
                         ],
                         'type' => 'missing',
@@ -112,14 +119,21 @@ class PlanSeederProd extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
-                            'webhook' => false,
                         ],
                         'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
+                            'webhook' => false,
+                        ],
+                        'type' => 'missing',
                     ],
                     'support' => [
                         'order' => 5,
@@ -173,11 +187,18 @@ class PlanSeederProd extends Seeder
                         'config' => [],
                         'type' => 'feature',
                     ],
-                    'notification' => [
+                    'email_notification' => [
                         'order' => 4.5,
-                        'label' => 'Get notified via email or webhook when a message is retrieved',
+                        'label' => 'Email Notifications',
                         'config' => [
                             'email' => true,
+                        ],
+                        'type' => 'feature',
+                    ],
+                    'webhook_notification' => [
+                        'order' => 5.5,
+                        'label' => 'Webhook Notifications',
+                        'config' => [
                             'webhook' => true,
                         ],
                         'type' => 'feature',

--- a/resources/js/Components/ConfirmsPasswordOrPasskey.vue
+++ b/resources/js/Components/ConfirmsPasswordOrPasskey.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { ref, reactive, nextTick } from 'vue';
+import { ref, reactive, computed, nextTick } from 'vue';
+import { usePage } from '@inertiajs/vue3';
 import DialogModal from './DialogModal.vue';
 import InputError from './InputError.vue';
 import PrimaryButton from './PrimaryButton.vue';
-import SecondaryButton from './SecondaryButton.vue';
 import TextInput from './TextInput.vue';
 import ConfirmsPasskey from './ConfirmsPasskey.vue';
 
@@ -33,8 +33,16 @@ const props = defineProps({
 });
 
 const confirmingPassword = ref(false);
+const showingAuthChoice = ref(false);
+const passkeyFailed = ref(false);
+const passkeyVerifying = ref(false);
 
 const passkeyConfirmation = ref(null);
+
+const userHasPasskeys = computed(() => {
+    const user = usePage().props.auth?.user;
+    return user?.passkeys?.length > 0;
+});
 
 const form = reactive({
     password: '',
@@ -54,10 +62,43 @@ const startConfirmingPassword = () => {
     axios.get(route('password.confirmation', props.seconds > 0 ? {seconds: props.seconds} : {})).then(response => {
         if (response.data.confirmed && !props.mandatory) {
             emit('confirmed');
+        } else if (userHasPasskeys.value) {
+            showingAuthChoice.value = true;
+            passkeyFailed.value = false;
         } else {
-            passkeyConfirmation.value.start();
+            askForPassword();
         }
     });
+};
+
+const usePasskey = () => {
+    passkeyFailed.value = false;
+    passkeyVerifying.value = true;
+    passkeyConfirmation.value.start();
+};
+
+const onPasskeyConfirmed = () => {
+    showingAuthChoice.value = false;
+    passkeyFailed.value = false;
+    passkeyVerifying.value = false;
+    emit('confirmed');
+};
+
+const onPasskeyCancelled = () => {
+    passkeyFailed.value = true;
+    passkeyVerifying.value = false;
+};
+
+const usePassword = () => {
+    showingAuthChoice.value = false;
+    passkeyFailed.value = false;
+    askForPassword();
+};
+
+const closeAuthChoice = () => {
+    showingAuthChoice.value = false;
+    passkeyFailed.value = false;
+    passkeyVerifying.value = false;
 };
 
 const confirmPassword = () => {
@@ -91,44 +132,94 @@ const closeModal = () => {
             <slot />
         </span>
 
-        <ConfirmsPasskey :email="$page.props.auth.user.email" ref="passkeyConfirmation" @confirmed="emit('confirmed')" @cancelled="askForPassword"/>
+        <ConfirmsPasskey :email="$page.props.auth.user.email" ref="passkeyConfirmation" @confirmed="onPasskeyConfirmed" @cancelled="onPasskeyCancelled"/>
 
-        <DialogModal :show="confirmingPassword" @close="closeModal" ref="password">
+        <DialogModal :show="showingAuthChoice" @close="closeAuthChoice" max-width="sm">
             <template #title>
-                {{ title }}
+                <div class="flex flex-col items-center text-center">
+                    <svg class="w-12 h-12 text-gray-400 dark:text-gray-500 mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+                    </svg>
+                    <span class="text-xl">Passkey or security key</span>
+                </div>
             </template>
 
             <template #content>
-                {{ content }}
+                <div class="text-center">
+                    <p>When you are ready, authenticate using the button below.</p>
 
-                <div class="mt-4">
-                    <TextInput
-                        ref="passwordInput"
-                        v-model="form.password"
-                        type="password"
-                        class="mt-1 block w-3/4"
-                        placeholder="Password"
-                        autocomplete="current-password"
-                        @keyup.enter="confirmPassword"
-                    />
+                    <div v-if="passkeyFailed" class="mt-4 flex items-center gap-2 rounded-md border border-red-300 dark:border-red-600 bg-red-50 dark:bg-red-900/30 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+                        <svg class="h-5 w-5 shrink-0 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+                        </svg>
+                        Authentication failed.
+                    </div>
 
-                    <InputError :message="form.error" class="mt-2" />
+                    <PrimaryButton
+                        @click="usePasskey"
+                        :disabled="passkeyVerifying"
+                        class="mt-4 w-full justify-center py-3"
+                    >
+                        {{ passkeyVerifying ? 'Verifying...' : (passkeyFailed ? 'Retry passkey or security key' : 'Use passkey or security key') }}
+                    </PrimaryButton>
                 </div>
             </template>
 
             <template #footer>
-                <SecondaryButton @click="closeModal">
-                    Cancel
-                </SecondaryButton>
+                <div class="w-full text-sm text-gray-600 dark:text-gray-400">
+                    Having problems?
+                    <button @click="usePassword" class="text-blue-600 dark:text-blue-400 hover:underline">
+                        Use your password
+                    </button>
+                </div>
+            </template>
+        </DialogModal>
 
-                <PrimaryButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                    @click="confirmPassword"
-                >
-                    {{ button }}
-                </PrimaryButton>
+        <DialogModal :show="confirmingPassword" @close="closeModal" ref="password" max-width="sm">
+            <template #title>
+                <div class="flex flex-col items-center text-center">
+                    <svg class="w-12 h-12 text-gray-400 dark:text-gray-500 mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                    </svg>
+                    <span class="text-xl">{{ title }}</span>
+                </div>
+            </template>
+
+            <template #content>
+                <div class="text-center">
+                    <p>{{ content }}</p>
+
+                    <div class="mt-4">
+                        <TextInput
+                            ref="passwordInput"
+                            v-model="form.password"
+                            type="password"
+                            class="w-full"
+                            placeholder="Password"
+                            autocomplete="current-password"
+                            @keyup.enter="confirmPassword"
+                        />
+
+                        <InputError :message="form.error" class="mt-2" />
+                    </div>
+
+                    <PrimaryButton
+                        @click="confirmPassword"
+                        :disabled="form.processing"
+                        class="mt-4 w-full justify-center py-3"
+                    >
+                        {{ form.processing ? 'Confirming...' : button }}
+                    </PrimaryButton>
+
+                </div>
+            </template>
+
+            <template #footer>
+                <div class="w-full text-center">
+                    <button @click="closeModal" class="text-sm text-gray-500 dark:text-gray-400 hover:underline">
+                        Cancel
+                    </button>
+                </div>
             </template>
         </DialogModal>
     </span>

--- a/resources/js/Components/ToggleButton.vue
+++ b/resources/js/Components/ToggleButton.vue
@@ -8,12 +8,14 @@
 </script>
 <template>
     <div class="flex flex-row mb-4">
-        <div class="flex flex-row gap-0 rounded-md bg-white">
-            <button 
-                v-for="option in options" 
-                @click="() => $emit('update:modelValue', option.value)" 
-                :class="{ 'bg-gamboge-300 dark:bg-gamboge-800': option.value == modelValue }"
-                class="inline-flex items-center px-4 py-2 border border-transparent rounded-md font-semibold text-xs text-gamboge-800 dark:text-gamboge-200 uppercase tracking-widest focus:outline-none disabled:opacity-50 transition ease-in-out duration-150 justify-center p-2 "
+        <div class="flex flex-row gap-0 rounded-md bg-gray-200 dark:bg-gray-700">
+            <button
+                v-for="option in options"
+                @click="() => $emit('update:modelValue', option.value)"
+                :class="option.value == modelValue
+                    ? 'bg-gamboge-500 text-white dark:bg-gamboge-600 dark:text-white'
+                    : 'text-gray-700 dark:text-gray-300'"
+                class="inline-flex items-center px-4 py-2 border border-transparent rounded-md font-semibold text-xs uppercase tracking-widest focus:outline-none disabled:opacity-50 transition ease-in-out duration-150 justify-center p-2"
                 >
                     {{ option.label }}
             </button>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -11,7 +11,7 @@ const page = usePage();
 const user = computed(() => page.props.auth.user);
 
 const planSupportsNotifications = computed(() =>
-    user.value.plan?.settings?.notification?.email ?? false
+    user.value.plan?.settings?.email_notification?.email ?? false
 );
 
 const form = useForm({

--- a/tests/Feature/Api/SecretApiTest.php
+++ b/tests/Feature/Api/SecretApiTest.php
@@ -41,11 +41,17 @@ class SecretApiTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/SecretMetadataApiTest.php
+++ b/tests/Feature/Api/SecretMetadataApiTest.php
@@ -41,11 +41,17 @@ class SecretMetadataApiTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/SecretRetrievalTest.php
+++ b/tests/Feature/Api/SecretRetrievalTest.php
@@ -45,11 +45,17 @@ class SecretRetrievalTest extends TestCase
                     'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200],
                     'type' => 'feature',
                 ],
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/Api/WebhookApiTest.php
+++ b/tests/Feature/Api/WebhookApiTest.php
@@ -28,10 +28,16 @@ class WebhookApiTest extends TestCase
             'price_per_month' => 50,
             'price_per_year' => 500,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => true],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
+                    'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => true],
                     'type' => 'feature',
                 ],
                 'api' => [

--- a/tests/Feature/ConfirmsPasswordOrPasskeyTest.php
+++ b/tests/Feature/ConfirmsPasswordOrPasskeyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConfirmsPasswordOrPasskeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_with_passkeys_has_passkeys_in_page_props(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $user->passkeys()->create([
+            'credential_id' => 'test-credential-id',
+            'public_key' => 'test-public-key',
+            'name' => 'Test Passkey',
+        ]);
+
+        $user->load('passkeys');
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertStatus(200);
+        $response->assertInertia(function ($page) {
+            $passkeys = data_get($page->toArray(), 'props.auth.user.passkeys', []);
+            $this->assertNotEmpty($passkeys, 'User with passkeys should have passkeys in page props');
+        });
+    }
+
+    public function test_user_without_passkeys_has_empty_passkeys_in_page_props(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertStatus(200);
+        $response->assertInertia(function ($page) {
+            $passkeys = data_get($page->toArray(), 'props.auth.user.passkeys', []);
+            $this->assertEmpty($passkeys, 'User without passkeys should have empty passkeys array');
+        });
+    }
+
+    public function test_password_confirmation_status_returns_confirmed_state(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/user/confirmed-password-status');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['confirmed']);
+    }
+
+    public function test_password_confirmation_status_respects_seconds_parameter(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/user/confirmed-password-status?seconds=60');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['confirmed']);
+    }
+
+    public function test_password_can_be_confirmed_for_protected_actions(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/user/confirm-password', [
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_invalid_password_is_rejected_for_protected_actions(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/user/confirm-password', [
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertSessionHasErrors();
+    }
+}

--- a/tests/Feature/NotificationPreferencesTest.php
+++ b/tests/Feature/NotificationPreferencesTest.php
@@ -25,11 +25,17 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 25,
             'price_per_year' => 250,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
             ],
         ]);
@@ -106,10 +112,16 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 0,
             'price_per_year' => 0,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => false, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => false],
+                    'type' => 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
                     'type' => 'missing',
                 ],
             ],
@@ -141,10 +153,16 @@ class NotificationPreferencesTest extends TestCase
             'price_per_month' => 0,
             'price_per_year' => 0,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => false, 'webhook' => false],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => false],
+                    'type' => 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
                     'type' => 'missing',
                 ],
             ],

--- a/tests/Feature/SecretRetrievedNotificationTest.php
+++ b/tests/Feature/SecretRetrievedNotificationTest.php
@@ -103,11 +103,17 @@ class SecretRetrievedNotificationTest extends TestCase
         return Plan::factory()->create([
             'name' => $enabled ? 'Pro' : 'Free',
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Get notified when a message is retrieved',
+                    'label' => 'Email Notifications',
                     'config' => ['email' => $enabled],
                     'type' => $enabled ? 'feature' : 'missing',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => false],
+                    'type' => 'missing',
                 ],
             ],
             'stripe_product_id' => 'prod_test',

--- a/tests/Feature/WebhookNotificationTest.php
+++ b/tests/Feature/WebhookNotificationTest.php
@@ -128,14 +128,21 @@ class WebhookNotificationTest extends TestCase
         return Plan::factory()->create([
             'name' => $webhookEnabled ? 'Prime' : 'Basic',
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
+                    'label' => 'Email Notifications',
                     'config' => [
                         'email' => true,
-                        'webhook' => $webhookEnabled,
                     ],
                     'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => [
+                        'webhook' => $webhookEnabled,
+                    ],
+                    'type' => $webhookEnabled ? 'feature' : 'missing',
                 ],
                 'api' => [
                     'order' => 6,

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -29,10 +29,16 @@ class WebhookSettingsTest extends TestCase
             'price_per_month' => 50,
             'price_per_year' => 500,
             'features' => [
-                'notification' => [
+                'email_notification' => [
                     'order' => 4.5,
-                    'label' => 'Notifications',
-                    'config' => ['email' => true, 'webhook' => true],
+                    'label' => 'Email Notifications',
+                    'config' => ['email' => true],
+                    'type' => 'feature',
+                ],
+                'webhook_notification' => [
+                    'order' => 4.6,
+                    'label' => 'Webhook Notifications',
+                    'config' => ['webhook' => true],
                     'type' => 'feature',
                 ],
                 'api' => [


### PR DESCRIPTION
## Commits since last release: 2

**Change breakdown:**

- **Breaking:** None
- **Features:**
  - `0ca80ad` — Add intermediary prompt before passkey confirmation (PIO-60) — new UX flow for passkey confirmation
- **Fixes:**
  - `f979ece` — Fix toggle contrast & split notification into email and webhook features (PIO-59) — bug fix + refactor of notification preferences

Both commits touch only web app code (models, Vue components, migrations, tests). No changes to `tools/flashview-cli/`.