### PR TITLE
Add authentication confirmation for API token actions (PIO-62)

### DIFF
--- a/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -15,6 +15,7 @@ import SecondaryButton from '@/Components/SecondaryButton.vue';
 import SectionBorder from '@/Components/SectionBorder.vue';
 import TextInput from '@/Components/TextInput.vue';
 import Alert from '@/Components/Alert.vue';
+import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
 
 const props = defineProps({
     tokens: Array,
@@ -93,7 +94,7 @@ const deleteApiToken = () => {
         </div>
 
         <!-- Generate API Token -->
-        <FormSection @submitted="createApiToken">
+        <FormSection>
             <template #title>
                 Create API Token
             </template>
@@ -136,9 +137,11 @@ const deleteApiToken = () => {
                     Created.
                 </ActionMessage>
 
-                <PrimaryButton :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
-                    Create
-                </PrimaryButton>
+                <ConfirmsPasswordOrPasskey @confirmed="createApiToken">
+                    <PrimaryButton type="button" :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
+                        Create
+                    </PrimaryButton>
+                </ConfirmsPasswordOrPasskey>
             </template>
         </FormSection>
 
@@ -200,9 +203,11 @@ const deleteApiToken = () => {
                                         Permissions
                                     </button>
 
-                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmApiTokenDeletion(token)">
-                                        Delete
-                                    </button>
+                                    <ConfirmsPasswordOrPasskey @confirmed="confirmApiTokenDeletion(token)" title="Confirm Token Deletion" content="Please verify your identity before deleting this API token.">
+                                        <button class="cursor-pointer ms-6 text-sm text-red-500">
+                                            Delete
+                                        </button>
+                                    </ConfirmsPasswordOrPasskey>
                                 </div>
                             </div>
                         </div>
@@ -256,14 +261,16 @@ const deleteApiToken = () => {
                     Cancel
                 </SecondaryButton>
 
-                <PrimaryButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': updateApiTokenForm.processing }"
-                    :disabled="updateApiTokenForm.processing"
-                    @click="updateApiToken"
-                >
-                    Save
-                </PrimaryButton>
+                <ConfirmsPasswordOrPasskey @confirmed="updateApiToken">
+                    <PrimaryButton
+                        type="button"
+                        class="ms-3"
+                        :class="{ 'opacity-25': updateApiTokenForm.processing }"
+                        :disabled="updateApiTokenForm.processing"
+                    >
+                        Save
+                    </PrimaryButton>
+                </ConfirmsPasswordOrPasskey>
             </template>
         </DialogModal>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,11 +114,19 @@ Route::middleware([
 
     Route::middleware([EnsurePlanHasApiAccess::class])->group(function () {
         Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
-        Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-        Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
-        Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+        Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.store');
+        Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.update');
+        Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.destroy');
 
-        Route::delete('/user/cli-installations/{token}', [CliInstallationController::class, 'destroy'])->name('cli-installations.destroy');
+        Route::delete('/user/cli-installations/{token}', [CliInstallationController::class, 'destroy'])
+            ->middleware('password.confirm')
+            ->name('cli-installations.destroy');
 
         Route::put('/user/webhook-settings', [WebhookSettingsController::class, 'update'])
             ->name('user.webhook-settings.update');

--- a/tests/Feature/ApiTokenPermissionsTest.php
+++ b/tests/Feature/ApiTokenPermissionsTest.php
@@ -45,16 +45,59 @@ class ApiTokenPermissionsTest extends TestCase
             'abilities' => ['secrets:create', 'secrets:list'],
         ]);
 
-        $this->put('/user/api-tokens/'.$token->id, [
-            'name' => $token->name,
-            'permissions' => [
-                'secrets:delete',
-                'missing-permission',
-            ],
-        ]);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->put('/user/api-tokens/'.$token->id, [
+                'name' => $token->name,
+                'permissions' => [
+                    'secrets:delete',
+                    'missing-permission',
+                ],
+            ]);
 
         $this->assertTrue($user->fresh()->tokens->first()->can('secrets:delete'));
         $this->assertFalse($user->fresh()->tokens->first()->can('secrets:list'));
         $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+    }
+
+    public function test_updating_api_token_permissions_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_perms_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $token = $user->tokens()->create([
+            'name' => 'Test Token',
+            'token' => Str::random(40),
+            'abilities' => ['secrets:create', 'secrets:list'],
+        ]);
+
+        $response = $this->put('/user/api-tokens/'.$token->id, [
+            'name' => $token->name,
+            'permissions' => ['secrets:delete'],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertFalse($user->fresh()->tokens->first()->can('secrets:delete'));
+        $this->assertTrue($user->fresh()->tokens->first()->can('secrets:create'));
     }
 }

--- a/tests/Feature/CliInstallationTest.php
+++ b/tests/Feature/CliInstallationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CliInstallationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSubscribedUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_cli_test_'.Str::random(8),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        return $user;
+    }
+
+    public function test_unauthenticated_user_cannot_delete_cli_installation(): void
+    {
+        $response = $this->delete('/user/cli-installations/1');
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_cli_installation_can_be_deleted(): void
+    {
+        $user = $this->createSubscribedUser();
+        $this->actingAs($user);
+
+        $token = $user->tokens()->create([
+            'name' => 'My CLI',
+            'token' => Str::random(40),
+            'abilities' => ['*'],
+            'type' => 'cli',
+        ]);
+
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/cli-installations/'.$token->id);
+
+        $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    public function test_deleting_cli_installation_requires_password_confirmation(): void
+    {
+        $user = $this->createSubscribedUser();
+        $this->actingAs($user);
+
+        $token = $user->tokens()->create([
+            'name' => 'My CLI',
+            'token' => Str::random(40),
+            'abilities' => ['*'],
+            'type' => 'cli',
+        ]);
+
+        $response = $this->delete('/user/cli-installations/'.$token->id);
+
+        $response->assertRedirect();
+        $this->assertCount(1, $user->fresh()->tokens);
+    }
+}

--- a/tests/Feature/CliMultipleInstallationsTest.php
+++ b/tests/Feature/CliMultipleInstallationsTest.php
@@ -207,6 +207,7 @@ class CliMultipleInstallationsTest extends TestCase
         $tokenToDelete = $tokens->where('name', 'Delete This')->first();
 
         $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$tokenToDelete->id}");
 
         $response->assertRedirect();
@@ -225,6 +226,7 @@ class CliMultipleInstallationsTest extends TestCase
         $token = $user1->fresh()->tokens()->where('type', 'cli')->first();
 
         $this->actingAs($user2)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$token->id}")
             ->assertNotFound();
 
@@ -238,6 +240,7 @@ class CliMultipleInstallationsTest extends TestCase
         $apiToken = $user->createToken('API Token', ['secrets:create']);
 
         $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$apiToken->accessToken->id}")
             ->assertNotFound();
     }

--- a/tests/Feature/CreateApiTokenTest.php
+++ b/tests/Feature/CreateApiTokenTest.php
@@ -38,17 +38,53 @@ class CreateApiTokenTest extends TestCase
             'quantity' => 1,
         ]);
 
-        $this->post('/user/api-tokens', [
-            'name' => 'Test Token',
-            'permissions' => [
-                'secrets:create',
-                'secrets:list',
-            ],
-        ]);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/api-tokens', [
+                'name' => 'Test Token',
+                'permissions' => [
+                    'secrets:create',
+                    'secrets:list',
+                ],
+            ]);
 
         $this->assertCount(1, $user->fresh()->tokens);
         $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
         $this->assertTrue($user->fresh()->tokens->first()->can('secrets:create'));
         $this->assertFalse($user->fresh()->tokens->first()->can('secrets:delete'));
+    }
+
+    public function test_creating_api_token_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_create_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $response = $this->post('/user/api-tokens', [
+            'name' => 'Test Token',
+            'permissions' => ['secrets:create'],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertCount(0, $user->fresh()->tokens);
     }
 }

--- a/tests/Feature/DeleteApiTokenTest.php
+++ b/tests/Feature/DeleteApiTokenTest.php
@@ -45,8 +45,47 @@ class DeleteApiTokenTest extends TestCase
             'abilities' => ['secrets:create', 'secrets:list'],
         ]);
 
-        $this->delete('/user/api-tokens/'.$token->id);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/api-tokens/'.$token->id);
 
         $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    public function test_deleting_api_token_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_delete_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $token = $user->tokens()->create([
+            'name' => 'Test Token',
+            'token' => Str::random(40),
+            'abilities' => ['secrets:create'],
+        ]);
+
+        $response = $this->delete('/user/api-tokens/'.$token->id);
+
+        $response->assertRedirect();
+        $this->assertCount(1, $user->fresh()->tokens);
     }
 }


### PR DESCRIPTION
## Summary

- Wrap Create, Save permissions, and Delete API token actions with `ConfirmsPasswordOrPasskey`, matching the existing pattern used for webhook secret reveal
- Delete wrapper placed at the list level (not inside the modal) to avoid modal-stacking issues — identity is confirmed first, then the "Are you sure?" modal opens
- Add `password.confirm` middleware server-side to `api-tokens.store`, `api-tokens.update`, `api-tokens.destroy`, and `cli-installations.destroy` routes for backend enforcement
- Update all affected feature tests to include confirmed password session; add negative tests verifying each route requires confirmation; add new `CliInstallationTest`

## Regression risks

- **Low** — `password.confirm` session window (3h default) expiry between the two delete steps would cause an unexpected redirect. Very low probability in practice; pre-existing architectural concern.
- **Low** — Enter key in the token name field no longer creates a token (intentional security trade-off, documented in plan).

## Test plan

- [x] Create an API token — confirm the password/passkey prompt appears before the token is created
- [x] Update token permissions — confirm the prompt appears before saving
- [x] Delete an API token — confirm the prompt appears first, then "Are you sure?" modal, then deletion
- [x] Delete a CLI installation — same confirmation flow
- [x] Cancel at the identity prompt — confirm nothing happens
- [x] Users with passkeys see the passkey modal; fallback to password works
- [x] Calling the routes directly without a confirmed session redirects (server-side enforcement)
- [x] `php artisan test tests/Feature/CreateApiTokenTest.php tests/Feature/DeleteApiTokenTest.php tests/Feature/ApiTokenPermissionsTest.php tests/Feature/CliInstallationTest.php tests/Feature/CliMultipleInstallationsTest.php` — all pass