### PR TITLE
fix: bump flashview-crypto to v1.1.0 to fix CLI install

### DIFF
--- a/tools/flashview-crypto/package.json
+++ b/tools/flashview-crypto/package.json
@@ -3,7 +3,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Isomorphic encryption package for FlashView — browser and Node.js",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

- Bumps `@pioneer-dynamics/flashview-crypto` from v1.0.1 to v1.1.0
- `encryptBuffer` and `decryptBuffer` were added to the source in a prior PR but the package version was never incremented, so CI skipped republishing it
- The CLI v1.9.0 therefore resolved the stale npm version and crashed on import with a missing export error

## Test plan

- [ ] Merge to develop → master triggers the `publish-cli` CI workflow
- [ ] CI publishes flashview-crypto@1.1.0 to npm
- [ ] CI pins CLI dependency to `^1.1.0` and publishes updated CLI
- [ ] `npm install -g @pioneer-dynamics/flashview-cli` no longer throws `SyntaxError: does not provide an export named 'encryptBuffer'`