### PR TITLE
fix: replace direct push with PR-based sync for develop branch (#82)

### DIFF
--- a/.github/workflows/sync-master-to-develop.yml
+++ b/.github/workflows/sync-master-to-develop.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -14,13 +15,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge master into develop
+      - name: Check if master has new commits not in develop
+        id: check-sync
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git merge origin/master --no-edit -m "chore: merge master into develop [skip ci]"
-          git push origin develop
+          git fetch origin develop master
+          AHEAD=$(git rev-list --count origin/develop..origin/master)
+          echo "commits_ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          echo "master is $AHEAD commit(s) ahead of develop"
+
+      - name: Create sync PR (if not already open)
+        if: steps.check-sync.outputs.commits_ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head master \
+            --title "chore: sync master into develop" \
+            --body "Automated sync of master into develop after release." \
+          || true
+
+      - name: Enable auto-merge on sync PR
+        if: steps.check-sync.outputs.commits_ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --base develop \
+            --head master \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Enabling auto-merge on PR #$PR_NUMBER"
+            # Note: --delete-branch is deliberately omitted; omitting it is the gh default (do not delete).
+            # Requires "Allow auto-merge" to be enabled in repository Settings → General.
+            gh pr merge "$PR_NUMBER" --auto --merge \
+              || echo "Warning: auto-merge could not be enabled on PR #$PR_NUMBER — manual merge required."
+          else
+            echo "No open sync PR found — possibly already merged."
+          fi


### PR DESCRIPTION
The direct git push to develop was being rejected by branch protection rules requiring 2 status checks to pass. Switch to opening a PR from master into develop and enabling auto-merge so the required CI checks run normally before the merge proceeds.