### PR TITLE
Domain verification: exponential backoff retry + email notifications (PIO-66)

### DIFF
--- a/app/Console/Commands/ReverifyDomainIdentities.php
+++ b/app/Console/Commands/ReverifyDomainIdentities.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\SenderIdentity;
+use App\Notifications\DomainLapsedNotification;
 use App\Services\DomainVerificationService;
 use Illuminate\Console\Command;
 
@@ -32,6 +33,7 @@ class ReverifyDomainIdentities extends Command
                     $passed++;
                 } else {
                     $identity->update(['verified_at' => null]);
+                    $identity->user->notify(new DomainLapsedNotification($identity));
                     $failed++;
                 }
             });

--- a/app/Http/Controllers/SenderIdentityController.php
+++ b/app/Http/Controllers/SenderIdentityController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreSenderIdentityRequest;
+use App\Jobs\RetryDomainVerification;
+use App\Notifications\DomainVerifiedNotification;
 use App\Services\DomainVerificationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -25,6 +27,7 @@ class SenderIdentityController extends Controller
                 'email' => $user->email,
                 'verification_token' => null,
                 'verified_at' => now(),
+                'verification_retry_dispatched_at' => null, // cancel any in-flight domain retry
             ];
 
             if (! $identity) {
@@ -52,6 +55,7 @@ class SenderIdentityController extends Controller
             if ($domainChanged || $identity->isEmailType()) {
                 $data['verification_token'] = $this->verificationService->generateToken();
                 $data['verified_at'] = null;
+                $data['verification_retry_dispatched_at'] = null;
             }
             $identity->update($data);
         }
@@ -68,9 +72,18 @@ class SenderIdentityController extends Controller
         }
 
         if ($this->verificationService->verify($identity)) {
-            $identity->update(['verified_at' => now()]);
+            $identity->update([
+                'verified_at' => now(),
+                'verification_retry_dispatched_at' => null,
+            ]);
+            $request->user()->notify(new DomainVerifiedNotification($identity));
 
             return back()->with('status', 'domain-verified');
+        }
+
+        if (! $identity->hasActiveRetry()) {
+            $identity->update(['verification_retry_dispatched_at' => now()]);
+            RetryDomainVerification::dispatch($identity, $identity->verification_token, now()->addHours(24));
         }
 
         return back()->withErrors(['domain' => 'DNS TXT record not found. Please check the record is published and try again in a few minutes.']);

--- a/app/Http/Controllers/SenderIdentityController.php
+++ b/app/Http/Controllers/SenderIdentityController.php
@@ -81,10 +81,12 @@ class SenderIdentityController extends Controller
             return back()->with('status', 'domain-verified');
         }
 
-        if (! $identity->hasActiveRetry()) {
-            $identity->update(['verification_retry_dispatched_at' => now()]);
-            RetryDomainVerification::dispatch($identity, $identity->verification_token, now()->addHours(24));
+        if ($identity->hasActiveRetry()) {
+            return back()->withErrors(['domain' => "We're already working on verifying your domain in the background. You'll receive an email once it's done."]);
         }
+
+        $identity->update(['verification_retry_dispatched_at' => now()]);
+        RetryDomainVerification::dispatch($identity, $identity->verification_token, now()->addHours(24));
 
         return back()->withErrors(['domain' => 'DNS TXT record not found. Please check the record is published and try again in a few minutes.']);
     }

--- a/app/Http/Resources/SenderIdentityResource.php
+++ b/app/Http/Resources/SenderIdentityResource.php
@@ -23,6 +23,7 @@ class SenderIdentityResource extends JsonResource
             'email' => $this->email,
             'verification_token' => $this->verification_token,
             'is_verified' => $this->isVerified(),
+            'has_active_retry' => $this->hasActiveRetry(),
         ];
     }
 }

--- a/app/Jobs/RetryDomainVerification.php
+++ b/app/Jobs/RetryDomainVerification.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\SenderIdentity;
+use App\Notifications\DomainVerificationTimeoutNotification;
+use App\Notifications\DomainVerifiedNotification;
+use App\Services\DomainVerificationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RetryDomainVerification implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 0;
+
+    /**
+     * @param  \DateTime  $deadline  Absolute deadline passed at dispatch time so retries
+     *                               are capped relative to the original dispatch, not each
+     *                               individual attempt.
+     */
+    public function __construct(
+        public SenderIdentity $identity,
+        public string $tokenAtDispatch,
+        public \DateTime $deadline,
+    ) {}
+
+    /**
+     * Exponential backoff: 2m, 4m, 8m, …, 512m.
+     * Laravel repeats the last value (30720 s) once the array is exhausted;
+     * retryUntil() acts as the effective 24-hour ceiling.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [120, 240, 480, 960, 1920, 3840, 7680, 15360, 30720];
+    }
+
+    public function retryUntil(): \DateTime
+    {
+        return $this->deadline;
+    }
+
+    public function handle(DomainVerificationService $verificationService): void
+    {
+        $identity = SenderIdentity::find($this->identity->id);
+
+        // Stop chain if identity was deleted or domain was changed (token mismatch).
+        if (! $identity || $identity->verification_token !== $this->tokenAtDispatch) {
+            return;
+        }
+
+        // Stop chain if the identity was already verified by a manual click.
+        if ($identity->isVerified()) {
+            $identity->update(['verification_retry_dispatched_at' => null]);
+
+            return;
+        }
+
+        if ($verificationService->verify($identity)) {
+            $identity->update([
+                'verified_at' => now(),
+                'verification_retry_dispatched_at' => null,
+            ]);
+            $identity->user->notify(new DomainVerifiedNotification($identity));
+
+            return;
+        }
+
+        // DNS TXT record not found yet — throw to trigger the next retry with backoff.
+        // Note: on multi-worker setups a concurrent manual verify and this job could both
+        // send DomainVerifiedNotification before the other's guard fires. The window is
+        // narrow and both emails are identical — accepted trade-off.
+        throw new \RuntimeException('DNS TXT record not found for domain: '.$identity->domain);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        $identity = SenderIdentity::find($this->identity->id);
+
+        if ($identity && $identity->verification_token === $this->tokenAtDispatch) {
+            $identity->update(['verification_retry_dispatched_at' => null]);
+            $identity->user->notify(new DomainVerificationTimeoutNotification($identity));
+        }
+    }
+}

--- a/app/Models/SenderIdentity.php
+++ b/app/Models/SenderIdentity.php
@@ -19,12 +19,14 @@ class SenderIdentity extends Model
         'email',
         'verification_token',
         'verified_at',
+        'verification_retry_dispatched_at',
     ];
 
     protected function casts(): array
     {
         return [
             'verified_at' => 'datetime',
+            'verification_retry_dispatched_at' => 'datetime',
         ];
     }
 
@@ -46,5 +48,10 @@ class SenderIdentity extends Model
     public function isEmailType(): bool
     {
         return $this->type === 'email';
+    }
+
+    public function hasActiveRetry(): bool
+    {
+        return $this->verification_retry_dispatched_at !== null;
     }
 }

--- a/app/Notifications/DomainLapsedNotification.php
+++ b/app/Notifications/DomainLapsedNotification.php
@@ -30,7 +30,7 @@ class DomainLapsedNotification extends Notification implements ShouldQueue
             ->line(__('Your sender badge has been paused until the domain is re-verified.'))
             ->line(__('Links you have already shared will continue to display your verified badge — only new links are affected.'))
             ->line(__('Please ensure your DNS TXT record is still correctly published, then click "Verify Domain" from your settings.'))
-            ->action(__('View Settings'), url(route('profile.show')))
+            ->action(__('View Settings'), url(route('user.settings.index')))
             ->line(__('Thank you for using :app', ['app' => config('app.name')]));
     }
 

--- a/app/Notifications/DomainLapsedNotification.php
+++ b/app/Notifications/DomainLapsedNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\SenderIdentity;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DomainLapsedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public SenderIdentity $identity) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('Action needed: re-verify your domain :domain', ['domain' => $this->identity->domain]))
+            ->line(__('We were unable to confirm your domain :domain during a routine check — your DNS TXT record could not be found.', ['domain' => $this->identity->domain]))
+            ->line(__('Your sender badge has been paused until the domain is re-verified.'))
+            ->line(__('Links you have already shared will continue to display your verified badge — only new links are affected.'))
+            ->line(__('Please ensure your DNS TXT record is still correctly published, then click "Verify Domain" from your settings.'))
+            ->action(__('View Settings'), url(route('profile.show')))
+            ->line(__('Thank you for using :app', ['app' => config('app.name')]));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/app/Notifications/DomainVerificationTimeoutNotification.php
+++ b/app/Notifications/DomainVerificationTimeoutNotification.php
@@ -28,7 +28,7 @@ class DomainVerificationTimeoutNotification extends Notification implements Shou
             ->subject(__('Domain verification failed for :domain', ['domain' => $this->identity->domain]))
             ->line(__('We were unable to verify your domain :domain after 24 hours of retrying.', ['domain' => $this->identity->domain]))
             ->line(__('Please check that your DNS TXT record is correctly published, then click "Verify Domain" again from your settings.'))
-            ->action(__('View Settings'), url(route('profile.show')))
+            ->action(__('View Settings'), url(route('user.settings.index')))
             ->line(__('Thank you for using :app', ['app' => config('app.name')]));
     }
 

--- a/app/Notifications/DomainVerificationTimeoutNotification.php
+++ b/app/Notifications/DomainVerificationTimeoutNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\SenderIdentity;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DomainVerificationTimeoutNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public SenderIdentity $identity) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('Domain verification failed for :domain', ['domain' => $this->identity->domain]))
+            ->line(__('We were unable to verify your domain :domain after 24 hours of retrying.', ['domain' => $this->identity->domain]))
+            ->line(__('Please check that your DNS TXT record is correctly published, then click "Verify Domain" again from your settings.'))
+            ->action(__('View Settings'), url(route('profile.show')))
+            ->line(__('Thank you for using :app', ['app' => config('app.name')]));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/app/Notifications/DomainVerifiedNotification.php
+++ b/app/Notifications/DomainVerifiedNotification.php
@@ -28,7 +28,7 @@ class DomainVerifiedNotification extends Notification implements ShouldQueue
             ->subject(__('Your domain :domain has been verified', ['domain' => $this->identity->domain]))
             ->line(__('Your domain :domain has been successfully verified.', ['domain' => $this->identity->domain]))
             ->line(__('Your :company sender badge is now active on shared links.', ['company' => $this->identity->company_name]))
-            ->action(__('View Settings'), url(route('user.settings.index)))
+            ->action(__('View Settings'), url(route('user.settings.index')))
             ->line(__('Thank you for using :app', ['app' => config('app.name')]));
     }
 

--- a/app/Notifications/DomainVerifiedNotification.php
+++ b/app/Notifications/DomainVerifiedNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\SenderIdentity;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DomainVerifiedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public SenderIdentity $identity) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('Your domain :domain has been verified', ['domain' => $this->identity->domain]))
+            ->line(__('Your domain :domain has been successfully verified.', ['domain' => $this->identity->domain]))
+            ->line(__('Your :company sender badge is now active on shared links.', ['company' => $this->identity->company_name]))
+            ->action(__('View Settings'), url(route('profile.show')))
+            ->line(__('Thank you for using :app', ['app' => config('app.name')]));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/app/Notifications/DomainVerifiedNotification.php
+++ b/app/Notifications/DomainVerifiedNotification.php
@@ -28,7 +28,7 @@ class DomainVerifiedNotification extends Notification implements ShouldQueue
             ->subject(__('Your domain :domain has been verified', ['domain' => $this->identity->domain]))
             ->line(__('Your domain :domain has been successfully verified.', ['domain' => $this->identity->domain]))
             ->line(__('Your :company sender badge is now active on shared links.', ['company' => $this->identity->company_name]))
-            ->action(__('View Settings'), url(route('profile.show')))
+            ->action(__('View Settings'), url(route('user.settings.index)))
             ->line(__('Thank you for using :app', ['app' => config('app.name')]));
     }
 

--- a/database/migrations/2026_04_05_124620_add_retry_dispatched_to_sender_identities_table.php
+++ b/database/migrations/2026_04_05_124620_add_retry_dispatched_to_sender_identities_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sender_identities', function (Blueprint $table) {
+            $table->dateTime('verification_retry_dispatched_at')->nullable()->after('verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sender_identities', function (Blueprint $table) {
+            $table->dropColumn('verification_retry_dispatched_at');
+        });
+    }
+};

--- a/resources/js/Pages/Settings/Partials/SenderIdentityForm.vue
+++ b/resources/js/Pages/Settings/Partials/SenderIdentityForm.vue
@@ -39,6 +39,8 @@ const hasVerificationToken = computed(() => !!props.senderIdentity?.verification
 
 const verificationToken = computed(() => props.senderIdentity?.verification_token ?? '');
 
+const hasActiveRetry = computed(() => props.senderIdentity?.has_active_retry ?? false);
+
 const verificationStatus = computed(() => {
     if (!props.senderIdentity) {
         return null;
@@ -181,8 +183,15 @@ const removeIdentity = () => {
                     </div>
 
                     <div v-else class="space-y-4">
+                        <!-- Active retry in progress -->
+                        <div v-if="hasActiveRetry" class="rounded-md bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-3">
+                            <p class="text-sm text-blue-700 dark:text-blue-400">
+                                We're checking your domain in the background — you'll get an email when it's verified.
+                            </p>
+                        </div>
+
                         <!-- Not yet verified or lapsed -->
-                        <div class="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3">
+                        <div v-else class="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3">
                             <p class="text-sm text-amber-700 dark:text-amber-400">
                                 <template v-if="hasVerificationToken">
                                     Domain not yet verified — add the TXT record below to activate your badge.

--- a/tests/Feature/DomainVerificationNotificationTest.php
+++ b/tests/Feature/DomainVerificationNotificationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\RetryDomainVerification;
+use App\Models\Plan;
+use App\Models\SenderIdentity;
+use App\Models\User;
+use App\Notifications\DomainLapsedNotification;
+use App\Notifications\DomainVerificationTimeoutNotification;
+use App\Notifications\DomainVerifiedNotification;
+use App\Services\DomainVerificationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class DomainVerificationNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createPrimeUser(): User
+    {
+        $plan = Plan::factory()->withSenderIdentity()->create();
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_notify',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        return $user;
+    }
+
+    private function makeDomainIdentity(User $user, array $attrs = []): SenderIdentity
+    {
+        return SenderIdentity::factory()->for($user)->create(array_merge([
+            'type' => 'domain',
+            'company_name' => 'Acme Corp',
+            'domain' => 'acme.com',
+            'verification_token' => 'flashview-verification-test-abc',
+            'verified_at' => null,
+            'verification_retry_dispatched_at' => null,
+        ], $attrs));
+    }
+
+    public function test_domain_verified_notification_sent_on_manual_success(): void
+    {
+        Notification::fake();
+
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user);
+
+        $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(true);
+        });
+
+        $this->actingAs($user)->post(route('user.sender-identity.verify'));
+
+        Notification::assertSentTo($user, DomainVerifiedNotification::class);
+    }
+
+    public function test_domain_verified_notification_sent_on_job_success(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(true);
+        });
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->handle($service);
+
+        Notification::assertSentTo($user, DomainVerifiedNotification::class);
+    }
+
+    public function test_domain_verification_timeout_notification_sent_on_exhaustion(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->failed(new \RuntimeException('retryUntil exceeded'));
+
+        Notification::assertSentTo($user, DomainVerificationTimeoutNotification::class);
+        Notification::assertNotSentTo($user, DomainVerifiedNotification::class);
+    }
+
+    public function test_domain_lapsed_notification_sent_by_reverify_command(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        SenderIdentity::factory()->for($user)->create([
+            'type' => 'domain',
+            'company_name' => 'Acme Corp',
+            'domain' => 'acme.com',
+            'verification_token' => 'flashview-verification-test-abc',
+            'verified_at' => now()->subMonths(4), // older than 3-month threshold
+        ]);
+
+        $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(false);
+        });
+
+        $this->artisan('sender-identity:reverify');
+
+        Notification::assertSentTo($user, DomainLapsedNotification::class);
+    }
+
+    public function test_no_notification_sent_when_already_verified_guard_triggers(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, [
+            'verified_at' => now(),
+            'verification_retry_dispatched_at' => now(),
+        ]);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->never();
+        });
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->handle($service);
+
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Feature/DomainVerificationRetryTest.php
+++ b/tests/Feature/DomainVerificationRetryTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\RetryDomainVerification;
+use App\Models\Plan;
+use App\Models\SenderIdentity;
+use App\Models\User;
+use App\Notifications\DomainVerificationTimeoutNotification;
+use App\Notifications\DomainVerifiedNotification;
+use App\Services\DomainVerificationService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DomainVerificationRetryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createPrimeUser(): User
+    {
+        $plan = Plan::factory()->withSenderIdentity()->create();
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_retry',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        return $user;
+    }
+
+    private function makeDomainIdentity(User $user, array $attrs = []): SenderIdentity
+    {
+        return SenderIdentity::factory()->for($user)->create(array_merge([
+            'type' => 'domain',
+            'company_name' => 'Acme Corp',
+            'domain' => 'acme.com',
+            'verification_token' => 'flashview-verification-test-abc',
+            'verified_at' => null,
+            'verification_retry_dispatched_at' => null,
+        ], $attrs));
+    }
+
+    // -----------------------------------------------------------------------
+    // Controller dispatch
+    // -----------------------------------------------------------------------
+
+    public function test_retry_job_dispatched_on_first_failed_verify(): void
+    {
+        Queue::fake();
+
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user);
+
+        $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(false);
+        });
+
+        $this->actingAs($user)->post(route('user.sender-identity.verify'));
+
+        Queue::assertPushed(RetryDomainVerification::class);
+        $this->assertNotNull($user->fresh()->senderIdentity->verification_retry_dispatched_at);
+    }
+
+    public function test_retry_job_not_dispatched_when_retry_already_active(): void
+    {
+        Queue::fake();
+
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(false);
+        });
+
+        $this->actingAs($user)->post(route('user.sender-identity.verify'));
+
+        Queue::assertNotPushed(RetryDomainVerification::class);
+    }
+
+    public function test_retry_flag_cleared_on_manual_verify_success(): void
+    {
+        Queue::fake();
+        Notification::fake();
+
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(true);
+        });
+
+        $this->actingAs($user)->post(route('user.sender-identity.verify'));
+
+        $this->assertNull($user->fresh()->senderIdentity->verification_retry_dispatched_at);
+    }
+
+    public function test_domain_change_clears_retry_flag(): void
+    {
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $this->actingAs($user)->post(route('user.sender-identity.store'), [
+            'type' => 'domain',
+            'company_name' => 'Acme Corp',
+            'domain' => 'new-acme.com',
+        ]);
+
+        $this->assertNull($user->fresh()->senderIdentity->verification_retry_dispatched_at);
+    }
+
+    public function test_switching_to_email_type_clears_retry_flag(): void
+    {
+        $user = $this->createPrimeUser();
+        $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $this->actingAs($user)->post(route('user.sender-identity.store'), ['type' => 'email']);
+
+        $this->assertNull($user->fresh()->senderIdentity->verification_retry_dispatched_at);
+    }
+
+    // -----------------------------------------------------------------------
+    // Job handle()
+    // -----------------------------------------------------------------------
+
+    public function test_job_verifies_and_clears_flag_on_success(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, [
+            'verification_retry_dispatched_at' => now(),
+        ]);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(true);
+        });
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->handle($service);
+
+        $identity->refresh();
+        $this->assertNotNull($identity->verified_at);
+        $this->assertNull($identity->verification_retry_dispatched_at);
+        Notification::assertSentTo($user, DomainVerifiedNotification::class);
+    }
+
+    public function test_job_throws_on_dns_not_found_to_trigger_retry(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->once()->andReturn(false);
+        });
+
+        $this->expectException(\RuntimeException::class);
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->handle($service);
+    }
+
+    public function test_job_stops_silently_on_token_mismatch(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, [
+            'verification_token' => 'new-token-after-domain-change',
+            'verification_retry_dispatched_at' => now(),
+        ]);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->never();
+        });
+
+        $job = new RetryDomainVerification($identity, 'old-token-at-dispatch', now()->addHours(24));
+        $job->handle($service);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_job_stops_silently_when_identity_deleted(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user);
+        $token = $identity->verification_token;
+        $identity->delete();
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->never();
+        });
+
+        $job = new RetryDomainVerification($identity, $token, now()->addHours(24));
+        $job->handle($service);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_job_stops_silently_when_already_verified(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, [
+            'verified_at' => now(),
+            'verification_retry_dispatched_at' => now(),
+        ]);
+
+        $service = $this->mock(DomainVerificationService::class, function ($mock) {
+            $mock->shouldReceive('verify')->never();
+        });
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->handle($service);
+
+        $this->assertNull($identity->fresh()->verification_retry_dispatched_at);
+        Notification::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Job failed()
+    // -----------------------------------------------------------------------
+
+    public function test_failed_callback_clears_flag_and_sends_timeout_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, ['verification_retry_dispatched_at' => now()]);
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+        $job->failed(new \RuntimeException('timeout'));
+
+        $this->assertNull($identity->fresh()->verification_retry_dispatched_at);
+        Notification::assertSentTo($user, DomainVerificationTimeoutNotification::class);
+    }
+
+    public function test_failed_callback_does_nothing_if_token_changed(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user, [
+            'verification_token' => 'new-token',
+        ]);
+
+        $job = new RetryDomainVerification($identity, 'old-token-at-dispatch', now()->addHours(24));
+        $job->failed(new \RuntimeException('timeout'));
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_failed_callback_does_nothing_if_identity_deleted(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user);
+        $token = $identity->verification_token;
+        $identity->delete();
+
+        $job = new RetryDomainVerification($identity, $token, now()->addHours(24));
+        $job->failed(new \RuntimeException('timeout'));
+
+        Notification::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Job configuration
+    // -----------------------------------------------------------------------
+
+    public function test_job_has_correct_backoff_schedule(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user);
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, now()->addHours(24));
+
+        $this->assertEquals([120, 240, 480, 960, 1920, 3840, 7680, 15360, 30720], $job->backoff());
+    }
+
+    public function test_job_retry_until_returns_provided_deadline(): void
+    {
+        Carbon::setTestNow(now());
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $identity = $this->makeDomainIdentity($user);
+        $deadline = now()->addHours(24);
+
+        $job = new RetryDomainVerification($identity, $identity->verification_token, $deadline);
+
+        $this->assertEquals($deadline, $job->retryUntil());
+
+        Carbon::setTestNow();
+    }
+}

--- a/tests/Feature/DomainVerificationRetryTest.php
+++ b/tests/Feature/DomainVerificationRetryTest.php
@@ -78,7 +78,9 @@ class DomainVerificationRetryTest extends TestCase
             $mock->shouldReceive('verify')->once()->andReturn(false);
         });
 
-        $this->actingAs($user)->post(route('user.sender-identity.verify'));
+        $this->actingAs($user)
+            ->post(route('user.sender-identity.verify'))
+            ->assertSessionHasErrors(['domain' => "We're already working on verifying your domain in the background. You'll receive an email once it's done."]);
 
         Queue::assertNotPushed(RetryDomainVerification::class);
     }

--- a/tests/Feature/ReverifyDomainIdentitiesTest.php
+++ b/tests/Feature/ReverifyDomainIdentitiesTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature;
 
 use App\Models\SenderIdentity;
 use App\Models\User;
+use App\Notifications\DomainLapsedNotification;
 use App\Services\DomainVerificationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class ReverifyDomainIdentitiesTest extends TestCase
@@ -37,6 +39,8 @@ class ReverifyDomainIdentitiesTest extends TestCase
 
     public function test_verified_identity_older_than_3_months_with_failing_dns_is_nulled(): void
     {
+        Notification::fake();
+
         $user = User::factory()->create();
         $identity = SenderIdentity::factory()->for($user)->create([
             'type' => 'domain',
@@ -53,6 +57,7 @@ class ReverifyDomainIdentitiesTest extends TestCase
         $this->artisan('sender-identity:reverify')->assertSuccessful();
 
         $this->assertNull($identity->fresh()->verified_at);
+        Notification::assertSentTo($user, DomainLapsedNotification::class);
     }
 
     public function test_verified_identity_younger_than_3_months_is_skipped(): void

--- a/tests/Feature/SenderIdentityTest.php
+++ b/tests/Feature/SenderIdentityTest.php
@@ -2,12 +2,16 @@
 
 namespace Tests\Feature;
 
+use App\Jobs\RetryDomainVerification;
 use App\Models\Plan;
 use App\Models\SenderIdentity;
 use App\Models\User;
+use App\Notifications\DomainVerifiedNotification;
 use App\Services\DomainVerificationService;
 use Database\Factories\SecretFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class SenderIdentityTest extends TestCase
@@ -220,6 +224,7 @@ class SenderIdentityTest extends TestCase
             'domain' => 'acme.com',
             'verification_token' => 'old-token',
             'verified_at' => now(),
+            'verification_retry_dispatched_at' => now(),
         ]);
 
         $this->actingAs($user)
@@ -233,6 +238,7 @@ class SenderIdentityTest extends TestCase
         $this->assertEquals('new-acme.com', $identity->domain);
         $this->assertNull($identity->verified_at);
         $this->assertNotEquals('old-token', $identity->verification_token);
+        $this->assertNull($identity->verification_retry_dispatched_at);
     }
 
     public function test_updating_domain_without_change_keeps_verification(): void
@@ -308,6 +314,9 @@ class SenderIdentityTest extends TestCase
 
     public function test_domain_verification_succeeds_when_dns_record_found(): void
     {
+        Notification::fake();
+        Queue::fake();
+
         $user = $this->createPrimeUser();
         $identity = SenderIdentity::factory()->for($user)->create([
             'type' => 'domain',
@@ -327,10 +336,14 @@ class SenderIdentityTest extends TestCase
 
         $this->assertNotNull($identity->fresh()->verified_at);
         $this->assertTrue($user->fresh()->hasVerifiedSenderIdentity());
+        Notification::assertSentTo($user, DomainVerifiedNotification::class);
+        Queue::assertNotPushed(RetryDomainVerification::class);
     }
 
     public function test_domain_verification_fails_when_dns_record_not_found(): void
     {
+        Queue::fake();
+
         $user = $this->createPrimeUser();
         $identity = SenderIdentity::factory()->for($user)->create([
             'type' => 'domain',
@@ -349,6 +362,8 @@ class SenderIdentityTest extends TestCase
             ->assertSessionHasErrors('domain');
 
         $this->assertNull($identity->fresh()->verified_at);
+        Queue::assertPushed(RetryDomainVerification::class);
+        $this->assertNotNull($identity->fresh()->verification_retry_dispatched_at);
     }
 
     public function test_verify_fails_when_no_domain_identity_configured(): void


### PR DESCRIPTION
## Summary

- Adds automatic background retry with exponential backoff (2m → 512m, capped at 24h) when "Verify Domain" fails due to DNS propagation delay
- Deduplicates retry chains via `verification_retry_dispatched_at` column — multiple clicks never stack multiple jobs
- Cancels in-flight retries automatically when the domain is changed, identity type is switched, or identity is removed (token mismatch guard in job)
- Sends email notifications at three key moments: domain verified, 24h retry timeout, domain lapse from daily re-verify
- Shows a blue in-app status banner ("We're checking your domain in the background") when a retry is active

## Changes

**New files:**
- `database/migrations/…add_retry_dispatched_to_sender_identities_table.php`
- `app/Jobs/RetryDomainVerification.php` — self-retrying job using `$tries = 0` + `retryUntil()` + `backoff()` (same pattern as `SendWebhookNotification`)
- `app/Notifications/DomainVerifiedNotification.php`
- `app/Notifications/DomainVerificationTimeoutNotification.php`
- `app/Notifications/DomainLapsedNotification.php`
- `tests/Feature/DomainVerificationRetryTest.php` (15 tests)
- `tests/Feature/DomainVerificationNotificationTest.php` (5 tests)

**Modified files:**
- `app/Models/SenderIdentity.php` — `verification_retry_dispatched_at` fillable/cast, `hasActiveRetry()`
- `app/Http/Controllers/SenderIdentityController.php` — dispatch retry on first fail, clear flag on success, distinct plain-language message on second click while retry active
- `app/Http/Resources/SenderIdentityResource.php` — exposes `has_active_retry`
- `app/Console/Commands/ReverifyDomainIdentities.php` — sends `DomainLapsedNotification` on lapse
- `resources/js/Pages/Settings/Partials/SenderIdentityForm.vue` — blue info banner when `has_active_retry`
- `tests/Feature/SenderIdentityTest.php` — updated assertions
- `tests/Feature/ReverifyDomainIdentitiesTest.php` — asserts `DomainLapsedNotification` on fail

## Test plan

- [ ] 42 feature tests passing (`DomainVerificationRetryTest`, `DomainVerificationNotificationTest`, `SenderIdentityTest`, `ReverifyDomainIdentitiesTest`)
- [ ] Click "Verify Domain" with no DNS record → error shown, blue banner appears, retry job dispatched
- [ ] Click "Verify Domain" again while banner visible → plain-language "already working on it" message, no duplicate job
- [ ] Change domain while banner active → `verification_retry_dispatched_at` cleared, banner gone, new token generated
- [ ] Switch to email identity while banner active → flag cleared immediately
- [ ] Background job succeeds → `DomainVerifiedNotification` email received, `verified_at` set, banner disappears
- [ ] Background job exhausts 24h → `DomainVerificationTimeoutNotification` email received
- [ ] `php artisan sender-identity:reverify` on lapsed domain → `DomainLapsedNotification` email with reassurance about existing links

## Regression notes

`HandleInertiaRequests` builds `auth.senderIdentity` as a hand-rolled array that does not include `has_active_retry`. No current consumer reads that field from the shared prop (only `SenderIdentityForm.vue` needs it, and it receives the full resource via the Settings page props). Worth aligning in a future cleanup.