### PR TITLE
fix: replace direct push with PR-based sync for develop branch

### DIFF
--- a/.github/workflows/sync-master-to-develop.yml
+++ b/.github/workflows/sync-master-to-develop.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -14,13 +15,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge master into develop
+      - name: Check if master has new commits not in develop
+        id: check-sync
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git merge origin/master --no-edit -m "chore: merge master into develop [skip ci]"
-          git push origin develop
+          git fetch origin develop master
+          AHEAD=$(git rev-list --count origin/develop..origin/master)
+          echo "commits_ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          echo "master is $AHEAD commit(s) ahead of develop"
+
+      - name: Create sync PR (if not already open)
+        if: steps.check-sync.outputs.commits_ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head master \
+            --title "chore: sync master into develop" \
+            --body "Automated sync of master into develop after release." \
+          || true
+
+      - name: Enable auto-merge on sync PR
+        if: steps.check-sync.outputs.commits_ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --base develop \
+            --head master \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Enabling auto-merge on PR #$PR_NUMBER"
+            # Note: --delete-branch is deliberately omitted; omitting it is the gh default (do not delete).
+            # Requires "Allow auto-merge" to be enabled in repository Settings → General.
+            gh pr merge "$PR_NUMBER" --auto --merge \
+              || echo "Warning: auto-merge could not be enabled on PR #$PR_NUMBER — manual merge required."
+          else
+            echo "No open sync PR found — possibly already merged."
+          fi


### PR DESCRIPTION
## Summary

- Fixes the `sync-master-to-develop` workflow which was failing with a branch protection violation on every push to `master`
- Replaces the direct `git push` approach with a PR-based sync that respects the required status checks on `develop`
- The workflow now opens a PR from `master` → `develop` and enables auto-merge; the PR merges automatically once CI checks pass

## Regression Risk

- **Prerequisite:** "Allow auto-merge" must be enabled in repository `Settings → General` for auto-merge to take effect. If it is not enabled, the PR is created but stays open for manual merge — which still resolves the branch protection failure.
- CI will now run on each sync PR (previously bypassed via `[skip ci]`), slightly increasing CI usage per release.

## Test plan

- [x] Confirm "Allow auto-merge" is enabled in repository Settings → General
- [x] Push a commit to `master` and verify the workflow runs without error in GitHub Actions
- [x] Confirm a "chore: sync master into develop" PR is opened targeting `develop`
- [x] Confirm auto-merge is enabled on the PR (GitHub shows the "Auto-merge enabled" banner)
- [x] Confirm the PR merges automatically once CI checks pass
- [x] Confirm `master` branch is not deleted after the merge