### PR TITLE
fix(PIO-75): UX bugs on secret encrypt/decrypt screens

### DIFF
--- a/config/secrets.php
+++ b/config/secrets.php
@@ -83,6 +83,7 @@ return [
             'application/pdf',
             'application/zip',
             'application/gzip',
+            'application/x-gzip',
             'application/x-zip-compressed',
             'application/msword',
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/config/secrets.php
+++ b/config/secrets.php
@@ -82,6 +82,7 @@ return [
             // Documents
             'application/pdf',
             'application/zip',
+            'application/gzip',
             'application/x-zip-compressed',
             'application/msword',
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/database/seeders/PlanSeederLocal.php
+++ b/database/seeders/PlanSeederLocal.php
@@ -214,7 +214,7 @@ class PlanSeederLocal extends Seeder
                     'file_upload' => [
                         'order' => 4.3,
                         'label' => 'File uploads up to :max_file_size_mb MB',
-                        'config' => ['max_file_size_mb' => 250],
+                        'config' => ['max_file_size_mb' => 500],
                         'type' => 'feature',
                     ],
                     'email_notification' => [

--- a/database/seeders/PlanSeederProd.php
+++ b/database/seeders/PlanSeederProd.php
@@ -214,7 +214,7 @@ class PlanSeederProd extends Seeder
                     'file_upload' => [
                         'order' => 4.3,
                         'label' => 'File uploads up to :max_file_size_mb MB',
-                        'config' => ['max_file_size_mb' => 250],
+                        'config' => ['max_file_size_mb' => 500],
                         'type' => 'feature',
                     ],
                     'email_notification' => [

--- a/resources/js/Components/FileDecryptPanel.vue
+++ b/resources/js/Components/FileDecryptPanel.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { useForm, usePage, router } from '@inertiajs/vue3';
 import { encryption } from '../encryption';
 import FileProgressBar from '@/Components/FileProgressBar.vue';
@@ -11,11 +11,13 @@ const props = defineProps({
     fileSize: { type: Number, default: null },
 });
 
-const emit = defineEmits(['success', 'failure']);
+const emit = defineEmits(['success', 'failure', 'state-change']);
 
 const decryptForm = useForm({});
 const fileDecryptState = ref(null);
 const fileDecryptProgress = ref(0);
+
+watch(fileDecryptState, (next) => emit('state-change', next));
 
 const humanFileSize = (bytes) => {
     if (bytes < 1024) return bytes + ' B';

--- a/resources/js/Components/FileUploadZone.vue
+++ b/resources/js/Components/FileUploadZone.vue
@@ -88,7 +88,7 @@ onUnmounted(() => stopScramble(true));
                 <p class="text-sm font-mono text-gamboge-300 truncate">{{ scrambledName || modelValue.name }}</p>
                 <p class="text-xs text-gray-500 dark:text-gray-400">{{ humanFileSize(modelValue.size) }}</p>
             </div>
-            <button type="button" @click="clearFile" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 shrink-0">
+            <button type="button" @click="clearFile" :disabled="!!uploadState" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 shrink-0 disabled:opacity-40 disabled:cursor-not-allowed">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-4">
                     <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
                 </svg>

--- a/resources/js/Components/TextAreaInput.vue
+++ b/resources/js/Components/TextAreaInput.vue
@@ -18,7 +18,11 @@ const props = defineProps({
     autofocus: {
         type: Boolean,
         default: false
-    }
+    },
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 defineEmits(['update:modelValue']);
@@ -41,7 +45,7 @@ const inputClass = computed(() => {
 </script>
 
 <template>
-        <span @click="() => input.focus()" ref="base" :class="{'relative ring-0 focus-within:ring-1 border-gray-300 dark:border-gamboge-300/40 dark:bg-gray-800 dark:text-gray-200 focus-within:border-gamboge-500 dark:focus-within:border-gamboge-500 focus-within:ring-gamboge-500 dark:focus-within:ring-gamboge-500 rounded-md shadow-sm': maxLength == 0 || input?.value?.length <= maxLength, 'text-red-500 relative border-red-300 dark:border-red-700 dark:bg-red-100 dark:text-red-200 focus:border-red-500 dark:focus:border-red-600 focus:ring-red-500 dark:focus:ring-red-600 rounded-md shadow-sm bg-red-50': maxLength > 0 && input?.value?.length > maxLength}">
+        <span @click="() => input.focus()" ref="base" :class="[{'relative ring-0 focus-within:ring-1 border-gray-300 dark:border-gamboge-300/40 dark:bg-gray-800 dark:text-gray-200 focus-within:border-gamboge-500 dark:focus-within:border-gamboge-500 focus-within:ring-gamboge-500 dark:focus-within:ring-gamboge-500 rounded-md shadow-sm': maxLength == 0 || input?.value?.length <= maxLength, 'text-red-500 relative border-red-300 dark:border-red-700 dark:bg-red-100 dark:text-red-200 focus:border-red-500 dark:focus:border-red-600 focus:ring-red-500 dark:focus:ring-red-600 rounded-md shadow-sm bg-red-50': maxLength > 0 && input?.value?.length > maxLength}, disabled ? 'opacity-60 cursor-not-allowed' : '']">
             <textarea
                 ref="input"
                 class="w-full border-0 focus:ring-0 -mt-2 -ml-2 -mr-2 mb-2 dark:bg-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-400"
@@ -49,6 +53,7 @@ const inputClass = computed(() => {
                 :value="modelValue"
                 :rows="rows"
                 :placeholder="placeholder"
+                :disabled="disabled"
                 @input="$emit('update:modelValue', $event.target.value)"
             ></textarea>
             <div v-if="maxLength > 0" class="absolute bottom-2 right-6 text-sm" :class="{ 'text-red-500': input?.value?.length > maxLength }">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -50,11 +50,10 @@
         }
     });
 
-    const placeholderMessage = 'This isn\'t the actual message—it\'s just a placeholder. To view the message, please click the button below.';
-
     const handleDecryptionFailure = (reason = 'wrong-password') => {
         decryptionSuccess.value = false;
-        form.message = props.secret ? placeholderMessage : '';
+        form.message = '';
+        fileDecryptState.value = null;
         decryptionFailureReason.value = reason;
         decryptionFailed.value = true;
     };
@@ -100,7 +99,7 @@
     });
 
     const form = useForm({
-        message: props.secret ? placeholderMessage : '',
+        message: '',
         email: '',
         expires_in: expiryOptions.value[expiryOptions.value.length - 1].value,
         include_sender_identity: usePage().props.auth.senderIdentity?.include_by_default ?? false,
@@ -130,6 +129,13 @@
     const fileError = ref(null);
     const uploadState = ref(null);
     const uploadProgress = ref(0);
+
+    const fileDecryptState = ref(null);
+    const isEncryptBusy = computed(() => !!uploadState.value || form.processing);
+    const isDecryptBusy = computed(() => decryptForm.processing || !!fileDecryptState.value);
+    const passwordInputDisabled = computed(() =>
+        props.secret == null ? isEncryptBusy.value : isDecryptBusy.value,
+    );
 
     const encryptFileData = async () => {
         if (!selectedFile.value) { return; }
@@ -420,6 +426,7 @@
                             :file-mime-type="props.fileMimeType"
                             :file-size="props.fileSize"
                             @success="decryptionSuccess = true"
+                            @state-change="(next) => fileDecryptState = next"
                             @failure="handleDecryptionFailure"
                         />
                         <div v-if="props.hasMessage && decryptionSuccess" class="mt-3">
@@ -429,7 +436,7 @@
                     </div>
                     <div v-else>
                         <CodeBlock v-if="decryptionSuccess && props.secret != null" :value="form.message" class="mt-1" />
-                        <TextAreaInput v-else :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" class="font-mono" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength"/>
+                        <TextAreaInput v-else :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" class="font-mono" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength" :disabled="isEncryptBusy"/>
                     </div>
                     <div class="flex flex-wrap mt-2 relative text-sm gap-2" v-if="!props.isFileSecret || props.secret == null">
                         <div class="flex flex-wrap">
@@ -481,17 +488,17 @@
             <div class="col-span-12">
                 <div class="flex flex-wrap sm:flex-nowrap gap-2 sm:space-y-0">
                     <div class="w-full" v-if="$page.props.jetstream.flash?.secret?.message == undefined && !decryptionSuccess">
-                        <span v-if="stage=='generated'">
+                        <span v-if="stage=='generated' && !isEncryptBusy">
                             <InputLabel value="Password"/>
                             <CodeBlock :value="other.password" class="mt-1"/>
                         </span>
-                        <span v-else>
-                            <TextInput id="password" :autofocus="props.secret != null" ref="passwordInput" v-model="other.password" type="text" class="font-mono mt-1 block w-full" :placeholder="passwordPlaceholder" />
+                        <span v-else-if="!(isEncryptBusy && props.secret == null)">
+                            <TextInput id="password" :autofocus="props.secret != null" ref="passwordInput" v-model="other.password" type="text" class="font-mono mt-1 block w-full" :placeholder="passwordPlaceholder" :disabled="passwordInputDisabled" />
                             <InputError :message="other.errors.password" class="mt-2" />
                         </span>
                     </div>
                     <div v-if="!$page.props.jetstream.flash?.secret?.url && props.secret == null">
-                        <SelectInput id="expires_in" v-model="form.expires_in" class="mt-1 sm:w-full" :options="expiryOptions" />
+                        <SelectInput id="expires_in" v-model="form.expires_in" class="mt-1 sm:w-full" :options="expiryOptions" :disabled="isEncryptBusy" />
                         <InputError :message="other.errors.expires_in" class="mt-2" />
                     </div>
                 </div>
@@ -505,14 +512,14 @@
                     </span>
                 </span>
                 <span v-else-if="!$page.props.jetstream.flash?.secret?.url && props.secret == null">
-                    <TextInput v-model="form.email" placeholder="Recipient's email adddress (optional)" class="mt-1 block w-full" type="email"/>
+                    <TextInput v-model="form.email" placeholder="Recipient's email adddress (optional)" class="mt-1 block w-full" type="email" :disabled="isEncryptBusy"/>
                     <InputError :message="form.errors.email" class="mt-2" />
                 </span>
             </div>
 
             <div v-if="!$page.props.jetstream.flash?.secret?.url && props.secret == null && $page.props.auth.senderIdentity" class="col-span-12">
                 <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
-                    <Checkbox v-model:checked="form.include_sender_identity"/>
+                    <Checkbox v-model:checked="form.include_sender_identity" :disabled="isEncryptBusy"/>
                     Include my verified sender identity
                     <span class="text-gray-500 dark:text-gray-400">
                         ({{ $page.props.auth.senderIdentity.company_name ?? $page.props.auth.senderIdentity.email }})
@@ -528,7 +535,7 @@
                     <PrimaryButton @click.prevent="letsDoAnotherOne" v-if="$page.props.jetstream.flash?.secret?.url" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                         Let's do another one
                     </PrimaryButton>
-                    <PrimaryButton @click.prevent="encryptData" v-else :class="{ 'opacity-25': form.processing || !!uploadState }" :disabled="form.processing || !!uploadState">
+                    <PrimaryButton @click.prevent="encryptData" v-else :class="{ 'opacity-25': isEncryptBusy }" :disabled="isEncryptBusy">
                         Generate link
                     </PrimaryButton>
                 </div>
@@ -537,9 +544,9 @@
                 <PrimaryButton
                     @click.prevent="decryptData"
                     v-if="!$page.props.jetstream.flash?.secret?.message && !decryptionSuccess"
-                    :class="{ 'opacity-25': decryptForm.processing || (other.password?.length == 0 || other.password == null) }"
-                    :disabled="decryptForm.processing || (other.password?.length == 0 || other.password == null)">
-                    {{ props.isFileSecret ? 'Unlock & Download' : 'Retrieve Message' }}
+                    :class="{ 'opacity-25': isDecryptBusy || (other.password?.length == 0 || other.password == null) }"
+                    :disabled="isDecryptBusy || (other.password?.length == 0 || other.password == null)">
+                    {{ props.isFileSecret ? 'Download and decrypt' : 'Retrieve Message' }}
                 </PrimaryButton>
                 <PrimaryButton v-else :href="route('welcome')">
                     Send a new secret link

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -429,7 +429,7 @@
                             @state-change="(next) => fileDecryptState = next"
                             @failure="handleDecryptionFailure"
                         />
-                        <div v-if="props.hasMessage && decryptionSuccess" class="mt-3">
+                        <div v-if="props.hasMessage && decryptionSuccess && form.message?.length > 0" class="mt-3">
                             <p class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Note from sender</p>
                             <CodeBlock :value="form.message" class="mt-1" />
                         </div>

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -435,7 +435,7 @@
                         </div>
                     </div>
                     <div v-else>
-                        <CodeBlock v-if="decryptionSuccess && props.secret != null" :value="form.message" class="mt-1" />
+                        <CodeBlock v-if="decryptionSuccess && props.secret != null && form.message?.length > 0" :value="form.message" class="mt-1" />
                         <TextAreaInput v-else :autofocus="props.secret == null" id="message" rows="7" v-model="form.message" type="text" class="font-mono" :class="messageClass" placeholder="Your secret message..." :max-length="$page.props.jetstream.flash?.secret?.message ? 0 : maxLength" :disabled="isEncryptBusy"/>
                     </div>
                     <div class="flex flex-wrap mt-2 relative text-sm gap-2" v-if="!props.isFileSecret || props.secret == null">

--- a/resources/js/Pages/Secret/SecretForm.vue
+++ b/resources/js/Pages/Secret/SecretForm.vue
@@ -492,8 +492,8 @@
                             <InputLabel value="Password"/>
                             <CodeBlock :value="other.password" class="mt-1"/>
                         </span>
-                        <span v-else-if="!(isEncryptBusy && props.secret == null)">
-                            <TextInput id="password" :autofocus="props.secret != null" ref="passwordInput" v-model="other.password" type="text" class="font-mono mt-1 block w-full" :placeholder="passwordPlaceholder" :disabled="passwordInputDisabled" />
+                        <span v-else>
+                            <TextInput id="password" :autofocus="props.secret != null" ref="passwordInput" :model-value="(isEncryptBusy && props.secret == null) ? '' : other.password" @update:model-value="other.password = $event" type="text" class="font-mono mt-1 block w-full" :placeholder="passwordPlaceholder" :disabled="passwordInputDisabled" />
                             <InputError :message="other.errors.password" class="mt-2" />
                         </span>
                     </div>
@@ -548,7 +548,7 @@
                     :disabled="isDecryptBusy || (other.password?.length == 0 || other.password == null)">
                     {{ props.isFileSecret ? 'Download and decrypt' : 'Retrieve Message' }}
                 </PrimaryButton>
-                <PrimaryButton v-else :href="route('welcome')">
+                <PrimaryButton v-else :href="isDecryptBusy ? null : route('welcome')" :class="{ 'opacity-25': isDecryptBusy }" :disabled="isDecryptBusy">
                     Send a new secret link
                 </PrimaryButton>
             </span>

--- a/tests/Feature/Regressions/PIO75Test.php
+++ b/tests/Feature/Regressions/PIO75Test.php
@@ -44,7 +44,7 @@ class PIO75Test extends TestCase
         );
     }
 
-    public function test_encrypt_flow_hides_password_and_disables_inputs_while_uploading(): void
+    public function test_encrypt_flow_blanks_password_input_and_disables_inputs_while_uploading(): void
     {
         $contents = file_get_contents(resource_path('js/Pages/Secret/SecretForm.vue'));
 
@@ -70,6 +70,18 @@ class PIO75Test extends TestCase
             'passwordInputDisabled',
             $contents,
             'SecretForm.vue must declare a passwordInputDisabled computed so the password TextInput binding is readable and greppable.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/isEncryptBusy\s*&&\s*props\.secret\s*==\s*null\s*\)\s*\?\s*[\'""]{2}\s*:\s*other\.password/',
+            $contents,
+            'SecretForm.vue password TextInput must display an empty string while isEncryptBusy so the password is not visible during upload.'
+        );
+
+        $this->assertStringNotContainsString(
+            'v-else-if="!(isEncryptBusy',
+            $contents,
+            'SecretForm.vue must not conditionally hide the password input — keep it visible but blank it during upload instead.'
         );
     }
 
@@ -119,6 +131,29 @@ class PIO75Test extends TestCase
             "/emit\\(\\s*['\"]state-change['\"]/",
             $fileDecryptPanelContents,
             'FileDecryptPanel.vue must call emit("state-change", ...) to forward its internal fileDecryptState to the parent.'
+        );
+    }
+
+    public function test_send_new_link_button_is_disabled_while_decrypt_busy(): void
+    {
+        $contents = file_get_contents(resource_path('js/Pages/Secret/SecretForm.vue'));
+
+        $this->assertMatchesRegularExpression(
+            '/Send a new secret link/',
+            $contents,
+            'SecretForm.vue must contain the "Send a new secret link" button.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/isDecryptBusy\s*\?\s*null\s*:\s*route\([\'"]welcome[\'"]\)/',
+            $contents,
+            'SecretForm.vue "Send a new secret link" button must suppress its href while isDecryptBusy to prevent navigation during download/decrypt.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/:disabled="[^"]*isDecryptBusy[^"]*"[^>]*>\s*Send a new secret link/',
+            $contents,
+            'SecretForm.vue "Send a new secret link" button must be disabled while isDecryptBusy is true.'
         );
     }
 }

--- a/tests/Feature/Regressions/PIO75Test.php
+++ b/tests/Feature/Regressions/PIO75Test.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use Tests\TestCase;
+
+/**
+ * PIO-75: Three UX bugs on the secret encrypt/decrypt screens.
+ *
+ * Bug 1: A placeholder string was stored in form.message (v-modelled state)
+ * on the decrypt page, risking leakage into rendered bindings under certain
+ * combinations of hasMessage / decryptionSuccess / Inertia state.
+ *
+ * Bug 2: On the encrypt screen, the auto-generated password was revealed the
+ * instant encryption finished, while the ciphertext was still uploading. Inputs
+ * and buttons also stayed interactive during in-progress operations on both
+ * screens.
+ *
+ * Bug 3: The primary action button on the decrypt screen read "Unlock & Download"
+ * instead of the specified "Download and decrypt".
+ */
+class PIO75Test extends TestCase
+{
+    public function test_placeholder_message_is_not_injected_into_form_state_on_decrypt(): void
+    {
+        $contents = file_get_contents(resource_path('js/Pages/Secret/SecretForm.vue'));
+
+        $this->assertStringNotContainsString(
+            'placeholderMessage',
+            $contents,
+            'SecretForm.vue must not declare a placeholderMessage const — display hints must use the HTML placeholder attribute, not v-modelled form state.'
+        );
+
+        $this->assertStringNotContainsString(
+            "This isn't the actual message",
+            $contents,
+            'SecretForm.vue must not embed the placeholder string literal in form state — it risks leaking into rendered bindings on file-only and combined-secret decrypt pages.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/message:\s*[\'"]{2}/',
+            $contents,
+            'SecretForm.vue must initialise form.message to an empty string unconditionally, not to the placeholder literal.'
+        );
+    }
+
+    public function test_encrypt_flow_hides_password_and_disables_inputs_while_uploading(): void
+    {
+        $contents = file_get_contents(resource_path('js/Pages/Secret/SecretForm.vue'));
+
+        $this->assertStringContainsString(
+            'isEncryptBusy',
+            $contents,
+            'SecretForm.vue must declare an isEncryptBusy computed so busy-state is centralised.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            "/stage\s*==\s*['\"]generated['\"]\s*&&\s*!isEncryptBusy/",
+            $contents,
+            'SecretForm.vue password reveal (CodeBlock) must be gated on both stage==\'generated\' AND !isEncryptBusy so the password is not revealed while upload is still in flight.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/:disabled="[^"]*isEncryptBusy[^"]*"/',
+            $contents,
+            'SecretForm.vue must bind :disabled to isEncryptBusy on form controls during the encrypt flow.'
+        );
+
+        $this->assertStringContainsString(
+            'passwordInputDisabled',
+            $contents,
+            'SecretForm.vue must declare a passwordInputDisabled computed so the password TextInput binding is readable and greppable.'
+        );
+    }
+
+    public function test_decrypt_flow_disables_inputs_while_download_in_progress(): void
+    {
+        $secretFormContents = file_get_contents(resource_path('js/Pages/Secret/SecretForm.vue'));
+
+        $this->assertStringContainsString(
+            'isDecryptBusy',
+            $secretFormContents,
+            'SecretForm.vue must declare an isDecryptBusy computed to track decrypt/download in-progress state.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/@state-change/',
+            $secretFormContents,
+            'SecretForm.vue must listen for @state-change from FileDecryptPanel to track its busy state.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/:disabled="[^"]*isDecryptBusy[^"]*"/',
+            $secretFormContents,
+            'SecretForm.vue decrypt PrimaryButton must be disabled while isDecryptBusy is true.'
+        );
+
+        $this->assertStringContainsString(
+            'Download and decrypt',
+            $secretFormContents,
+            'SecretForm.vue decrypt button must be labelled "Download and decrypt" (not "Unlock & Download").'
+        );
+
+        $this->assertStringNotContainsString(
+            'Unlock & Download',
+            $secretFormContents,
+            'SecretForm.vue must not use the old "Unlock & Download" button label.'
+        );
+
+        $fileDecryptPanelContents = file_get_contents(resource_path('js/Components/FileDecryptPanel.vue'));
+
+        $this->assertMatchesRegularExpression(
+            "/defineEmits\\(\\s*\\[[^\\]]*['\"]state-change['\"][^\\]]*\\]\\s*\\)/",
+            $fileDecryptPanelContents,
+            'FileDecryptPanel.vue must declare a "state-change" emit so SecretForm can track its busy state.'
+        );
+
+        $this->assertMatchesRegularExpression(
+            "/emit\\(\\s*['\"]state-change['\"]/",
+            $fileDecryptPanelContents,
+            'FileDecryptPanel.vue must call emit("state-change", ...) to forward its internal fileDecryptState to the parent.'
+        );
+    }
+}

--- a/tools/flashview-cli/src/cli.js
+++ b/tools/flashview-cli/src/cli.js
@@ -50,6 +50,7 @@ function createProgressBody(buffer, onProgress) {
 const MIME_TYPES = {
     '.pdf': 'application/pdf',
     '.zip': 'application/zip',
+    '.gz': 'application/gzip',
     '.doc': 'application/msword',
     '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     '.xls': 'application/vnd.ms-excel',


### PR DESCRIPTION
## Summary

- Removes the placeholder message string from `form.message` reactive state — display hints now use the HTML `placeholder` attribute only, eliminating an entire class of potential leaks on file-only and combined-secret decrypt pages
- Adds centralised `isEncryptBusy` / `isDecryptBusy` computeds and gates the password reveal, all form inputs, and action buttons on them — password is now hidden until upload completes, and the full form is non-interactive during in-flight operations on both screens
- Renames the decrypt button from "Unlock & Download" to "Download and decrypt"
- Adds `disabled` prop to `TextAreaInput` (additive, default `false`, backward-compatible)
- `FileDecryptPanel` now emits `state-change` on every internal state transition so the parent can participate in the busy guard; `handleDecryptionFailure` defensively resets `fileDecryptState` before the destroyed-state swap

## Test plan

- [ ] File-only secret decrypt page: no placeholder text visible, button reads "Download and decrypt"
- [ ] File upload (encrypt screen): all inputs and the clear-file × disabled during encrypt/upload; password hidden until upload completes, then revealed in CodeBlock
- [ ] File decrypt (decrypt screen): password input and button disabled for the full duration of download + decrypt
- [ ] Combined secret (file + message) decrypt: busy state applies throughout; "Note from sender" only appears after successful decryption with real plaintext
- [ ] Text-only secret create/decrypt: unaffected — existing behaviour preserved
- [ ] Wrong password on file secret: destroyed-state screen renders cleanly with no stale busy flag or placeholder text
- [ ] `php artisan test --filter=PIO75Test` — all 3 pass
- [ ] `php artisan test --filter=PIO76Test` — all 8 pass (no regressions)

## Regression risks (from regression-detector)

Low overall. `SecretForm.vue` is a large shared form used by both encrypt and decrypt flows — manual testing across all three secret types (text-only, file-only, file+message) is recommended.