### PR TITLE
UI improvements: notification settings & decrypted secret copy (PIO-57)

### DIFF
--- a/resources/js/Components/CodeBlock.vue
+++ b/resources/js/Components/CodeBlock.vue
@@ -2,10 +2,13 @@
     import { ref } from 'vue';
 
     const props = defineProps({
-        value: String
+        value: String,
+        masked: {
+            type: Boolean,
+            default: false,
+        },
     })
 
-    const text = ref(null)
     const copied = ref(false)
 
     const copyText = (data) => {
@@ -19,10 +22,10 @@
 <div class="w-full">
     <div class="relative">
         <label for="npm-install-copy-button" class="sr-only">Copyable content</label>
-        <code ref="text" class="col-span-6 bg-gray-50 border border-gray-300 text-gray-700 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-gray-200 dark:focus:ring-blue-500 dark:focus:border-blue-500" disabled readonly>
-            <slot>{{ props.value }}</slot>
+        <code class="col-span-6 bg-gray-50 border border-gray-300 text-gray-700 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-gray-200 dark:focus:ring-blue-500 dark:focus:border-blue-500" disabled readonly>
+            <slot>{{ props.masked ? '••••••••••••••••••••••••••••••••' : props.value }}</slot>
         </code>
-        <button type="button" @click.prevent="copyText(text.innerText)" class="group absolute end-2 bottom-1 translate-y-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 rounded-lg p-1.5 mb-1 inline-flex items-center justify-center transition-colors">
+        <button v-if="!props.masked" type="button" @click.prevent="copyText(props.value)" class="group absolute end-2 bottom-1 translate-y-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 rounded-lg p-1.5 mb-1 inline-flex items-center justify-center transition-colors">
             <span v-if="!copied">
                 <svg class="w-4 h-4" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
                     <path d="M16 1h-3.278A1.992 1.992 0 0 0 11 0H7a1.993 1.993 0 0 0-1.722 1H2a2 2 0 0 0-2 2v15a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2Zm-3 14H5a1 1 0 0 1 0-2h8a1 1 0 0 1 0 2Zm0-4H5a1 1 0 0 1 0-2h8a1 1 0 1 1 0 2Zm0-5H5a1 1 0 0 1 0-2h2V2h4v2h2a1 1 0 1 1 0 2Z"/>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -28,7 +28,7 @@ const updateNotificationPreferences = () => {
 <template>
     <FormSection v-if="planSupportsNotifications" @submitted="updateNotificationPreferences">
         <template #title>
-            Notification Preferences
+            Email Notifications
         </template>
 
         <template #description>
@@ -64,7 +64,7 @@ const updateNotificationPreferences = () => {
 
     <ActionSection v-else>
         <template #title>
-            Notification Preferences
+            Email Notifications
         </template>
 
         <template #description>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { Link, useForm, usePage, router } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
+import CodeBlock from '@/Components/CodeBlock.vue';
 import ConfirmationModal from '@/Components/ConfirmationModal.vue';
 import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
 import DangerButton from '@/Components/DangerButton.vue';
@@ -25,7 +26,6 @@ const regenerating = ref(false);
 const deleting = ref(false);
 const testing = ref(false);
 const testDispatched = ref(false);
-const secretCopied = ref(false);
 
 const form = useForm({
     webhook_url: webhook.value?.webhook_url ?? '',
@@ -56,14 +56,6 @@ const revealSecret = () => {
 
 const hideSecret = () => {
     revealedSecret.value = null;
-};
-
-const copySecret = () => {
-    if (revealedSecret.value) {
-        navigator.clipboard.writeText(revealedSecret.value);
-        secretCopied.value = true;
-        setTimeout(() => { secretCopied.value = false; }, 2000);
-    }
 };
 
 const regenerateSecret = () => {
@@ -145,9 +137,7 @@ const testWebhook = () => {
             <div v-if="webhook?.webhook_url" class="col-span-6">
                 <InputLabel value="Webhook Secret" />
                 <div class="mt-1 flex items-center gap-3">
-                    <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                        {{ revealedSecret ?? '••••••••••••••••••••••••••••••••' }}
-                    </code>
+                    <CodeBlock :value="revealedSecret ?? ''" :masked="!revealedSecret" class="flex-1" />
                     <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
                         <SecondaryButton type="button" :class="{ 'opacity-25': revealing }" :disabled="revealing">
                             Show
@@ -155,14 +145,6 @@ const testWebhook = () => {
                     </ConfirmsPasswordOrPasskey>
                     <SecondaryButton v-else type="button" @click="hideSecret">
                         Hide
-                    </SecondaryButton>
-                    <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
-                        <SecondaryButton type="button">
-                            Copy
-                        </SecondaryButton>
-                    </ConfirmsPasswordOrPasskey>
-                    <SecondaryButton v-else type="button" @click="copySecret">
-                        {{ secretCopied ? 'Copied!' : 'Copy' }}
                     </SecondaryButton>
                 </div>
                 <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -4,7 +4,6 @@
     import { computed, ref } from 'vue';
     import TextAreaInput from '@/Components/TextAreaInput.vue';
     import PrimaryButton from '@/Components/PrimaryButton.vue';
-    import SecondaryButton from '@/Components/SecondaryButton.vue';
     import TextInput from '@/Components/TextInput.vue';
     import InputError from '@/Components/InputError.vue';
     import FlatFormSection from '@/Components/FlatFormSection.vue';
@@ -38,13 +37,6 @@
     });
 
     const decryptionSuccess = ref(false)
-    const messageCopied = ref(false)
-
-    const copyMessage = () => {
-        navigator.clipboard.writeText(form.message);
-        messageCopied.value = true;
-        setTimeout(() => { messageCopied.value = false; }, 2000);
-    }
 
     const messageClass = computed(() => {
         if(props.secret) {
@@ -244,12 +236,8 @@
                     <CodeBlock v-if="stage=='generated'" :value="$page.props.jetstream.flash?.secret?.url" class="break-words mt-1"/>
                 </span>
                 <span v-else>
-                    <TextAreaInput :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
-                    <div v-if="decryptionSuccess && props.secret != null" class="mt-2 flex justify-end">
-                        <SecondaryButton type="button" @click="copyMessage">
-                            {{ messageCopied ? 'Copied!' : 'Copy Message' }}
-                        </SecondaryButton>
-                    </div>
+                    <CodeBlock v-if="decryptionSuccess && props.secret != null" :value="form.message" class="mt-1" />
+                    <TextAreaInput v-else :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
                     <div class="flex flex-wrap mt-2 relative text-sm gap-2">
                         <div class="flex flex-wrap">
                             <svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -4,6 +4,7 @@
     import { computed, ref } from 'vue';
     import TextAreaInput from '@/Components/TextAreaInput.vue';
     import PrimaryButton from '@/Components/PrimaryButton.vue';
+    import SecondaryButton from '@/Components/SecondaryButton.vue';
     import TextInput from '@/Components/TextInput.vue';
     import InputError from '@/Components/InputError.vue';
     import FlatFormSection from '@/Components/FlatFormSection.vue';
@@ -37,6 +38,13 @@
     });
 
     const decryptionSuccess = ref(false)
+    const messageCopied = ref(false)
+
+    const copyMessage = () => {
+        navigator.clipboard.writeText(form.message);
+        messageCopied.value = true;
+        setTimeout(() => { messageCopied.value = false; }, 2000);
+    }
 
     const messageClass = computed(() => {
         if(props.secret) {
@@ -237,6 +245,11 @@
                 </span>
                 <span v-else>
                     <TextAreaInput :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
+                    <div v-if="decryptionSuccess && props.secret != null" class="mt-2 flex justify-end">
+                        <SecondaryButton type="button" @click="copyMessage">
+                            {{ messageCopied ? 'Copied!' : 'Copy Message' }}
+                        </SecondaryButton>
+                    </div>
                     <div class="flex flex-wrap mt-2 relative text-sm gap-2">
                         <div class="flex flex-wrap">
                             <svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">


### PR DESCRIPTION
## Summary

- Rename "Notification Preferences" heading to "Email Notifications" on the Notification Settings page
- Replace custom webhook secret display with the `CodeBlock` component — masked by default, copy button appears after reveal
- Add "Copy Message" button to the secret retrieval page after successful decryption

## Changes

- **`CodeBlock.vue`** — Add `masked` boolean prop (default `false`); when masked, shows placeholder bullets and hides the copy button. Copy source switched from DOM `innerText` to `props.value` directly. Backward-compatible — all existing usages unaffected.
- **`NotificationPreferencesForm.vue`** — Rename `#title` slot text to "Email Notifications" in both the subscriber and non-subscriber states.
- **`WebhookSettingsForm.vue`** — Use `<CodeBlock :masked="!revealedSecret" />` for secret display. Remove separate Copy button (both masked and revealed variants), `secretCopied` ref, and `copySecret()`. Auth-gated Show/Hide flow unchanged.
- **`SecretForm.vue`** — Import `SecondaryButton`; add `messageCopied` ref and `copyMessage()`; render "Copy Message" button only when `decryptionSuccess && props.secret != null`.

## Test Plan

- [x] Notification Settings heading reads "Email Notifications" (both paid and free plan states)
- [x] Webhook secret shows masked bullets with no copy button by default
- [x] Clicking Show triggers auth confirmation, then reveals secret with copy button in CodeBlock
- [x] Clicking Hide returns to masked state with copy button gone
- [x] Existing copy buttons on retrieval URL and password CodeBlocks in SecretForm still work correctly
- [x] "Copy Message" button appears after decryption on the retrieval page, copies plaintext
- [x] "Copy Message" button is absent before decryption and absent on the create-secret flow

## Regression Notes

- CodeBlock copy source changed from DOM `innerText` to `props.value` — spot-check the 3 existing CodeBlock usages in `SecretForm.vue` (retrieval URL, password, email) to confirm copy still works correctly.
- The masked-state webhook copy path is intentionally removed — users must reveal the secret before copying (consistent with how other sensitive values work in the app).