### PR TITLE
feat(PIO-67): restrict non-production environment to prevent Stripe test payment abuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,7 @@ PASSKEY_APP_LOGO=
 LARAVEL_CLOUDFLARE_ENABLED=true
 LARAVEL_CLOUDFLARE_REPLACE_IP=true
 TRUSTED_PROXIES=*
+
+# Non-production access gate: comma-separated list of email addresses permitted to register and subscribe.
+# Only active when APP_ENV is not 'production', 'prod', or 'testing'.
+ACCESS_ALLOWED_EMAILS=

--- a/app/Http/Middleware/EnsureEnvironmentSubscriptionAllowed.php
+++ b/app/Http/Middleware/EnsureEnvironmentSubscriptionAllowed.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEnvironmentSubscriptionAllowed
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! config('access.enabled')) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+
+        if (! $user) {
+            abort(403, 'Subscription upgrades are restricted on this environment.');
+        }
+
+        $allowedEmails = config('access.allowed_emails', []);
+
+        if (! empty($allowedEmails) && in_array($user->email, $allowedEmails)) {
+            return $next($request);
+        }
+
+        abort(403, 'Subscription upgrades are restricted on this environment. Contact the team to request access.');
+    }
+}

--- a/app/Http/Middleware/EnsureEnvironmentSubscriptionAllowed.php
+++ b/app/Http/Middleware/EnsureEnvironmentSubscriptionAllowed.php
@@ -20,9 +20,9 @@ class EnsureEnvironmentSubscriptionAllowed
             abort(403, 'Subscription upgrades are restricted on this environment.');
         }
 
-        $allowedEmails = config('access.allowed_emails', []);
+        $allowedEmails = array_map('strtolower', config('access.allowed_emails', []));
 
-        if (! empty($allowedEmails) && in_array($user->email, $allowedEmails)) {
+        if (! empty($allowedEmails) && in_array(strtolower($user->email), $allowedEmails)) {
             return $next($request);
         }
 

--- a/app/Http/Requests/Auth/InitiateRegistrationRequest.php
+++ b/app/Http/Requests/Auth/InitiateRegistrationRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Auth;
 
+use App\Rules\AllowedEnvironmentEmail;
 use Illuminate\Foundation\Http\FormRequest;
 
 class InitiateRegistrationRequest extends FormRequest
@@ -17,7 +18,7 @@ class InitiateRegistrationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email:rfc,dns', 'max:255'],
+            'email' => ['required', 'string', 'email:rfc,dns', 'max:255', new AllowedEnvironmentEmail],
         ];
     }
 }

--- a/app/Rules/AllowedEnvironmentEmail.php
+++ b/app/Rules/AllowedEnvironmentEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Str;
+
+class AllowedEnvironmentEmail implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! config('access.enabled')) {
+            return;
+        }
+
+        $allowedEmails = array_map('strtolower', config('access.allowed_emails', []));
+        $normalisedEmail = Str::lower($value);
+
+        if (empty($allowedEmails) || ! in_array($normalisedEmail, $allowedEmails)) {
+            $fail('Registration is restricted on this environment. Contact the team to request access.');
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEnvironmentSubscriptionAllowed;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SecurityHeadersMiddleware;
 use Illuminate\Foundation\Application;
@@ -41,6 +42,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'ability' => CheckForAnyAbility::class,
             'abilities' => CheckAbilities::class,
+            'environment.subscription' => EnsureEnvironmentSubscriptionAllowed::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/access.php
+++ b/config/access.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'enabled' => ! in_array(env('APP_ENV'), ['production', 'prod', 'testing']),
+    'allowed_emails' => array_filter(
+        array_map('trim', explode(',', env('ACCESS_ALLOWED_EMAILS', '')))
+    ),
+];

--- a/config/share.php
+++ b/config/share.php
@@ -12,6 +12,7 @@ return [
         'app.name',
         'secrets',
         'support',
+        'access.enabled',
     ],
 
     /**

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -36,6 +36,13 @@ const logout = () => {
 
         <Banner />
 
+        <!-- Non-production Environment Banner -->
+        <div v-if="$page.props.config.access?.enabled"
+            class="bg-amber-400 dark:bg-amber-600 text-amber-900 dark:text-amber-100 text-center text-sm font-semibold py-2 px-4">
+            This is a non-production environment. Test payments are enabled. Do not enter real card data.
+            Need access? Contact the team.
+        </div>
+
         <div class="bg-white text-black/80 dark:bg-gray-900 dark:text-white/80 h-full min-h-screen">
             <div>
                 <nav class="bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700">

--- a/routes/web.php
+++ b/routes/web.php
@@ -100,7 +100,9 @@ Route::middleware([
         return Inertia::render('Dashboard');
     })->name('dashboard');
 
-    Route::get('plans/{plan}/{period}', [PlanController::class, 'subscribe'])->name('plans.subscribe');
+    Route::get('plans/{plan}/{period}', [PlanController::class, 'subscribe'])
+        ->middleware('environment.subscription')
+        ->name('plans.subscribe');
     Route::post('plans/cancel', [PlanController::class, 'unsubscribe'])->name('plans.unsubscribe');
     Route::post('plans/resume', [PlanController::class, 'resume'])->name('plans.resume');
 

--- a/tests/Feature/Regressions/PIO67Test.php
+++ b/tests/Feature/Regressions/PIO67Test.php
@@ -26,10 +26,10 @@ class PIO67Test extends TestCase
     public function test_non_allowlisted_user_cannot_subscribe_on_non_production(): void
     {
         Config::set('access.enabled', true);
-        Config::set('access.allowed_emails', ['allowed@example.com']);
+        Config::set('access.allowed_emails', ['allowed@gmail.com']);
 
         $plan = Plan::factory()->create();
-        $user = User::factory()->create(['email' => 'blocked@example.com']);
+        $user = User::factory()->create(['email' => 'blocked@gmail.com']);
 
         $response = $this->actingAs($user)->get(route('plans.subscribe', [$plan, 'monthly']));
 
@@ -39,12 +39,12 @@ class PIO67Test extends TestCase
     public function test_allowlisted_user_can_initiate_subscription_on_non_production(): void
     {
         Config::set('access.enabled', true);
-        Config::set('access.allowed_emails', ['allowed@example.com']);
+        Config::set('access.allowed_emails', ['allowed@gmail.com']);
 
         Route::middleware(['web', 'auth', EnsureEnvironmentSubscriptionAllowed::class])
             ->get('/test-env-subscription', fn () => 'ok');
 
-        $user = User::factory()->create(['email' => 'allowed@example.com']);
+        $user = User::factory()->create(['email' => 'allowed@gmail.com']);
 
         $response = $this->actingAs($user)->get('/test-env-subscription');
 
@@ -59,7 +59,7 @@ class PIO67Test extends TestCase
         Route::middleware(['web', 'auth', EnsureEnvironmentSubscriptionAllowed::class])
             ->get('/test-env-subscription-prod', fn () => 'ok');
 
-        $user = User::factory()->create(['email' => 'anyone@example.com']);
+        $user = User::factory()->create(['email' => 'anyone@gmail.com']);
 
         $response = $this->actingAs($user)->get('/test-env-subscription-prod');
 
@@ -70,10 +70,10 @@ class PIO67Test extends TestCase
     public function test_non_allowlisted_email_cannot_register_on_non_production(): void
     {
         Config::set('access.enabled', true);
-        Config::set('access.allowed_emails', ['allowed@example.com']);
+        Config::set('access.allowed_emails', ['allowed@gmail.com']);
 
         $response = $this->post('/register', [
-            'email' => 'blocked@example.com',
+            'email' => 'blocked@gmail.com',
         ]);
 
         $response->assertSessionHasErrors(['email']);
@@ -82,10 +82,10 @@ class PIO67Test extends TestCase
     public function test_allowlisted_email_can_register_on_non_production(): void
     {
         Config::set('access.enabled', true);
-        Config::set('access.allowed_emails', ['allowed@example.com']);
+        Config::set('access.allowed_emails', ['allowed@gmail.com']);
 
         $response = $this->post('/register', [
-            'email' => 'allowed@example.com',
+            'email' => 'allowed@gmail.com',
         ]);
 
         $response->assertSessionHasNoErrors();
@@ -96,7 +96,7 @@ class PIO67Test extends TestCase
         Config::set('access.enabled', false);
 
         $response = $this->post('/register', [
-            'email' => 'anyone@example.com',
+            'email' => 'anyone@gmail.com',
         ]);
 
         $response->assertSessionHasNoErrors();
@@ -108,7 +108,7 @@ class PIO67Test extends TestCase
         Config::set('access.allowed_emails', []);
 
         $response = $this->post('/register', [
-            'email' => 'anyone@example.com',
+            'email' => 'anyone@gmail.com',
         ]);
 
         $response->assertSessionHasErrors(['email']);
@@ -117,10 +117,10 @@ class PIO67Test extends TestCase
     public function test_allowlist_check_is_case_insensitive(): void
     {
         Config::set('access.enabled', true);
-        Config::set('access.allowed_emails', ['allowed@example.com']);
+        Config::set('access.allowed_emails', ['allowed@gmail.com']);
 
         $response = $this->post('/register', [
-            'email' => 'Allowed@example.com',
+            'email' => 'Allowed@gmail.com',
         ]);
 
         $response->assertSessionHasNoErrors();

--- a/tests/Feature/Regressions/PIO67Test.php
+++ b/tests/Feature/Regressions/PIO67Test.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Http\Middleware\EnsureEnvironmentSubscriptionAllowed;
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+/**
+ * PIO-67: Non-production environments use Stripe test payment gateway,
+ * allowing anyone to register and subscribe using test cards to gain
+ * paid-feature access for free.
+ */
+class PIO67Test extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Core regression: a user with a non-allowlisted email can freely
+     * subscribe to a paid plan on a non-production environment.
+     */
+    public function test_non_allowlisted_user_cannot_subscribe_on_non_production(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', ['allowed@example.com']);
+
+        $plan = Plan::factory()->create();
+        $user = User::factory()->create(['email' => 'blocked@example.com']);
+
+        $response = $this->actingAs($user)->get(route('plans.subscribe', [$plan, 'monthly']));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_allowlisted_user_can_initiate_subscription_on_non_production(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', ['allowed@example.com']);
+
+        Route::middleware(['web', 'auth', EnsureEnvironmentSubscriptionAllowed::class])
+            ->get('/test-env-subscription', fn () => 'ok');
+
+        $user = User::factory()->create(['email' => 'allowed@example.com']);
+
+        $response = $this->actingAs($user)->get('/test-env-subscription');
+
+        $response->assertOk();
+        $response->assertSee('ok');
+    }
+
+    public function test_subscription_not_restricted_on_production(): void
+    {
+        Config::set('access.enabled', false);
+
+        Route::middleware(['web', 'auth', EnsureEnvironmentSubscriptionAllowed::class])
+            ->get('/test-env-subscription-prod', fn () => 'ok');
+
+        $user = User::factory()->create(['email' => 'anyone@example.com']);
+
+        $response = $this->actingAs($user)->get('/test-env-subscription-prod');
+
+        $response->assertOk();
+        $response->assertSee('ok');
+    }
+
+    public function test_non_allowlisted_email_cannot_register_on_non_production(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', ['allowed@example.com']);
+
+        $response = $this->post('/register', [
+            'email' => 'blocked@example.com',
+        ]);
+
+        $response->assertSessionHasErrors(['email']);
+    }
+
+    public function test_allowlisted_email_can_register_on_non_production(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', ['allowed@example.com']);
+
+        $response = $this->post('/register', [
+            'email' => 'allowed@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_registration_not_restricted_on_production(): void
+    {
+        Config::set('access.enabled', false);
+
+        $response = $this->post('/register', [
+            'email' => 'anyone@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_empty_allowlist_blocks_all_users_on_non_production(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', []);
+
+        $response = $this->post('/register', [
+            'email' => 'anyone@example.com',
+        ]);
+
+        $response->assertSessionHasErrors(['email']);
+    }
+
+    public function test_allowlist_check_is_case_insensitive(): void
+    {
+        Config::set('access.enabled', true);
+        Config::set('access.allowed_emails', ['allowed@example.com']);
+
+        $response = $this->post('/register', [
+            'email' => 'Allowed@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a three-layer access gate active on all non-production environments (`APP_ENV` ≠ `production`/`prod`/`testing`), controlled entirely via the `ACCESS_ALLOWED_EMAILS` environment variable
- Registration is blocked for emails not in the allowlist (`AllowedEnvironmentEmail` validation rule on `InitiateRegistrationRequest`)
- Stripe checkout is blocked for non-allowlisted users (`EnsureEnvironmentSubscriptionAllowed` middleware on `plans.subscribe`)
- A persistent amber banner is shown on all non-production pages via `AppLayout.vue`
- `access.enabled` is shared to the frontend via `config/share.php`; the allowlist is never exposed to the browser

## Files changed

| File | Change |
|---|---|
| `config/access.php` | New — gate config (enabled flag + allowlist parsing) |
| `app/Rules/AllowedEnvironmentEmail.php` | New — registration validation rule (case-insensitive) |
| `app/Http/Middleware/EnsureEnvironmentSubscriptionAllowed.php` | New — subscription middleware (case-insensitive) |
| `app/Http/Requests/Auth/InitiateRegistrationRequest.php` | Add `AllowedEnvironmentEmail` rule to email field |
| `bootstrap/app.php` | Register `environment.subscription` middleware alias |
| `routes/web.php` | Apply middleware to `plans.subscribe` route |
| `config/share.php` | Add `access.enabled` to shared Inertia config |
| `resources/js/Layouts/AppLayout.vue` | Add persistent amber non-production banner |
| `.env.example` | Document `ACCESS_ALLOWED_EMAILS` |
| `tests/Feature/Regressions/PIO67Test.php` | 8 regression tests (TDD — written before fix) |

## Deployment (develop environment)

Set in Laravel Cloud:

```
ACCESS_ALLOWED_EMAILS=alice@pioneer-dynamics.com,bob@pioneer-dynamics.com
```

Empty value = all users blocked (safe default). Production requires no changes.

## Known limitations / risks

- **Plan/Index.vue does not display the 403 flash error** — when a non-allowlisted user clicks Subscribe, the Inertia exception handler redirects back silently. This is a pre-existing UX limitation of the 403 handler unrelated to this PR; the user is blocked correctly, they just don't see the error message inline.
- **Step 2 of registration (signed URL) is not re-checked** — by design. A non-allowlisted email cannot pass step 1 and therefore cannot receive a valid signed URL; re-checking at step 2 is redundant.
- **`resume` and `cancel` routes are not gated** — intentional. The gate blocks initiating new subscriptions and plan-swaps. Users with an existing test subscription can still manage (cancel/resume) it.

## Test plan

- [x] Set `ACCESS_ALLOWED_EMAILS` to your email on the develop environment
- [x] Confirm amber banner is visible after login
- [x] Confirm a non-allowlisted email is rejected at `/register` with the access restriction message
- [x] Confirm your allowlisted email can complete registration
- [x] Confirm a non-allowlisted logged-in user cannot reach Stripe checkout via the Pricing page
- [x] Confirm your allowlisted user can reach Stripe checkout
- [x] Confirm production (`APP_ENV=production`) is completely unaffected