### PR TITLE
Redesign register pages with split-layout branding panel (PIO-61)

### DIFF
--- a/resources/js/Components/AuthenticationCardWithFeatures.vue
+++ b/resources/js/Components/AuthenticationCardWithFeatures.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { Link } from '@inertiajs/vue3';
-import Logo from '../../images/logo.svg';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
 </script>
 
 <template>
@@ -9,9 +8,7 @@ import Logo from '../../images/logo.svg';
             <!-- Branding Panel -->
             <div class="bg-gray-800 dark:bg-gray-950 px-8 py-10 md:py-16 flex flex-col justify-center">
                 <div class="mb-8">
-                    <Link href="/">
-                        <img :src="Logo" class="h-16 md:h-24 w-auto">
-                    </Link>
+                    <AuthenticationCardLogo />
                 </div>
 
                 <h1 class="text-2xl md:text-3xl font-bold text-white leading-tight">

--- a/resources/js/Components/AuthenticationCardWithFeatures.vue
+++ b/resources/js/Components/AuthenticationCardWithFeatures.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import Logo from '../../images/logo.svg';
+</script>
+
+<template>
+    <div class="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900 px-4 py-8">
+        <div class="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-0 overflow-hidden sm:rounded-lg shadow-md">
+            <!-- Branding Panel -->
+            <div class="bg-gray-800 dark:bg-gray-950 px-8 py-10 md:py-16 flex flex-col justify-center">
+                <div class="mb-8">
+                    <Link href="/">
+                        <img :src="Logo" class="h-16 md:h-24 w-auto">
+                    </Link>
+                </div>
+
+                <h1 class="text-2xl md:text-3xl font-bold text-white leading-tight">
+                    <slot name="heading" />
+                </h1>
+
+                <p class="mt-3 text-sm md:text-base text-gray-400 hidden md:block">
+                    <slot name="subtitle" />
+                </p>
+
+                <ul class="mt-6 md:mt-8 space-y-4">
+                    <slot name="features" />
+                </ul>
+            </div>
+
+            <!-- Form Panel -->
+            <div class="flex items-center justify-center bg-white dark:bg-gray-800 px-6 py-8 md:py-16">
+                <div class="w-full max-w-sm">
+                    <slot />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Head, Link, useForm } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
@@ -19,9 +18,40 @@ const submit = () => {
 <template>
     <Head title="Register" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            Secrets that disappear after one view
+        </template>
+
+        <template #subtitle>
+            Keep sensitive information out of your email and chat logs
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">End-to-end encrypted — secrets are encrypted in your browser</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Auto-expiring links — set custom expiry times</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">One-time access — links are destroyed after viewing</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Personal dashboard to manage your shared secrets</span>
+            </li>
         </template>
 
         <form @submit.prevent="submit">
@@ -49,5 +79,5 @@ const submit = () => {
                 </PrimaryButton>
             </div>
         </form>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/resources/js/Pages/Auth/RegisterComplete.vue
+++ b/resources/js/Pages/Auth/RegisterComplete.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Head, useForm } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 import Checkbox from '@/Components/Checkbox.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
@@ -39,9 +38,40 @@ const submit = () => {
 <template>
     <Head title="Complete Registration" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            Almost there
+        </template>
+
+        <template #subtitle>
+            Complete your account to unlock additional features
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Longer expiry options for your secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Higher message size limits</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Dashboard to track your shared secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Webhook notifications</span>
+            </li>
         </template>
 
         <form @submit.prevent="submit">
@@ -118,5 +148,5 @@ const submit = () => {
                 </PrimaryButton>
             </div>
         </form>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/resources/js/Pages/Auth/RegisterSuccess.vue
+++ b/resources/js/Pages/Auth/RegisterSuccess.vue
@@ -1,15 +1,45 @@
 <script setup>
 import { Head, Link } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 </script>
 
 <template>
     <Head title="Check Your Email" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            You're almost there
+        </template>
+
+        <template #subtitle>
+            Here's what you'll get with your FlashView account
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">End-to-end encrypted secret sharing</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Extended expiry options and higher limits</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Personal dashboard to track your secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Webhook notifications for secret access</span>
+            </li>
         </template>
 
         <div class="text-center">
@@ -36,5 +66,5 @@ import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
                 </Link>
             </div>
         </div>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/tests/Feature/RegisterPageDesignTest.php
+++ b/tests/Feature/RegisterPageDesignTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\URL;
+use Inertia\Testing\AssertableInertia;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class RegisterPageDesignTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get('/register');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/Register')
+        );
+    }
+
+    public function test_register_complete_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => 'newuser@example.com']
+        );
+
+        $response = $this->get($signedUrl);
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/RegisterComplete')
+            ->has('email')
+            ->has('signedUrl')
+        );
+    }
+
+    public function test_register_success_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get(route('register.success'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/RegisterSuccess')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add new `AuthenticationCardWithFeatures.vue` component with two-panel layout: branding panel (logo, heading, features) on the left, form on the right — stacks vertically on mobile
- Redesign Register, RegisterComplete, and RegisterSuccess pages with value proposition messaging alongside the forms
- Existing `AuthenticationCard` and other auth pages (Login, ForgotPassword, etc.) are untouched

## Regression Notes

- Frontend-only change — no backend, route, or database modifications
- Layout shift between Login (single-column) and Register (split-layout) is intentional per design
- Logo renders correctly on the dark branding panel (amber/gamboge SVG fills)

## Test plan

- [x] Verify Register page shows "Secrets that disappear after one view" heading with 4 feature bullets
- [x] Verify RegisterComplete page shows "Almost there" heading with account-benefit features
- [x] Verify RegisterSuccess page shows "You're almost there" heading with value props alongside check-email instructions
- [x] Test desktop layout: two-column split (branding left, form right)
- [x] Test mobile layout: branding stacks above form, subtitle hidden
- [x] Test dark mode on all three pages
- [x] Verify Login and ForgotPassword pages are unaffected
- [x] Complete full registration flow end-to-end (email → check email → complete → dashboard)