### PR TITLE
Release/v4.8.0

### DIFF
--- a/resources/js/Components/AuthenticationCardWithFeatures.vue
+++ b/resources/js/Components/AuthenticationCardWithFeatures.vue
@@ -1,0 +1,35 @@
+<script setup>
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+</script>
+
+<template>
+    <div class="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900 px-4 py-8">
+        <div class="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-0 overflow-hidden sm:rounded-lg shadow-md">
+            <!-- Branding Panel -->
+            <div class="bg-gray-800 dark:bg-gray-950 px-8 py-10 md:py-16 flex flex-col justify-center">
+                <div class="mb-8">
+                    <AuthenticationCardLogo />
+                </div>
+
+                <h1 class="text-2xl md:text-3xl font-bold text-white leading-tight">
+                    <slot name="heading" />
+                </h1>
+
+                <p class="mt-3 text-sm md:text-base text-gray-400 hidden md:block">
+                    <slot name="subtitle" />
+                </p>
+
+                <ul class="mt-6 md:mt-8 space-y-4">
+                    <slot name="features" />
+                </ul>
+            </div>
+
+            <!-- Form Panel -->
+            <div class="flex items-center justify-center bg-white dark:bg-gray-800 px-6 py-8 md:py-16">
+                <div class="w-full max-w-sm">
+                    <slot />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/CodeBlock.vue
+++ b/resources/js/Components/CodeBlock.vue
@@ -2,10 +2,13 @@
     import { ref } from 'vue';
 
     const props = defineProps({
-        value: String
+        value: String,
+        masked: {
+            type: Boolean,
+            default: false,
+        },
     })
 
-    const text = ref(null)
     const copied = ref(false)
 
     const copyText = (data) => {
@@ -19,10 +22,10 @@
 <div class="w-full">
     <div class="relative">
         <label for="npm-install-copy-button" class="sr-only">Copyable content</label>
-        <code ref="text" class="col-span-6 bg-gray-50 border border-gray-300 text-gray-700 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-gray-200 dark:focus:ring-blue-500 dark:focus:border-blue-500" disabled readonly>
-            <slot>{{ props.value }}</slot>
+        <code class="col-span-6 bg-gray-50 border border-gray-300 text-gray-700 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-gray-200 dark:focus:ring-blue-500 dark:focus:border-blue-500" disabled readonly>
+            <slot>{{ props.masked ? '••••••••••••••••••••••••••••••••' : props.value }}</slot>
         </code>
-        <button type="button" @click.prevent="copyText(text.innerText)" class="group absolute end-2 bottom-1 translate-y-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 rounded-lg p-1.5 mb-1 inline-flex items-center justify-center transition-colors">
+        <button v-if="!props.masked" type="button" @click.prevent="copyText(props.value)" class="group absolute end-2 bottom-1 translate-y-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 rounded-lg p-1.5 mb-1 inline-flex items-center justify-center transition-colors">
             <span v-if="!copied">
                 <svg class="w-4 h-4" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 20">
                     <path d="M16 1h-3.278A1.992 1.992 0 0 0 11 0H7a1.993 1.993 0 0 0-1.722 1H2a2 2 0 0 0-2 2v15a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2Zm-3 14H5a1 1 0 0 1 0-2h8a1 1 0 0 1 0 2Zm0-4H5a1 1 0 0 1 0-2h8a1 1 0 1 1 0 2Zm0-5H5a1 1 0 0 1 0-2h2V2h4v2h2a1 1 0 1 1 0 2Z"/>

--- a/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -15,6 +15,7 @@ import SecondaryButton from '@/Components/SecondaryButton.vue';
 import SectionBorder from '@/Components/SectionBorder.vue';
 import TextInput from '@/Components/TextInput.vue';
 import Alert from '@/Components/Alert.vue';
+import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
 
 const props = defineProps({
     tokens: Array,
@@ -93,7 +94,7 @@ const deleteApiToken = () => {
         </div>
 
         <!-- Generate API Token -->
-        <FormSection @submitted="createApiToken">
+        <FormSection>
             <template #title>
                 Create API Token
             </template>
@@ -136,9 +137,11 @@ const deleteApiToken = () => {
                     Created.
                 </ActionMessage>
 
-                <PrimaryButton :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
-                    Create
-                </PrimaryButton>
+                <ConfirmsPasswordOrPasskey @confirmed="createApiToken">
+                    <PrimaryButton type="button" :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
+                        Create
+                    </PrimaryButton>
+                </ConfirmsPasswordOrPasskey>
             </template>
         </FormSection>
 
@@ -200,9 +203,11 @@ const deleteApiToken = () => {
                                         Permissions
                                     </button>
 
-                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmApiTokenDeletion(token)">
-                                        Delete
-                                    </button>
+                                    <ConfirmsPasswordOrPasskey @confirmed="confirmApiTokenDeletion(token)" title="Confirm Token Deletion" content="Please verify your identity before deleting this API token.">
+                                        <button class="cursor-pointer ms-6 text-sm text-red-500">
+                                            Delete
+                                        </button>
+                                    </ConfirmsPasswordOrPasskey>
                                 </div>
                             </div>
                         </div>
@@ -256,14 +261,16 @@ const deleteApiToken = () => {
                     Cancel
                 </SecondaryButton>
 
-                <PrimaryButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': updateApiTokenForm.processing }"
-                    :disabled="updateApiTokenForm.processing"
-                    @click="updateApiToken"
-                >
-                    Save
-                </PrimaryButton>
+                <ConfirmsPasswordOrPasskey @confirmed="updateApiToken">
+                    <PrimaryButton
+                        type="button"
+                        class="ms-3"
+                        :class="{ 'opacity-25': updateApiTokenForm.processing }"
+                        :disabled="updateApiTokenForm.processing"
+                    >
+                        Save
+                    </PrimaryButton>
+                </ConfirmsPasswordOrPasskey>
             </template>
         </DialogModal>
 

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Head, Link, useForm } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
@@ -19,9 +18,40 @@ const submit = () => {
 <template>
     <Head title="Register" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            Secrets that disappear after one view
+        </template>
+
+        <template #subtitle>
+            Keep sensitive information out of your email and chat logs
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">End-to-end encrypted — secrets are encrypted in your browser</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Auto-expiring links — set custom expiry times</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">One-time access — links are destroyed after viewing</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Personal dashboard to manage your shared secrets</span>
+            </li>
         </template>
 
         <form @submit.prevent="submit">
@@ -49,5 +79,5 @@ const submit = () => {
                 </PrimaryButton>
             </div>
         </form>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/resources/js/Pages/Auth/RegisterComplete.vue
+++ b/resources/js/Pages/Auth/RegisterComplete.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Head, useForm } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 import Checkbox from '@/Components/Checkbox.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
@@ -39,9 +38,40 @@ const submit = () => {
 <template>
     <Head title="Complete Registration" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            Almost there
+        </template>
+
+        <template #subtitle>
+            Complete your account to unlock additional features
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Longer expiry options for your secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Higher message size limits</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Dashboard to track your shared secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Webhook notifications</span>
+            </li>
         </template>
 
         <form @submit.prevent="submit">
@@ -118,5 +148,5 @@ const submit = () => {
                 </PrimaryButton>
             </div>
         </form>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/resources/js/Pages/Auth/RegisterSuccess.vue
+++ b/resources/js/Pages/Auth/RegisterSuccess.vue
@@ -1,15 +1,45 @@
 <script setup>
 import { Head, Link } from '@inertiajs/vue3';
-import AuthenticationCard from '@/Components/AuthenticationCard.vue';
-import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import AuthenticationCardWithFeatures from '@/Components/AuthenticationCardWithFeatures.vue';
 </script>
 
 <template>
     <Head title="Check Your Email" />
 
-    <AuthenticationCard>
-        <template #logo>
-            <AuthenticationCardLogo />
+    <AuthenticationCardWithFeatures>
+        <template #heading>
+            You're almost there
+        </template>
+
+        <template #subtitle>
+            Here's what you'll get with your FlashView account
+        </template>
+
+        <template #features>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">End-to-end encrypted secret sharing</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Extended expiry options and higher limits</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Personal dashboard to track your secrets</span>
+            </li>
+            <li class="flex items-start gap-3">
+                <svg class="flex-shrink-0 w-4 h-4 text-gamboge-700 dark:text-gamboge-200 mt-1" aria-hidden="true" xmlns="https://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
+                </svg>
+                <span class="text-sm text-gray-300">Webhook notifications for secret access</span>
+            </li>
         </template>
 
         <div class="text-center">
@@ -36,5 +66,5 @@ import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
                 </Link>
             </div>
         </div>
-    </AuthenticationCard>
+    </AuthenticationCardWithFeatures>
 </template>

--- a/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
+++ b/resources/js/Pages/Profile/Partials/NotificationPreferencesForm.vue
@@ -28,7 +28,7 @@ const updateNotificationPreferences = () => {
 <template>
     <FormSection v-if="planSupportsNotifications" @submitted="updateNotificationPreferences">
         <template #title>
-            Notification Preferences
+            Email Notifications
         </template>
 
         <template #description>
@@ -64,7 +64,7 @@ const updateNotificationPreferences = () => {
 
     <ActionSection v-else>
         <template #title>
-            Notification Preferences
+            Email Notifications
         </template>
 
         <template #description>

--- a/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
+++ b/resources/js/Pages/Profile/Partials/WebhookSettingsForm.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { Link, useForm, usePage, router } from '@inertiajs/vue3';
 import ActionMessage from '@/Components/ActionMessage.vue';
 import ActionSection from '@/Components/ActionSection.vue';
+import CodeBlock from '@/Components/CodeBlock.vue';
 import ConfirmationModal from '@/Components/ConfirmationModal.vue';
 import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
 import DangerButton from '@/Components/DangerButton.vue';
@@ -25,7 +26,6 @@ const regenerating = ref(false);
 const deleting = ref(false);
 const testing = ref(false);
 const testDispatched = ref(false);
-const secretCopied = ref(false);
 
 const form = useForm({
     webhook_url: webhook.value?.webhook_url ?? '',
@@ -56,14 +56,6 @@ const revealSecret = () => {
 
 const hideSecret = () => {
     revealedSecret.value = null;
-};
-
-const copySecret = () => {
-    if (revealedSecret.value) {
-        navigator.clipboard.writeText(revealedSecret.value);
-        secretCopied.value = true;
-        setTimeout(() => { secretCopied.value = false; }, 2000);
-    }
 };
 
 const regenerateSecret = () => {
@@ -145,9 +137,7 @@ const testWebhook = () => {
             <div v-if="webhook?.webhook_url" class="col-span-6">
                 <InputLabel value="Webhook Secret" />
                 <div class="mt-1 flex items-center gap-3">
-                    <code class="flex-1 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                        {{ revealedSecret ?? '••••••••••••••••••••••••••••••••' }}
-                    </code>
+                    <CodeBlock :value="revealedSecret ?? ''" :masked="!revealedSecret" class="flex-1" />
                     <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
                         <SecondaryButton type="button" :class="{ 'opacity-25': revealing }" :disabled="revealing">
                             Show
@@ -155,14 +145,6 @@ const testWebhook = () => {
                     </ConfirmsPasswordOrPasskey>
                     <SecondaryButton v-else type="button" @click="hideSecret">
                         Hide
-                    </SecondaryButton>
-                    <ConfirmsPasswordOrPasskey v-if="!revealedSecret" @confirmed="revealSecret">
-                        <SecondaryButton type="button">
-                            Copy
-                        </SecondaryButton>
-                    </ConfirmsPasswordOrPasskey>
-                    <SecondaryButton v-else type="button" @click="copySecret">
-                        {{ secretCopied ? 'Copied!' : 'Copy' }}
                     </SecondaryButton>
                 </div>
                 <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -236,7 +236,8 @@
                     <CodeBlock v-if="stage=='generated'" :value="$page.props.jetstream.flash?.secret?.url" class="break-words mt-1"/>
                 </span>
                 <span v-else>
-                    <TextAreaInput :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
+                    <CodeBlock v-if="decryptionSuccess && props.secret != null" :value="form.message" class="mt-1" />
+                    <TextAreaInput v-else :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
                     <div class="flex flex-wrap mt-2 relative text-sm gap-2">
                         <div class="flex flex-wrap">
                             <svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -200,28 +200,6 @@
         
     }
 </script>
-<style>
-    .underline-svg {
-      position: absolute;
-      bottom: -12px; /* Adjust for spacing */
-      left: 0;
-      width: 100%;
-      height: 20px; /* Adjust SVG height */
-      fill: none;
-      /* stroke: #3b82f6; Tailwind's blue-500 */
-      @apply stroke-gamboge-500;
-      stroke-width: 8; /* Double thickness */
-      stroke-dasharray: 400; /* Total length of the path */
-      stroke-dashoffset: 400; /* Initially hidden */
-      animation: draw 1s cubic-bezier(0.25, 1, 0.5, 1) forwards;
-    }
-
-    @keyframes draw {
-      to {
-        stroke-dashoffset: 0;
-      }
-    }
-</style>
 <template>
     <FlatFormSection>
         <template #title>
@@ -231,20 +209,17 @@
         <template #form>
             <div class="col-span-12">
                 <Alert v-if="props.secret != null" type="Warning" hide-title>
-                    <div class="mb-2">
-                        You can attempt to retrieve this message 
-                        <span class="relative inline-block">
-                            ONLY ONCE
-                            <svg class="underline-svg" xmlns="https://www.w3.org/2000/svg" viewBox="0 0 300 20">
-                                <path d="M0 15 Q150 -10 300 15" />
-                            </svg>
-                        </span>.
+                    <div class="space-y-2">
+                        <p class="font-semibold">
+                            This message will self-destruct after one retrieval attempt &mdash; even if you enter the wrong password.
+                        </p>
+                        <p>
+                            Please double-check your password before submitting &mdash; this cannot be undone.
+                        </p>
+                        <p class="text-xs opacity-75">
+                            Unretrieved messages are also deleted after expiration.
+                        </p>
                     </div>
-                    <ol class="space-y-1 list-decimal list-inside">
-                        <li>Wrong password will result in the message being deleted.</li>
-                        <li>Correct password will show the message, and the message will be deleted.</li>
-                        <li>Message will be deleted after the expiration time.</li>
-                    </ol>
                 </Alert>
                 <Alert hide-title v-if="$page.props.jetstream.flash.error?.code == 404" type="Error">
                     This message has expired or has already been retrieved.

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,11 +114,19 @@ Route::middleware([
 
     Route::middleware([EnsurePlanHasApiAccess::class])->group(function () {
         Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
-        Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-        Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
-        Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+        Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.store');
+        Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.update');
+        Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])
+            ->middleware('password.confirm')
+            ->name('api-tokens.destroy');
 
-        Route::delete('/user/cli-installations/{token}', [CliInstallationController::class, 'destroy'])->name('cli-installations.destroy');
+        Route::delete('/user/cli-installations/{token}', [CliInstallationController::class, 'destroy'])
+            ->middleware('password.confirm')
+            ->name('cli-installations.destroy');
 
         Route::put('/user/webhook-settings', [WebhookSettingsController::class, 'update'])
             ->name('user.webhook-settings.update');

--- a/tests/Feature/ApiTokenPermissionsTest.php
+++ b/tests/Feature/ApiTokenPermissionsTest.php
@@ -45,16 +45,59 @@ class ApiTokenPermissionsTest extends TestCase
             'abilities' => ['secrets:create', 'secrets:list'],
         ]);
 
-        $this->put('/user/api-tokens/'.$token->id, [
-            'name' => $token->name,
-            'permissions' => [
-                'secrets:delete',
-                'missing-permission',
-            ],
-        ]);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->put('/user/api-tokens/'.$token->id, [
+                'name' => $token->name,
+                'permissions' => [
+                    'secrets:delete',
+                    'missing-permission',
+                ],
+            ]);
 
         $this->assertTrue($user->fresh()->tokens->first()->can('secrets:delete'));
         $this->assertFalse($user->fresh()->tokens->first()->can('secrets:list'));
         $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+    }
+
+    public function test_updating_api_token_permissions_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_perms_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $token = $user->tokens()->create([
+            'name' => 'Test Token',
+            'token' => Str::random(40),
+            'abilities' => ['secrets:create', 'secrets:list'],
+        ]);
+
+        $response = $this->put('/user/api-tokens/'.$token->id, [
+            'name' => $token->name,
+            'permissions' => ['secrets:delete'],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertFalse($user->fresh()->tokens->first()->can('secrets:delete'));
+        $this->assertTrue($user->fresh()->tokens->first()->can('secrets:create'));
     }
 }

--- a/tests/Feature/CliInstallationTest.php
+++ b/tests/Feature/CliInstallationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CliInstallationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSubscribedUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_cli_test_'.Str::random(8),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        return $user;
+    }
+
+    public function test_unauthenticated_user_cannot_delete_cli_installation(): void
+    {
+        $response = $this->delete('/user/cli-installations/1');
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_cli_installation_can_be_deleted(): void
+    {
+        $user = $this->createSubscribedUser();
+        $this->actingAs($user);
+
+        $token = $user->tokens()->create([
+            'name' => 'My CLI',
+            'token' => Str::random(40),
+            'abilities' => ['*'],
+            'type' => 'cli',
+        ]);
+
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/cli-installations/'.$token->id);
+
+        $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    public function test_deleting_cli_installation_requires_password_confirmation(): void
+    {
+        $user = $this->createSubscribedUser();
+        $this->actingAs($user);
+
+        $token = $user->tokens()->create([
+            'name' => 'My CLI',
+            'token' => Str::random(40),
+            'abilities' => ['*'],
+            'type' => 'cli',
+        ]);
+
+        $response = $this->delete('/user/cli-installations/'.$token->id);
+
+        $response->assertRedirect();
+        $this->assertCount(1, $user->fresh()->tokens);
+    }
+}

--- a/tests/Feature/CliMultipleInstallationsTest.php
+++ b/tests/Feature/CliMultipleInstallationsTest.php
@@ -207,6 +207,7 @@ class CliMultipleInstallationsTest extends TestCase
         $tokenToDelete = $tokens->where('name', 'Delete This')->first();
 
         $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$tokenToDelete->id}");
 
         $response->assertRedirect();
@@ -225,6 +226,7 @@ class CliMultipleInstallationsTest extends TestCase
         $token = $user1->fresh()->tokens()->where('type', 'cli')->first();
 
         $this->actingAs($user2)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$token->id}")
             ->assertNotFound();
 
@@ -238,6 +240,7 @@ class CliMultipleInstallationsTest extends TestCase
         $apiToken = $user->createToken('API Token', ['secrets:create']);
 
         $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
             ->delete("/user/cli-installations/{$apiToken->accessToken->id}")
             ->assertNotFound();
     }

--- a/tests/Feature/CreateApiTokenTest.php
+++ b/tests/Feature/CreateApiTokenTest.php
@@ -38,17 +38,53 @@ class CreateApiTokenTest extends TestCase
             'quantity' => 1,
         ]);
 
-        $this->post('/user/api-tokens', [
-            'name' => 'Test Token',
-            'permissions' => [
-                'secrets:create',
-                'secrets:list',
-            ],
-        ]);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->post('/user/api-tokens', [
+                'name' => 'Test Token',
+                'permissions' => [
+                    'secrets:create',
+                    'secrets:list',
+                ],
+            ]);
 
         $this->assertCount(1, $user->fresh()->tokens);
         $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
         $this->assertTrue($user->fresh()->tokens->first()->can('secrets:create'));
         $this->assertFalse($user->fresh()->tokens->first()->can('secrets:delete'));
+    }
+
+    public function test_creating_api_token_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_create_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $response = $this->post('/user/api-tokens', [
+            'name' => 'Test Token',
+            'permissions' => ['secrets:create'],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertCount(0, $user->fresh()->tokens);
     }
 }

--- a/tests/Feature/DeleteApiTokenTest.php
+++ b/tests/Feature/DeleteApiTokenTest.php
@@ -45,8 +45,47 @@ class DeleteApiTokenTest extends TestCase
             'abilities' => ['secrets:create', 'secrets:list'],
         ]);
 
-        $this->delete('/user/api-tokens/'.$token->id);
+        $this->withSession(['auth.password_confirmed_at' => time()])
+            ->delete('/user/api-tokens/'.$token->id);
 
         $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    public function test_deleting_api_token_requires_password_confirmation(): void
+    {
+        if (! Features::hasApiFeatures()) {
+            $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        $plan = Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => 'price_monthly_prime',
+            'stripe_yearly_price_id' => 'price_yearly_prime',
+            'stripe_product_id' => 'prod_prime',
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => ['api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature']],
+        ]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_delete_confirm',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $token = $user->tokens()->create([
+            'name' => 'Test Token',
+            'token' => Str::random(40),
+            'abilities' => ['secrets:create'],
+        ]);
+
+        $response = $this->delete('/user/api-tokens/'.$token->id);
+
+        $response->assertRedirect();
+        $this->assertCount(1, $user->fresh()->tokens);
     }
 }

--- a/tests/Feature/RegisterPageDesignTest.php
+++ b/tests/Feature/RegisterPageDesignTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\URL;
+use Inertia\Testing\AssertableInertia;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class RegisterPageDesignTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get('/register');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/Register')
+        );
+    }
+
+    public function test_register_complete_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $signedUrl = URL::temporarySignedRoute(
+            'register.complete',
+            now()->addMinutes(120),
+            ['email' => 'newuser@example.com']
+        );
+
+        $response = $this->get($signedUrl);
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/RegisterComplete')
+            ->has('email')
+            ->has('signedUrl')
+        );
+    }
+
+    public function test_register_success_page_renders_correct_component(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration support is not enabled.');
+        }
+
+        $response = $this->get(route('register.success'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Auth/RegisterSuccess')
+        );
+    }
+}

--- a/tests/Feature/Web/SecretControllerTest.php
+++ b/tests/Feature/Web/SecretControllerTest.php
@@ -89,6 +89,16 @@ class SecretControllerTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_show_passes_secret_prop_to_inertia(): void
+    {
+        $secret = Secret::factory()->create();
+        $signedUrl = URL::temporarySignedRoute('secret.show', now()->addHour(), ['secret' => $secret->hash_id]);
+
+        $response = $this->get($signedUrl);
+
+        $response->assertInertia(fn ($page) => $page->has('secret'));
+    }
+
     public function test_show_rejects_invalid_signature(): void
     {
         $secret = Secret::factory()->create();


### PR DESCRIPTION
**Commits since last release:** 3

**Change breakdown:**

- **Features (minor):**
  - `Add authentication confirmation for API token actions (PIO-62)` — new auth confirmation UX
  - `Redesign register pages with split-layout branding panel (PIO-61)` — new page design
- **Fixes/improvements (patch):**
  - `Reword secret retrieval warning to lead with critical risk (PIO-58)` — copy/UX tweak

No breaking changes. Two feature-level commits → **minor bump**.
