### PR TITLE
fix(PIO-74): silence webhook delivery alerts and notify user on permanent failure

### DIFF
--- a/app/Exceptions/WebhookDeliveryFailedException.php
+++ b/app/Exceptions/WebhookDeliveryFailedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Contracts\Debug\ShouldntReport;
+
+class WebhookDeliveryFailedException extends \RuntimeException implements ShouldntReport {}

--- a/app/Http/Controllers/WebhookSettingsController.php
+++ b/app/Http/Controllers/WebhookSettingsController.php
@@ -83,6 +83,7 @@ class WebhookSettingsController extends Controller
             hashId: 'test-'.Str::random(5),
             createdAt: now()->toIso8601String(),
             retrievedAt: now()->toIso8601String(),
+            userId: $user->id,
             event: 'ping',
         );
 

--- a/app/Jobs/SendWebhookNotification.php
+++ b/app/Jobs/SendWebhookNotification.php
@@ -2,10 +2,14 @@
 
 namespace App\Jobs;
 
+use App\Exceptions\WebhookDeliveryFailedException;
+use App\Mail\WebhookDeliveryFailedMail;
+use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
 class SendWebhookNotification implements ShouldQueue
@@ -20,6 +24,7 @@ class SendWebhookNotification implements ShouldQueue
         public string $hashId,
         public string $createdAt,
         public string $retrievedAt,
+        public int $userId,
         public string $event = 'retrieved',
     ) {}
 
@@ -62,7 +67,7 @@ class SendWebhookNotification implements ShouldQueue
             ->post($this->webhookUrl);
 
         if ($response->failed()) {
-            throw new \RuntimeException(
+            throw new WebhookDeliveryFailedException(
                 "Webhook delivery failed with status {$response->status()}"
             );
         }
@@ -76,5 +81,11 @@ class SendWebhookNotification implements ShouldQueue
             'event' => $this->event,
             'error' => $exception->getMessage(),
         ]);
+
+        $user = User::find($this->userId);
+
+        if ($user) {
+            Mail::to($user)->sendNow(new WebhookDeliveryFailedMail($user, $this->webhookUrl));
+        }
     }
 }

--- a/app/Mail/WebhookDeliveryFailedMail.php
+++ b/app/Mail/WebhookDeliveryFailedMail.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+class WebhookDeliveryFailedMail extends Mailable
+{
+    public function __construct(public User $user, public string $webhookUrl) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('Webhook delivery permanently failed'),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.WebhookDeliveryFailedMail',
+            with: [
+                'webhookHost' => parse_url($this->webhookUrl, PHP_URL_HOST),
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Secret.php
+++ b/app/Models/Secret.php
@@ -120,6 +120,7 @@ class Secret extends Model
                                 hashId: $secret->hash_id,
                                 createdAt: $secret->created_at->toIso8601String(),
                                 retrievedAt: now()->toIso8601String(),
+                                userId: $user->id,
                             ));
                         }
                     }

--- a/resources/views/emails/WebhookDeliveryFailedMail.blade.php
+++ b/resources/views/emails/WebhookDeliveryFailedMail.blade.php
@@ -1,0 +1,20 @@
+<x-mail::message>
+# Webhook Delivery Failed
+
+Hi {{ $user->name }},
+
+We were unable to deliver webhook notifications to **{{ $webhookHost }}** after multiple retry attempts over the last 24 hours. Delivery attempts for this event have stopped.
+
+**Your webhook integration remains active** — future secret retrievals will continue to trigger delivery attempts as normal.
+
+**What to check:**
+- Your endpoint is reachable and responding with a 2xx status code.
+- If your endpoint requires an API key or token, it may have expired or been rotated.
+
+<x-mail::button :url="route('webhooks.index')">
+Review Webhook Settings
+</x-mail::button>
+
+Thanks,
+{{ config('app.name') }}
+</x-mail::message>

--- a/tests/Feature/Regressions/PIO74Test.php
+++ b/tests/Feature/Regressions/PIO74Test.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Exceptions\WebhookDeliveryFailedException;
+use App\Jobs\SendWebhookNotification;
+use App\Mail\WebhookDeliveryFailedMail;
+use App\Models\User;
+use Illuminate\Contracts\Debug\ShouldntReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * PIO-74: RuntimeException on webhook delivery failure was reported to Nightwatch on every retry.
+ * Fix: custom exception implementing ShouldntReport + alert email on permanent failure.
+ */
+class PIO74Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_delivery_exception_is_not_reportable(): void
+    {
+        $exception = new WebhookDeliveryFailedException('Webhook delivery failed with status 401');
+
+        $this->assertInstanceOf(ShouldntReport::class, $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    public function test_user_receives_email_on_permanent_webhook_failure(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+
+        $job = new SendWebhookNotification(
+            webhookUrl: 'https://example.com/webhook',
+            webhookSecret: 'secret',
+            hashId: 'abc123',
+            createdAt: now()->toIso8601String(),
+            retrievedAt: now()->toIso8601String(),
+            userId: $user->id,
+        );
+
+        $job->failed(new WebhookDeliveryFailedException('Webhook delivery failed with status 401'));
+
+        Mail::assertSent(WebhookDeliveryFailedMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
+    }
+
+    public function test_failed_does_not_throw_when_user_not_found(): void
+    {
+        Mail::fake();
+
+        $job = new SendWebhookNotification(
+            webhookUrl: 'https://example.com/webhook',
+            webhookSecret: 'secret',
+            hashId: 'abc123',
+            createdAt: now()->toIso8601String(),
+            retrievedAt: now()->toIso8601String(),
+            userId: 99999,
+        );
+
+        $this->expectNotToPerformAssertions();
+
+        $job->failed(new WebhookDeliveryFailedException('Webhook delivery failed with status 401'));
+    }
+}

--- a/tests/Feature/WebhookNotificationTest.php
+++ b/tests/Feature/WebhookNotificationTest.php
@@ -36,9 +36,10 @@ class WebhookNotificationTest extends TestCase
 
         $this->get($url);
 
-        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret) {
+        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret, $user) {
             return $job->hashId === $secret->hash_id
-                && $job->event === 'retrieved';
+                && $job->event === 'retrieved'
+                && $job->userId === $user->id;
         });
     }
 
@@ -113,13 +114,14 @@ class WebhookNotificationTest extends TestCase
 
         $this->get($url);
 
-        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret) {
+        Bus::assertDispatched(SendWebhookNotification::class, function ($job) use ($secret, $user) {
             return $job->webhookUrl === 'https://example.com/hook'
                 && $job->webhookSecret === 'test-secret-123'
                 && $job->hashId === $secret->hash_id
                 && $job->event === 'retrieved'
                 && ! empty($job->createdAt)
-                && ! empty($job->retrievedAt);
+                && ! empty($job->retrievedAt)
+                && $job->userId === $user->id;
         });
     }
 

--- a/tests/Feature/WebhookSettingsTest.php
+++ b/tests/Feature/WebhookSettingsTest.php
@@ -404,7 +404,8 @@ class WebhookSettingsTest extends TestCase
         Queue::assertPushed(SendWebhookNotification::class, function ($job) {
             return $job->event === 'ping'
                 && str_starts_with($job->hashId, 'test-')
-                && $job->webhookUrl === 'https://example.com/webhook';
+                && $job->webhookUrl === 'https://example.com/webhook'
+                && $job->userId === $this->user->id;
         });
     }
 

--- a/tests/Unit/SendWebhookNotificationTest.php
+++ b/tests/Unit/SendWebhookNotificationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Exceptions\WebhookDeliveryFailedException;
 use App\Jobs\SendWebhookNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -25,6 +26,7 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
         $job->handle();
@@ -50,6 +52,7 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
         $job->handle();
@@ -72,6 +75,7 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
         $job->handle();
@@ -91,9 +95,10 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(WebhookDeliveryFailedException::class);
         $this->expectExceptionMessage('Webhook delivery failed with status 500');
 
         $job->handle();
@@ -107,6 +112,7 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
         $backoff = $job->backoff();
@@ -124,6 +130,7 @@ class SendWebhookNotificationTest extends TestCase
             hashId: 'abc123',
             createdAt: '2026-03-25T10:00:00+00:00',
             retrievedAt: '2026-03-25T12:00:00+00:00',
+            userId: 1,
         );
 
         $retryUntil = $job->retryUntil();


### PR DESCRIPTION
## Summary

- Replaces the bare `RuntimeException` in `SendWebhookNotification::handle()` with a new `WebhookDeliveryFailedException` that implements `ShouldntReport`, stopping Nightwatch from alerting on every retry attempt while keeping the queue retry mechanism intact
- Adds `userId` to the job constructor so `failed()` can identify the user after all retries are exhausted
- Sends a `WebhookDeliveryFailedMail` synchronously (`sendNow()`) from `failed()` to alert the user — email shows the failing webhook hostname and hints at expired API keys as a common cause

## Test plan

- [x] All 469 existing tests pass (`php artisan test`)
- [x] Regression tests in `tests/Feature/Regressions/PIO74Test.php` pass (3 tests covering: exception is not reportable, email sent on permanent failure, no crash when user deleted)
- [x] Verify Nightwatch does not create a new alert when a webhook returns 4xx/5xx during retries
- [x] Verify alert email is received by the user when a webhook job permanently fails

## Deployment note

> **Drain the `jobs` queue before deploying.** Any `SendWebhookNotification` jobs serialized to the database queue before this deploy will fail deserialization due to the new required `userId` field and will be permanently failed immediately on deploy.

## Files changed

| Action | File |
|--------|------|
| New | `app/Exceptions/WebhookDeliveryFailedException.php` |
| New | `app/Mail/WebhookDeliveryFailedMail.php` |
| New | `resources/views/emails/WebhookDeliveryFailedMail.blade.php` |
| New | `tests/Feature/Regressions/PIO74Test.php` |
| Modified | `app/Jobs/SendWebhookNotification.php` |
| Modified | `app/Models/Secret.php` |
| Modified | `app/Http/Controllers/WebhookSettingsController.php` |
| Modified | `tests/Feature/WebhookNotificationTest.php` |
| Modified | `tests/Feature/WebhookSettingsTest.php` |
| Modified | `tests/Unit/SendWebhookNotificationTest.php` |