### PR TITLE
Store masked recipient email address & introduce Settings page (PIO-56)

### DIFF
--- a/app/Http/Controllers/Api/SecretController.php
+++ b/app/Http/Controllers/Api/SecretController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\StoreSecretRequest;
 use App\Http\Resources\SecretMessageResource;
 use App\Http\Resources\SecretResource;
 use App\Models\Secret;
+use App\Services\EmailMaskingService;
 use App\Services\SecretService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controllers\HasMiddleware;
@@ -18,7 +19,10 @@ use Illuminate\Routing\Controllers\Middleware;
 
 class SecretController extends Controller implements HasMiddleware
 {
-    public function __construct(private SecretService $secretService) {}
+    public function __construct(
+        private SecretService $secretService,
+        private EmailMaskingService $emailMaskingService,
+    ) {}
 
     public static function middleware(): array
     {
@@ -42,10 +46,17 @@ class SecretController extends Controller implements HasMiddleware
      */
     public function store(StoreSecretRequest $request): JsonResponse
     {
+        $maskedRecipientEmail = null;
+
+        if ($request->user()->store_masked_recipient_email && $email = $request->safe()->email) {
+            $maskedRecipientEmail = $this->emailMaskingService->mask($email);
+        }
+
         $result = $this->secretService->createSecret(
             $request->message,
             (int) $request->expires_in,
             $request->user()->id,
+            $maskedRecipientEmail,
         );
 
         if ($email = $request->safe()->email) {

--- a/app/Http/Controllers/ConfigurationController.php
+++ b/app/Http/Controllers/ConfigurationController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateConfigurationRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ConfigurationController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        return Inertia::render('Settings/Index', [
+            'storeMaskedRecipientEmail' => (bool) $request->user()->store_masked_recipient_email,
+        ]);
+    }
+
+    public function update(UpdateConfigurationRequest $request): RedirectResponse
+    {
+        $request->user()->update($request->validated());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/SecretController.php
+++ b/app/Http/Controllers/SecretController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\BurnSecretRequest;
 use App\Http\Requests\StoreSecretRequest;
 use App\Http\Resources\SecretResourceCollection;
 use App\Models\Secret;
+use App\Services\EmailMaskingService;
 use App\Services\SecretService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -39,10 +40,17 @@ class SecretController extends Controller implements HasMiddleware
      */
     public function store(StoreSecretRequest $request): RedirectResponse
     {
+        $maskedRecipientEmail = null;
+
+        if ($request->user()?->store_masked_recipient_email && $email = $request->safe()->email) {
+            $maskedRecipientEmail = app(EmailMaskingService::class)->mask($email);
+        }
+
         $result = $this->secretService->createSecret(
             $request->message,
             (int) $request->expires_in,
             $request->user()?->id,
+            $maskedRecipientEmail,
         );
 
         if ($request->user() && $email = $request->safe()->email) {

--- a/app/Http/Controllers/SecretController.php
+++ b/app/Http/Controllers/SecretController.php
@@ -18,7 +18,10 @@ use Inertia\Response;
 
 class SecretController extends Controller implements HasMiddleware
 {
-    public function __construct(private SecretService $secretService) {}
+    public function __construct(
+        private SecretService $secretService,
+        private EmailMaskingService $emailMaskingService,
+    ) {}
 
     public static function middleware(): array
     {
@@ -43,7 +46,7 @@ class SecretController extends Controller implements HasMiddleware
         $maskedRecipientEmail = null;
 
         if ($request->user()?->store_masked_recipient_email && $email = $request->safe()->email) {
-            $maskedRecipientEmail = app(EmailMaskingService::class)->mask($email);
+            $maskedRecipientEmail = $this->emailMaskingService->mask($email);
         }
 
         $result = $this->secretService->createSecret(

--- a/app/Http/Requests/UpdateConfigurationRequest.php
+++ b/app/Http/Requests/UpdateConfigurationRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateConfigurationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'store_masked_recipient_email' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Resources/SecretResource.php
+++ b/app/Http/Resources/SecretResource.php
@@ -21,6 +21,7 @@ class SecretResource extends JsonResource
             'is_expired' => $this->expires_at->isPast(),
             'is_retrieved' => $this->retrieved_at !== null,
             'retrieved_at' => $this->retrieved_at,
+            'masked_recipient_email' => $this->masked_recipient_email,
         ];
     }
 }

--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -52,6 +52,7 @@ class Secret extends Model
             'message' => 'encrypted',
             'ip_address_sent' => 'encrypted',
             'ip_address_retrieved' => 'encrypted',
+            'masked_recipient_email' => 'encrypted',
         ];
     }
 

--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -32,6 +32,7 @@ class Secret extends Model
         'filename',
         'user_id',
         'expires_at',
+        'masked_recipient_email',
     ];
 
     protected $hidden = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,6 +43,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'notify_secret_retrieved',
         'webhook_url',
         'webhook_secret',
+        'store_masked_recipient_email',
     ];
 
     /**
@@ -167,6 +168,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
             'password' => 'hashed',
             'notify_secret_retrieved' => 'boolean',
             'webhook_secret' => 'encrypted',
+            'store_masked_recipient_email' => 'boolean',
         ];
     }
 

--- a/app/Services/EmailMaskingService.php
+++ b/app/Services/EmailMaskingService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Str;
+
+class EmailMaskingService
+{
+    /**
+     * Mask an email address, preserving the first character of each part.
+     *
+     * Examples:
+     *
+     *   john.doe@example.com  → j*******@e******.com
+     *
+     *   user@mail.example.com → u***@m***.example.com
+     *   a@b.io                → a@b.io
+     */
+    public function mask(string $email): string
+    {
+        [$local, $domain] = explode('@', $email, 2);
+
+        $domainParts = explode('.', $domain);
+        $tld = array_pop($domainParts);
+
+        // Guard: bare hostname with no dot (e.g. user@localhost).
+        // The email validation rule in StoreSecretRequest prevents this in
+        // production, but this guard ensures no null-dereference defensively.
+        if (empty($domainParts)) {
+            return Str::mask($local, '*', 1).'@'.Str::mask($tld, '*', 1);
+        }
+
+        $firstLabel = array_shift($domainParts);
+        $remaining = count($domainParts) > 0 ? '.'.implode('.', $domainParts) : '';
+
+        return Str::mask($local, '*', 1).'@'.Str::mask($firstLabel, '*', 1).$remaining.'.'.$tld;
+    }
+}

--- a/app/Services/SecretService.php
+++ b/app/Services/SecretService.php
@@ -16,7 +16,7 @@ class SecretService
      *
      * @return array{secret: Secret, url: string}
      */
-    public function createSecret(string $message, int $expiresInMinutes, ?int $userId = null): array
+    public function createSecret(string $message, int $expiresInMinutes, ?int $userId = null, ?string $maskedRecipientEmail = null): array
     {
         $expiresAt = now()->addMinutes($expiresInMinutes);
 
@@ -24,6 +24,7 @@ class SecretService
             'message' => $message,
             'expires_at' => $expiresAt,
             'user_id' => $userId,
+            'masked_recipient_email' => $maskedRecipientEmail,
         ]);
 
         $url = URL::temporarySignedRoute('secret.show', $expiresAt, ['secret' => $secret->hash_id]);

--- a/database/migrations/2026_04_05_063004_add_masked_recipient_email_to_secrets_table.php
+++ b/database/migrations/2026_04_05_063004_add_masked_recipient_email_to_secrets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('secrets', function (Blueprint $table) {
+            $table->string('masked_recipient_email')->nullable()->after('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('secrets', function (Blueprint $table) {
+            $table->dropColumn('masked_recipient_email');
+        });
+    }
+};

--- a/database/migrations/2026_04_05_063004_add_store_masked_recipient_email_to_users_table.php
+++ b/database/migrations/2026_04_05_063004_add_store_masked_recipient_email_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('store_masked_recipient_email')->default(false)->after('webhook_secret');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('store_masked_recipient_email');
+        });
+    }
+};

--- a/database/migrations/2026_04_05_064108_change_masked_recipient_email_to_text_in_secrets_table.php
+++ b/database/migrations/2026_04_05_064108_change_masked_recipient_email_to_text_in_secrets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('secrets', function (Blueprint $table) {
+            $table->text('masked_recipient_email')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('secrets', function (Blueprint $table) {
+            $table->string('masked_recipient_email')->nullable()->change();
+        });
+    }
+};

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -196,6 +196,10 @@ const logout = () => {
                                                 Notification Settings
                                             </DropdownLink>
 
+                                            <DropdownLink :href="route('user.settings.index')">
+                                                Settings
+                                            </DropdownLink>
+
                                             <DropdownLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"
                                                 :href="route('api-tokens.index')">
                                                 API Tokens
@@ -311,6 +315,11 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('user.notification-settings.index')"
                                     :active="route().current('user.notification-settings.index')">
                                     Notification Settings
+                                </ResponsiveNavLink>
+
+                                <ResponsiveNavLink :href="route('user.settings.index')"
+                                    :active="route().current('user.settings.index')">
+                                    Settings
                                 </ResponsiveNavLink>
 
                                 <ResponsiveNavLink v-if="$page.props.jetstream.hasApiFeatures && $page.props.auth?.hasApiAccess"

--- a/resources/js/Pages/Secret/Index.vue
+++ b/resources/js/Pages/Secret/Index.vue
@@ -45,6 +45,9 @@ const burn = () => {
                             <th scope="col" class="px-6 py-3">
                                 Message ID
                             </th>
+                            <th v-if="hasAnyRecipient" scope="col" class="px-6 py-3 text-center">
+                                Recipient
+                            </th>
                             <th scope="col" class="px-6 py-3 text-center">
                                 Created At
                             </th>
@@ -54,9 +57,6 @@ const burn = () => {
                             <th scope="col" class="px-6 py-3 text-center">
                                 Retrieved / Burned At
                             </th>
-                            <th v-if="hasAnyRecipient" scope="col" class="px-6 py-3 text-center">
-                                Recipient
-                            </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -64,6 +64,10 @@ const burn = () => {
                             <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
                                 {{ secret.hash_id }}
                             </th>
+                            <td v-if="hasAnyRecipient" class="px-6 py-4 text-center">
+                                <span v-if="secret.masked_recipient_email" class="font-mono text-xs">{{ secret.masked_recipient_email }}</span>
+                                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+                            </td>
                             <td class="px-6 py-4 text-center">
                                 {{ DateTime.fromISO(secret.created_at).toLocaleString(DateTime.DATETIME_MED) }}
                             </td>
@@ -73,10 +77,6 @@ const burn = () => {
                             <td class="px-6 py-4 text-center">
                                 <span v-if="secret.retrieved_at">{{ DateTime.fromISO(secret.retrieved_at).toLocaleString(DateTime.DATETIME_MED) }}</span>
                                 <button v-if="!secret.retrieved_at" @click.prevent="() => messageIdBeingDeleted = secret" class="inline-flex items-center font-medium text-red-600 dark:text-red-500 hover:underline cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-offset-red-800">Burn</button>
-                            </td>
-                            <td v-if="hasAnyRecipient" class="px-6 py-4 text-center">
-                                <span v-if="secret.masked_recipient_email" class="font-mono text-xs">{{ secret.masked_recipient_email }}</span>
-                                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
                             </td>
                         </tr>
                         <tr class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700">

--- a/resources/js/Pages/Secret/Index.vue
+++ b/resources/js/Pages/Secret/Index.vue
@@ -4,14 +4,18 @@ import Page from '../Page.vue';
 import { DateTime } from 'luxon';
 import { useForm } from '@inertiajs/vue3';
 import ConfirmationModal from '@/Components/ConfirmationModal.vue';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import DangerButton from '@/Components/DangerButton.vue';
 import Paginator from '@/Components/Paginator.vue';
 
-defineProps({
+const props = defineProps({
     secrets: Array
 })
+
+const hasAnyRecipient = computed(() =>
+    props.secrets.data?.some(s => s.masked_recipient_email)
+);
 
 const form = useForm({})
 
@@ -50,6 +54,9 @@ const burn = () => {
                             <th scope="col" class="px-6 py-3 text-center">
                                 Retrieved / Burned At
                             </th>
+                            <th v-if="hasAnyRecipient" scope="col" class="px-6 py-3 text-center">
+                                Recipient
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -67,9 +74,13 @@ const burn = () => {
                                 <span v-if="secret.retrieved_at">{{ DateTime.fromISO(secret.retrieved_at).toLocaleString(DateTime.DATETIME_MED) }}</span>
                                 <button v-if="!secret.retrieved_at" @click.prevent="() => messageIdBeingDeleted = secret" class="inline-flex items-center font-medium text-red-600 dark:text-red-500 hover:underline cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-offset-red-800">Burn</button>
                             </td>
+                            <td v-if="hasAnyRecipient" class="px-6 py-4 text-center">
+                                <span v-if="secret.masked_recipient_email" class="font-mono text-xs">{{ secret.masked_recipient_email }}</span>
+                                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+                            </td>
                         </tr>
                         <tr class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700">
-                            <td colspan="4" class="text-center">
+                            <td :colspan="hasAnyRecipient ? 5 : 4" class="text-center">
                                 <Paginator :links="secrets.meta.links" />
                             </td>
                         </tr>

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -1,0 +1,25 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import StoreMaskedEmailForm from '@/Pages/Settings/Partials/StoreMaskedEmailForm.vue';
+import Page from '../Page.vue';
+
+defineProps({
+    storeMaskedRecipientEmail: Boolean,
+});
+</script>
+
+<template>
+    <AppLayout title="Settings">
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                Settings
+            </h2>
+        </template>
+
+        <Page>
+            <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+                <StoreMaskedEmailForm :store-masked-recipient-email="storeMaskedRecipientEmail" />
+            </div>
+        </Page>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Settings/Partials/StoreMaskedEmailForm.vue
+++ b/resources/js/Pages/Settings/Partials/StoreMaskedEmailForm.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { useForm } from '@inertiajs/vue3';
+import ActionMessage from '@/Components/ActionMessage.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import ConfirmsPasswordOrPasskey from '@/Components/ConfirmsPasswordOrPasskey.vue';
+import FormSection from '@/Components/FormSection.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+
+const props = defineProps({
+    storeMaskedRecipientEmail: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const form = useForm({
+    store_masked_recipient_email: props.storeMaskedRecipientEmail,
+});
+
+const saveConfiguration = () => {
+    form.put(route('user.settings.update'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <FormSection>
+        <template #title>
+            Email Privacy
+        </template>
+
+        <template #description>
+            Control how recipient email addresses are handled when creating secrets.
+        </template>
+
+        <template #form>
+            <div class="col-span-6">
+                <label class="flex items-center">
+                    <Checkbox v-model:checked="form.store_masked_recipient_email" />
+                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                        Store masked recipient email address
+                    </span>
+                </label>
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
+                    When enabled, a masked version of the recipient's email (e.g. <code>j***@e***.com</code>) will be stored alongside the secret so you can identify who it was sent to. The original email address is never stored.
+                </p>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-500">
+                    Turning this off only affects new secrets — masked emails on existing secrets are not removed.
+                </p>
+            </div>
+        </template>
+
+        <template #actions>
+            <ActionMessage :on="form.recentlySuccessful" class="me-3">
+                Saved.
+            </ActionMessage>
+
+            <ConfirmsPasswordOrPasskey @confirmed="saveConfiguration">
+                <PrimaryButton type="button" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Save
+                </PrimaryButton>
+            </ConfirmsPasswordOrPasskey>
+        </template>
+    </FormSection>
+</template>

--- a/resources/markdown/policy.md
+++ b/resources/markdown/policy.md
@@ -35,6 +35,10 @@ Additional information we collect include:
 3. Payment related information that helps us communicate with [Stripe](/https://stripe.com) and process payments.
 4. IP Addresses, browser user agents, and cookies used to make sure the website works as expected.
 
+## Recipient Email Addresses
+
+When the **"Store Masked Email"** privacy setting is enabled by an authenticated user, only a masked version of the recipient's email address (e.g. `j***@e***.com`) is stored alongside the secret. The original, unmasked email address is never stored on our servers. This setting is disabled by default, and enabling or disabling it requires password or passkey confirmation.
+
 ## Third Parties
 
 Where reasonable and practicable to do so, we will collect your Personal Information only from you. However, in some circumstances we may be provided with information by third parties (such as sharing your personal information with Stripe to help with payment processing). In such a case we will take reasonable steps to ensure that you are made aware of the information provided to us by the third party.

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\CliInstallationController;
+use App\Http\Controllers\ConfigurationController;
 use App\Http\Controllers\MarkdownDocumentController;
 use App\Http\Controllers\NotificationPreferencesController;
 use App\Http\Controllers\NotificationSettingsController;
@@ -103,6 +104,13 @@ Route::middleware([
 
     Route::get('/user/notification-settings', [NotificationSettingsController::class, 'index'])
         ->name('user.notification-settings.index');
+
+    Route::get('/user/settings', [ConfigurationController::class, 'index'])
+        ->name('user.settings.index');
+
+    Route::put('/user/settings', [ConfigurationController::class, 'update'])
+        ->middleware('password.confirm')
+        ->name('user.settings.update');
 
     Route::put('/user/notification-preferences', [NotificationPreferencesController::class, 'update'])
         ->name('user.notification-preferences.update');

--- a/tests/Feature/SecretMaskedEmailTest.php
+++ b/tests/Feature/SecretMaskedEmailTest.php
@@ -13,34 +13,6 @@ class SecretMaskedEmailTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function createApiPlan(string $monthlyPriceId, string $yearlyPriceId, string $productId): Plan
-    {
-        return Plan::factory()->create([
-            'name' => 'Prime',
-            'stripe_monthly_price_id' => $monthlyPriceId,
-            'stripe_yearly_price_id' => $yearlyPriceId,
-            'stripe_product_id' => $productId,
-            'price_per_month' => 50,
-            'price_per_year' => 500,
-            'features' => [
-                'messages' => ['order' => 2, 'label' => 'Messages', 'config' => ['message_length' => 100000], 'type' => 'feature'],
-                'expiry' => ['order' => 3, 'label' => 'Expiry', 'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200], 'type' => 'feature'],
-                'api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature'],
-            ],
-        ]);
-    }
-
-    private function subscribeUserToPlan(User $user, Plan $plan): void
-    {
-        $user->subscriptions()->create([
-            'type' => 'default',
-            'stripe_id' => 'sub_'.fake()->unique()->word(),
-            'stripe_status' => 'active',
-            'stripe_price' => $plan->stripe_monthly_price_id,
-            'quantity' => 1,
-        ]);
-    }
-
     private function validSecretPayload(int $plaintextLength = 50, int $expiresIn = 5): array
     {
         return [
@@ -138,13 +110,19 @@ class SecretMaskedEmailTest extends TestCase
 
     public function test_api_stores_masked_email_when_setting_enabled(): void
     {
-        $primePlan = $this->createApiPlan('price_monthly_prime_mask', 'price_yearly_prime_mask', 'prod_prime_mask');
+        $plan = Plan::factory()->withApiAccess()->create();
 
         $user = User::factory()->withPersonalTeam()->create([
             'store_masked_recipient_email' => true,
         ]);
 
-        $this->subscribeUserToPlan($user, $primePlan);
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_mask_enabled',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
 
         Sanctum::actingAs($user, ['secrets:create']);
 
@@ -163,13 +141,19 @@ class SecretMaskedEmailTest extends TestCase
 
     public function test_api_does_not_store_masked_email_when_setting_disabled(): void
     {
-        $primePlan = $this->createApiPlan('price_monthly_prime_mask2', 'price_yearly_prime_mask2', 'prod_prime_mask2');
+        $plan = Plan::factory()->withApiAccess()->create();
 
         $user = User::factory()->withPersonalTeam()->create([
             'store_masked_recipient_email' => false,
         ]);
 
-        $this->subscribeUserToPlan($user, $primePlan);
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_mask_disabled',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
 
         Sanctum::actingAs($user, ['secrets:create']);
 

--- a/tests/Feature/SecretMaskedEmailTest.php
+++ b/tests/Feature/SecretMaskedEmailTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Factories\SecretFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SecretMaskedEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function validSecretPayload(int $plaintextLength = 50, int $expiresIn = 5): array
+    {
+        return [
+            'message' => (new SecretFactory)->generateEncryptedMessage($plaintextLength),
+            'expires_in' => $expiresIn,
+        ];
+    }
+
+    public function test_masked_email_stored_when_setting_enabled(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->post(route('secret.store'), array_merge($this->validSecretPayload(), [
+                'email' => 'recipient@example.com',
+            ]));
+
+        $response->assertSessionHasNoErrors();
+
+        $secret = $user->secrets()->first();
+        $this->assertNotNull($secret->masked_recipient_email);
+        $this->assertStringStartsWith('r', $secret->masked_recipient_email);
+        $this->assertStringNotContainsString('ecipient', $secret->masked_recipient_email);
+        $this->assertStringNotContainsString('recipient@example.com', $secret->masked_recipient_email);
+    }
+
+    public function test_masked_email_not_stored_when_setting_disabled(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->post(route('secret.store'), array_merge($this->validSecretPayload(), [
+                'email' => 'recipient@example.com',
+            ]));
+
+        $response->assertSessionHasNoErrors();
+
+        $secret = $user->secrets()->first();
+        $this->assertNull($secret->masked_recipient_email);
+    }
+
+    public function test_no_masked_email_stored_when_no_email_provided(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->post(route('secret.store'), $this->validSecretPayload());
+
+        $response->assertSessionHasNoErrors();
+
+        $secret = $user->secrets()->first();
+        $this->assertNull($secret->masked_recipient_email);
+    }
+
+    public function test_masked_email_appears_in_secrets_list(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('secret.store'), array_merge($this->validSecretPayload(), [
+                'email' => 'recipient@example.com',
+            ]));
+
+        $response = $this->actingAs($user)->get(route('secrets.index'));
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Secret/Index')
+            ->has('secrets.data.0.masked_recipient_email')
+        );
+    }
+
+    public function test_masked_email_null_in_secrets_list_when_no_email_provided(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $this->actingAs($user)->post(route('secret.store'), $this->validSecretPayload());
+
+        $response = $this->actingAs($user)->get(route('secrets.index'));
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Secret/Index')
+            ->where('secrets.data.0.masked_recipient_email', null)
+        );
+    }
+
+    public function test_setting_enabled_after_creation_does_not_mask_old_secrets(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        // Create without masking
+        $this->actingAs($user)->post(route('secret.store'), array_merge($this->validSecretPayload(), [
+            'email' => 'recipient@example.com',
+        ]));
+
+        $secretBefore = $user->secrets()->first();
+        $this->assertNull($secretBefore->masked_recipient_email);
+
+        // Enable the setting — existing secret should remain unaffected
+        $user->update(['store_masked_recipient_email' => true]);
+
+        $secretAfter = $user->secrets()->first();
+        $this->assertNull($secretAfter->masked_recipient_email);
+    }
+}

--- a/tests/Feature/SecretMaskedEmailTest.php
+++ b/tests/Feature/SecretMaskedEmailTest.php
@@ -2,14 +2,44 @@
 
 namespace Tests\Feature;
 
+use App\Models\Plan;
 use App\Models\User;
 use Database\Factories\SecretFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class SecretMaskedEmailTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function createApiPlan(string $monthlyPriceId, string $yearlyPriceId, string $productId): Plan
+    {
+        return Plan::factory()->create([
+            'name' => 'Prime',
+            'stripe_monthly_price_id' => $monthlyPriceId,
+            'stripe_yearly_price_id' => $yearlyPriceId,
+            'stripe_product_id' => $productId,
+            'price_per_month' => 50,
+            'price_per_year' => 500,
+            'features' => [
+                'messages' => ['order' => 2, 'label' => 'Messages', 'config' => ['message_length' => 100000], 'type' => 'feature'],
+                'expiry' => ['order' => 3, 'label' => 'Expiry', 'config' => ['expiry_label' => '30 days', 'expiry_minutes' => 43200], 'type' => 'feature'],
+                'api' => ['order' => 6, 'label' => 'API Access', 'config' => [], 'type' => 'feature'],
+            ],
+        ]);
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_'.fake()->unique()->word(),
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+    }
 
     private function validSecretPayload(int $plaintextLength = 50, int $expiresIn = 5): array
     {
@@ -104,6 +134,55 @@ class SecretMaskedEmailTest extends TestCase
             ->component('Secret/Index')
             ->where('secrets.data.0.masked_recipient_email', null)
         );
+    }
+
+    public function test_api_stores_masked_email_when_setting_enabled(): void
+    {
+        $primePlan = $this->createApiPlan('price_monthly_prime_mask', 'price_yearly_prime_mask', 'prod_prime_mask');
+
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $this->subscribeUserToPlan($user, $primePlan);
+
+        Sanctum::actingAs($user, ['secrets:create']);
+
+        $response = $this->postJson('/api/v1/secrets', [
+            'message' => (new SecretFactory)->generateEncryptedMessage(50),
+            'expires_in' => 1440,
+            'email' => 'recipient@example.com',
+        ]);
+
+        $response->assertStatus(201);
+
+        $secret = $user->secrets()->first();
+        $this->assertNotNull($secret->masked_recipient_email);
+        $this->assertStringNotContainsString('recipient@example.com', $secret->masked_recipient_email);
+    }
+
+    public function test_api_does_not_store_masked_email_when_setting_disabled(): void
+    {
+        $primePlan = $this->createApiPlan('price_monthly_prime_mask2', 'price_yearly_prime_mask2', 'prod_prime_mask2');
+
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        $this->subscribeUserToPlan($user, $primePlan);
+
+        Sanctum::actingAs($user, ['secrets:create']);
+
+        $response = $this->postJson('/api/v1/secrets', [
+            'message' => (new SecretFactory)->generateEncryptedMessage(50),
+            'expires_in' => 1440,
+            'email' => 'recipient@example.com',
+        ]);
+
+        $response->assertStatus(201);
+
+        $secret = $user->secrets()->first();
+        $this->assertNull($secret->masked_recipient_email);
     }
 
     public function test_setting_enabled_after_creation_does_not_mask_old_secrets(): void

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_settings_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/user/settings');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Settings/Index')
+            ->has('storeMaskedRecipientEmail')
+        );
+    }
+
+    public function test_unauthenticated_user_cannot_view_settings_page(): void
+    {
+        $response = $this->get('/user/settings');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_settings_page_shows_correct_current_value(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/settings');
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('storeMaskedRecipientEmail', true)
+        );
+    }
+
+    public function test_settings_page_shows_false_when_disabled(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/settings');
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('storeMaskedRecipientEmail', false)
+        );
+    }
+
+    public function test_user_can_enable_store_masked_recipient_email(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->put('/user/settings', [
+                'store_masked_recipient_email' => true,
+            ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertTrue($user->fresh()->store_masked_recipient_email);
+    }
+
+    public function test_user_can_disable_store_masked_recipient_email(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->put('/user/settings', [
+                'store_masked_recipient_email' => false,
+            ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertFalse($user->fresh()->store_masked_recipient_email);
+    }
+
+    public function test_update_requires_password_confirmation(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'store_masked_recipient_email' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->put('/user/settings', [
+                'store_masked_recipient_email' => true,
+            ]);
+
+        $response->assertRedirect();
+        $this->assertFalse($user->fresh()->store_masked_recipient_email);
+    }
+
+    public function test_guest_cannot_update_settings(): void
+    {
+        $response = $this->put('/user/settings', [
+            'store_masked_recipient_email' => true,
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_validation_requires_boolean(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->put('/user/settings', [
+                'store_masked_recipient_email' => 'not-a-boolean',
+            ]);
+
+        $response->assertSessionHasErrors('store_masked_recipient_email');
+    }
+}

--- a/tests/Unit/Services/EmailMaskingServiceTest.php
+++ b/tests/Unit/Services/EmailMaskingServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\EmailMaskingService;
+use PHPUnit\Framework\TestCase;
+
+class EmailMaskingServiceTest extends TestCase
+{
+    private EmailMaskingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new EmailMaskingService;
+    }
+
+    public function test_masks_standard_email(): void
+    {
+        $result = $this->service->mask('john.doe@example.com');
+
+        $this->assertStringStartsWith('j', $result);
+        $this->assertStringContainsString('@', $result);
+        $this->assertStringEndsWith('.com', $result);
+        $this->assertStringNotContainsString('ohn', $result);
+        $this->assertStringNotContainsString('xample', $result);
+    }
+
+    public function test_masks_single_char_local_part(): void
+    {
+        $result = $this->service->mask('a@example.com');
+
+        $this->assertStringStartsWith('a', $result);
+        $this->assertStringEndsWith('.com', $result);
+        $this->assertStringContainsString('@', $result);
+    }
+
+    public function test_masks_subdomain_email(): void
+    {
+        $result = $this->service->mask('user@mail.example.com');
+
+        $this->assertStringStartsWith('u', $result);
+        $this->assertStringContainsString('@', $result);
+        $this->assertStringContainsString('.example.com', $result);
+        $this->assertStringNotContainsString('ser', $result);
+        $this->assertStringNotContainsString('ail', $result);
+    }
+
+    public function test_masks_short_domain_label(): void
+    {
+        $result = $this->service->mask('user@ab.io');
+
+        $this->assertStringStartsWith('u', $result);
+        $this->assertStringEndsWith('.io', $result);
+        $this->assertStringContainsString('@', $result);
+    }
+
+    public function test_masks_bare_hostname_defensively(): void
+    {
+        // Bare hostname (no dot in domain) — guarded defensively
+        $result = $this->service->mask('user@localhost');
+
+        $this->assertStringStartsWith('u', $result);
+        $this->assertStringContainsString('@', $result);
+    }
+
+    public function test_masked_email_contains_asterisks(): void
+    {
+        $result = $this->service->mask('john@example.com');
+
+        $this->assertStringContainsString('*', $result);
+    }
+
+    public function test_original_email_not_in_masked_output(): void
+    {
+        $email = 'john.doe@example.com';
+        $result = $this->service->mask($email);
+
+        $this->assertNotEquals($email, $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new **Settings page** (`/user/settings`) with an **Email Privacy** toggle — allows users to opt in to storing a masked version of the recipient email alongside each secret
- When enabled, the masked email (e.g. `j*******@e******.com`) is stored encrypted at rest using Laravel's `Str::mask()` for length-proportional masking
- A conditional **Recipient** column appears in the secrets list only when at least one secret on the page has a masked email — avoids cluttering the table for users who have never opted in
- Changing the setting requires password or passkey confirmation (two-layer guard: `ConfirmsPasswordOrPasskey` client-side + `password.confirm` middleware server-side)
- Privacy policy updated to document that only masked emails are ever stored — the original address is never persisted
- Masking is applied consistently across both the web and API secret creation flows

## Notable technical decisions

- `masked_recipient_email` is stored as an encrypted `text` column (consistent with `ip_address_sent`, `ip_address_retrieved`, and `message`)
- `ConfigurationController::index()` passes `storeMaskedRecipientEmail` as an explicit Inertia prop rather than relying on shared auth state
- `StoreMaskedEmailForm` uses `<FormSection>` with **no** `@submitted` binding — save is driven exclusively through `ConfirmsPasswordOrPasskey @confirmed` to prevent keyboard-Enter bypass

## Regression risks (from regression-detector)

- **Low** — `SecretRetrievedNotification` email to the owner does not yet surface the masked email (future consideration, not in scope)
- **Low** — `markSilentlyAsRetrieved()` uses a raw `DB::table()` write; any future extension touching `masked_recipient_email` via that path must manually `encrypt()` the value

## Test plan

- [x] Navigate to user dropdown → Settings — page loads with Email Privacy card, toggle unchecked by default
- [x] Click Save — password/passkey confirmation modal appears; cancel leaves setting unchanged
- [x] Confirm and save — reload page, toggle reflects saved state
- [x] With setting ON, create a secret at `/dashboard` with a recipient email — Recipient column appears in `/secrets` showing masked value (e.g. `j*******@e******.com`)
- [x] With setting OFF, create a secret with recipient email — Recipient column does not appear (or shows dash only if other masked secrets exist on same page)
- [x] Disable the setting — existing masked emails on old secrets remain visible; new secrets get no masked email
- [x] Check `/privacy-policy` — "Recipient Email Addresses" section is present
- [x] Automated: `php artisan test tests/Unit/Services/EmailMaskingServiceTest.php tests/Feature/SettingsTest.php tests/Feature/SecretMaskedEmailTest.php`