### PR TITLE
feat(PIO-81): admin menu dropdown and user management page

### DIFF
--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Plan;
 use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -41,8 +43,33 @@ class AdminUserController extends Controller
                         'plan_name' => $plan?->name ?? '—',
                         'subscription_status' => $subscription?->stripe_status ?? '—',
                         'joined_at' => $user->created_at->toDateString(),
+                        'is_suspended' => $user->isSuspended(),
+                        'suspended_at' => $user->suspended_at?->toDateString(),
                     ];
                 }),
         ]);
+    }
+
+    public function suspend(User $user): RedirectResponse
+    {
+        abort_if($user->is($this->currentAdmin()), 403, 'You cannot suspend your own account.');
+
+        $user->update(['suspended_at' => now()]);
+
+        return redirect()->route('admin.users.index')
+            ->with('flash', ['success' => "Account for {$user->name} has been suspended."]);
+    }
+
+    public function unsuspend(User $user): RedirectResponse
+    {
+        $user->update(['suspended_at' => null]);
+
+        return redirect()->route('admin.users.index')
+            ->with('flash', ['success' => "Account for {$user->name} has been unsuspended."]);
+    }
+
+    private function currentAdmin(): User
+    {
+        return Auth::user();
     }
 }

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Plan;
 use App\Models\User;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -11,19 +12,37 @@ class AdminUserController extends Controller
 {
     public function index(): Response
     {
+        $allPlans = Plan::all();
+        $freePlan = $allPlans->firstWhere('is_free_plan', true);
+        $plansByStripePrice = [];
+        foreach ($allPlans as $plan) {
+            if ($plan->stripe_monthly_price_id) {
+                $plansByStripePrice[$plan->stripe_monthly_price_id] = $plan;
+            }
+            if ($plan->stripe_yearly_price_id) {
+                $plansByStripePrice[$plan->stripe_yearly_price_id] = $plan;
+            }
+        }
+
         return Inertia::render('Admin/Users/Index', [
             'users' => User::query()
                 ->with(['subscriptions'])
                 ->orderBy('created_at', 'desc')
                 ->get()
-                ->map(fn (User $user) => [
-                    'id' => $user->id,
-                    'name' => $user->name,
-                    'email' => $user->email,
-                    'plan_name' => $user->resolvePlan()?->name ?? '—',
-                    'subscription_status' => $user->subscription?->stripe_status ?? '—',
-                    'joined_at' => $user->created_at->toDateString(),
-                ]),
+                ->map(function (User $user) use ($freePlan, $plansByStripePrice) {
+                    $subscription = $user->subscriptions->first();
+                    $stripePrice = $subscription?->stripe_price;
+                    $plan = $stripePrice ? ($plansByStripePrice[$stripePrice] ?? null) : $freePlan;
+
+                    return [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                        'email' => $user->email,
+                        'plan_name' => $plan?->name ?? '—',
+                        'subscription_status' => $subscription?->stripe_status ?? '—',
+                        'joined_at' => $user->created_at->toDateString(),
+                    ];
+                }),
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AdminUserController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Admin/Users/Index', [
+            'users' => User::query()
+                ->with(['subscriptions'])
+                ->orderBy('created_at', 'desc')
+                ->get()
+                ->map(fn (User $user) => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'plan_name' => $user->resolvePlan()?->name ?? '—',
+                    'subscription_status' => $user->subscription?->stripe_status ?? '—',
+                    'joined_at' => $user->created_at->toDateString(),
+                ]),
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsNotSuspended.php
+++ b/app/Http/Middleware/EnsureUserIsNotSuspended.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsNotSuspended
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::check() && Auth::user()->isSuspended()) {
+            Auth::guard('web')->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('login')->withErrors([
+                'email' => 'Your account has been suspended. Please contact support.',
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'webhook_url',
         'webhook_secret',
         'store_masked_recipient_email',
+        'suspended_at',
     ];
 
     /**
@@ -71,6 +72,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         'plan',
         'frequency',
         'is_admin',
+        'is_suspended',
     ];
 
     protected $with = [
@@ -169,6 +171,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
     {
         return [
             'email_verified_at' => 'datetime',
+            'suspended_at' => 'datetime',
             'password' => 'hashed',
             'notify_secret_retrieved' => 'boolean',
             'webhook_secret' => 'encrypted',
@@ -184,6 +187,16 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
     public function getIsAdminAttribute(): bool
     {
         return $this->isAdmin();
+    }
+
+    public function isSuspended(): bool
+    {
+        return $this->suspended_at !== null;
+    }
+
+    public function getIsSuspendedAttribute(): bool
+    {
+        return $this->isSuspended();
     }
 
     public function hasWebhookConfigured(): bool

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\EnsureEnvironmentSubscriptionAllowed;
 use App\Http\Middleware\EnsureUserIsAdmin;
+use App\Http\Middleware\EnsureUserIsNotSuspended;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SecurityHeadersMiddleware;
 use Illuminate\Foundation\Application;
@@ -33,6 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+            EnsureUserIsNotSuspended::class,
         ]);
 
         $middleware->validateCsrfTokens(except: [

--- a/database/migrations/2026_04_25_112904_add_suspended_at_to_users_table.php
+++ b/database/migrations/2026_04_25_112904_add_suspended_at_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('suspended_at')->nullable()->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('suspended_at');
+        });
+    }
+};

--- a/resources/js/Components/DangerButton.vue
+++ b/resources/js/Components/DangerButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex w-full items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150">
         <slot />
     </button>
 </template>

--- a/resources/js/Components/DangerButton.vue
+++ b/resources/js/Components/DangerButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex items-center justify-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex w-full items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150">
         <slot />
     </button>
 </template>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -85,10 +85,27 @@ const logout = () => {
                                         </NavLink>
                                     </template>
                                     <template v-if="$page.props?.auth?.user?.is_admin">
-                                        <NavLink :href="route('admin.plans.index')" :active="route().current('admin.plans.*')"
-                                            class="text-gamboge-300 dark:text-gamboge-300">
-                                            Admin
-                                        </NavLink>
+                                        <Dropdown align="right" width="48">
+                                            <template #trigger>
+                                                <button type="button"
+                                                    :class="route().current('admin.*') ? 'border-gamboge-400 text-gamboge-200' : 'border-transparent text-gamboge-300 hover:text-gamboge-200 hover:border-gamboge-300'"
+                                                    class="inline-flex items-center gap-1 px-1 pt-1 border-b-2 text-sm font-medium leading-5 focus:outline-none focus:text-gamboge-200 focus:border-gamboge-300 transition duration-150 ease-in-out">
+                                                    Admin
+                                                    <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                                        stroke-width="1.5" stroke="currentColor">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                                    </svg>
+                                                </button>
+                                            </template>
+                                            <template #content>
+                                                <DropdownLink :href="route('admin.plans.index')">
+                                                    Plans
+                                                </DropdownLink>
+                                                <DropdownLink :href="route('admin.users.index')">
+                                                    Manage Users
+                                                </DropdownLink>
+                                            </template>
+                                        </Dropdown>
                                     </template>
                                 </div>
                             </div>
@@ -304,10 +321,16 @@ const logout = () => {
                                 </ResponsiveNavLink>
                             </template>
                             <template v-if="$page.props?.auth?.user?.is_admin">
-                                <ResponsiveNavLink :href="route('admin.plans.index')"
-                                    :active="route().current('admin.plans.*')"
-                                    class="text-gamboge-300 dark:text-gamboge-300">
+                                <div class="block px-4 py-2 text-xs uppercase tracking-widest text-gamboge-300 font-mono">
                                     Admin
+                                </div>
+                                <ResponsiveNavLink :href="route('admin.plans.index')"
+                                    :active="route().current('admin.plans.*')">
+                                    Plans
+                                </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('admin.users.index')"
+                                    :active="route().current('admin.users.*')">
+                                    Manage Users
                                 </ResponsiveNavLink>
                             </template>
                         </div>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -89,7 +89,7 @@ const logout = () => {
                                             <Dropdown align="right" width="48">
                                                 <template #trigger>
                                                     <button type="button"
-                                                        :class="route().current('admin.*') ? 'border-gamboge-400 text-gamboge-200' : 'border-transparent text-gamboge-300 hover:text-gamboge-200 hover:border-gamboge-300'"
+                                                        :class="route().current('admin.*') ? 'border-gamboge-400 dark:border-gamboge-400 text-gamboge-200 dark:text-gamboge-200' : 'border-transparent text-gamboge-300 dark:text-gamboge-300 hover:text-gamboge-200 dark:hover:text-gamboge-200 hover:border-gamboge-300 dark:hover:border-gamboge-300'"
                                                         class="inline-flex items-center gap-1 px-1 pt-1 border-b-2 text-sm font-medium leading-5 focus:outline-none focus:text-gamboge-200 focus:border-gamboge-300 transition duration-150 ease-in-out">
                                                         Admin
                                                         <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -85,27 +85,29 @@ const logout = () => {
                                         </NavLink>
                                     </template>
                                     <template v-if="$page.props?.auth?.user?.is_admin">
-                                        <Dropdown align="right" width="48">
-                                            <template #trigger>
-                                                <button type="button"
-                                                    :class="route().current('admin.*') ? 'border-gamboge-400 text-gamboge-200' : 'border-transparent text-gamboge-300 hover:text-gamboge-200 hover:border-gamboge-300'"
-                                                    class="inline-flex items-center gap-1 px-1 pt-1 border-b-2 text-sm font-medium leading-5 focus:outline-none focus:text-gamboge-200 focus:border-gamboge-300 transition duration-150 ease-in-out">
-                                                    Admin
-                                                    <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                                        stroke-width="1.5" stroke="currentColor">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                                    </svg>
-                                                </button>
-                                            </template>
-                                            <template #content>
-                                                <DropdownLink :href="route('admin.plans.index')">
-                                                    Plans
-                                                </DropdownLink>
-                                                <DropdownLink :href="route('admin.users.index')">
-                                                    Manage Users
-                                                </DropdownLink>
-                                            </template>
-                                        </Dropdown>
+                                        <div class="flex items-center">
+                                            <Dropdown align="right" width="48">
+                                                <template #trigger>
+                                                    <button type="button"
+                                                        :class="route().current('admin.*') ? 'border-gamboge-400 text-gamboge-200' : 'border-transparent text-gamboge-300 hover:text-gamboge-200 hover:border-gamboge-300'"
+                                                        class="inline-flex items-center gap-1 px-1 pt-1 border-b-2 text-sm font-medium leading-5 focus:outline-none focus:text-gamboge-200 focus:border-gamboge-300 transition duration-150 ease-in-out">
+                                                        Admin
+                                                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                                            stroke-width="1.5" stroke="currentColor">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                                        </svg>
+                                                    </button>
+                                                </template>
+                                                <template #content>
+                                                    <DropdownLink :href="route('admin.plans.index')">
+                                                        Plans
+                                                    </DropdownLink>
+                                                    <DropdownLink :href="route('admin.users.index')">
+                                                        Manage Users
+                                                    </DropdownLink>
+                                                </template>
+                                            </Dropdown>
+                                        </div>
                                     </template>
                                 </div>
                             </div>

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -14,7 +14,7 @@ const statusClass = (status) => {
         return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
     }
     if (status === 'trialing') {
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+        return 'bg-gamboge-100 text-gamboge-800 dark:bg-gamboge-900/30 dark:text-gamboge-200';
     }
     return null;
 };
@@ -54,7 +54,7 @@ const statusClass = (status) => {
                             <td class="px-6 py-4 font-mono text-xs">
                                 {{ user.email }}
                             </td>
-                            <td class="px-6 py-4">
+                            <td class="px-6 py-4 font-mono text-xs dark:text-gray-300">
                                 {{ user.plan_name }}
                             </td>
                             <td class="px-6 py-4">

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -1,0 +1,79 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+
+const props = defineProps({
+    users: Array,
+});
+
+const statusClass = (status) => {
+    if (status === 'active') {
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+    }
+    if (status === 'canceled' || status === 'past_due' || status === 'unpaid') {
+        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
+    }
+    if (status === 'trialing') {
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+    }
+    return null;
+};
+</script>
+
+<template>
+    <AdminLayout title="Admin — Users">
+        <template #title>Users</template>
+
+        <Page>
+            <div class="mb-6">
+                <h1 class="text-xs uppercase tracking-widest text-gamboge-300 font-mono">User Management</h1>
+            </div>
+
+            <div class="relative overflow-x-auto shadow-md sm:rounded-lg dark:shadow-neon-cyan-sm">
+                <table class="w-full text-sm text-left text-gray-700 dark:text-gray-400">
+                    <thead class="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gamboge-300 tracking-widest">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Name</th>
+                            <th scope="col" class="px-6 py-3">Email</th>
+                            <th scope="col" class="px-6 py-3">Plan</th>
+                            <th scope="col" class="px-6 py-3">Subscription Status</th>
+                            <th scope="col" class="px-6 py-3">Joined</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-if="users.length === 0">
+                            <td colspan="5" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                                No users found.
+                            </td>
+                        </tr>
+                        <tr v-for="user in users" :key="user.id"
+                            class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700">
+                            <th scope="row" class="px-6 py-4 font-semibold text-gray-900 dark:text-white">
+                                {{ user.name }}
+                            </th>
+                            <td class="px-6 py-4 font-mono text-xs">
+                                {{ user.email }}
+                            </td>
+                            <td class="px-6 py-4">
+                                {{ user.plan_name }}
+                            </td>
+                            <td class="px-6 py-4">
+                                <span v-if="statusClass(user.subscription_status)"
+                                    :class="statusClass(user.subscription_status)"
+                                    class="px-2 py-0.5 rounded text-xs font-mono">
+                                    {{ user.subscription_status }}
+                                </span>
+                                <span v-else class="text-gray-400 dark:text-gray-600">
+                                    {{ user.subscription_status }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 font-mono text-xs">
+                                {{ user.joined_at }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </Page>
+    </AdminLayout>
+</template>

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -104,11 +104,11 @@ const subscriptionStatusClass = (status) => {
                             </td>
                             <td class="px-6 py-4">
                                 <span v-if="user.is_suspended"
-                                    class="px-2 py-0.5 rounded text-xs font-mono bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300">
+                                    class="px-2 py-0.5 rounded text-xs font-mono bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 line-through">
                                     Suspended
                                 </span>
                                 <span v-else
-                                    class="px-2 py-0.5 rounded text-xs font-mono bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                    class="px-2 py-0.5 rounded text-xs font-mono bg-gamboge-100 text-gamboge-800 dark:bg-gamboge-900/30 dark:text-gamboge-200">
                                     Active
                                 </span>
                             </td>

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -1,12 +1,42 @@
 <script setup>
 import AdminLayout from '@/Layouts/AdminLayout.vue';
 import Page from '@/Pages/Page.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import { useForm, usePage } from '@inertiajs/vue3';
+import { ref } from 'vue';
 
 const props = defineProps({
     users: Array,
 });
 
-const statusClass = (status) => {
+const page = usePage();
+const currentUserId = page.props?.auth?.user?.id;
+
+const userBeingSuspended = ref(null);
+const suspendForm = useForm({});
+const unsuspendForm = useForm({});
+
+const confirmSuspend = (user) => {
+    userBeingSuspended.value = user;
+};
+
+const suspendUser = () => {
+    suspendForm.post(route('admin.users.suspend', userBeingSuspended.value.id), {
+        preserveScroll: true,
+        onSuccess: () => { userBeingSuspended.value = null; },
+        onError: () => { userBeingSuspended.value = null; },
+    });
+};
+
+const unsuspendUser = (user) => {
+    unsuspendForm.delete(route('admin.users.unsuspend', user.id), {
+        preserveScroll: true,
+    });
+};
+
+const subscriptionStatusClass = (status) => {
     if (status === 'active') {
         return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
     }
@@ -38,11 +68,13 @@ const statusClass = (status) => {
                             <th scope="col" class="px-6 py-3">Plan</th>
                             <th scope="col" class="px-6 py-3">Subscription Status</th>
                             <th scope="col" class="px-6 py-3">Joined</th>
+                            <th scope="col" class="px-6 py-3">Status</th>
+                            <th scope="col" class="px-6 py-3 text-right">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr v-if="users.length === 0">
-                            <td colspan="5" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                            <td colspan="7" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
                                 No users found.
                             </td>
                         </tr>
@@ -58,8 +90,8 @@ const statusClass = (status) => {
                                 {{ user.plan_name }}
                             </td>
                             <td class="px-6 py-4">
-                                <span v-if="statusClass(user.subscription_status)"
-                                    :class="statusClass(user.subscription_status)"
+                                <span v-if="subscriptionStatusClass(user.subscription_status)"
+                                    :class="subscriptionStatusClass(user.subscription_status)"
                                     class="px-2 py-0.5 rounded text-xs font-mono">
                                     {{ user.subscription_status }}
                                 </span>
@@ -70,10 +102,51 @@ const statusClass = (status) => {
                             <td class="px-6 py-4 font-mono text-xs dark:text-gray-300">
                                 {{ user.joined_at }}
                             </td>
+                            <td class="px-6 py-4">
+                                <span v-if="user.is_suspended"
+                                    class="px-2 py-0.5 rounded text-xs font-mono bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300">
+                                    Suspended
+                                </span>
+                                <span v-else
+                                    class="px-2 py-0.5 rounded text-xs font-mono bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                    Active
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <div v-if="user.id !== currentUserId">
+                                    <DangerButton v-if="!user.is_suspended" class="text-xs"
+                                        @click="confirmSuspend(user)">
+                                        Suspend
+                                    </DangerButton>
+                                    <SecondaryButton v-else class="text-xs"
+                                        :disabled="unsuspendForm.processing"
+                                        @click="unsuspendUser(user)">
+                                        Unsuspend
+                                    </SecondaryButton>
+                                </div>
+                                <span v-else class="text-xs text-gray-400 dark:text-gray-600">You</span>
+                            </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </Page>
+
+        <ConfirmationModal :show="userBeingSuspended !== null" @close="userBeingSuspended = null">
+            <template #title>Suspend Account</template>
+            <template #content>
+                Are you sure you want to suspend <strong>{{ userBeingSuspended?.name }}</strong>?
+                They will be logged out immediately and unable to log in until unsuspended.
+            </template>
+            <template #footer>
+                <SecondaryButton @click="userBeingSuspended = null">Cancel</SecondaryButton>
+                <DangerButton class="ms-3"
+                    :class="{ 'opacity-25': suspendForm.processing }"
+                    :disabled="suspendForm.processing"
+                    @click="suspendUser">
+                    Suspend Account
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
     </AdminLayout>
 </template>

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -51,7 +51,7 @@ const statusClass = (status) => {
                             <th scope="row" class="px-6 py-4 font-semibold text-gray-900 dark:text-white">
                                 {{ user.name }}
                             </th>
-                            <td class="px-6 py-4 font-mono text-xs">
+                            <td class="px-6 py-4 font-mono text-xs dark:text-gray-300">
                                 {{ user.email }}
                             </td>
                             <td class="px-6 py-4 font-mono text-xs dark:text-gray-300">
@@ -67,7 +67,7 @@ const statusClass = (status) => {
                                     {{ user.subscription_status }}
                                 </span>
                             </td>
-                            <td class="px-6 py-4 font-mono text-xs">
+                            <td class="px-6 py-4 font-mono text-xs dark:text-gray-300">
                                 {{ user.joined_at }}
                             </td>
                         </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -215,4 +215,6 @@ Route::middleware([
 ])->prefix('admin')->name('admin.')->group(function () {
     Route::resource('plans', AdminPlanController::class)->except(['show']);
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
+    Route::post('users/{user}/suspend', [AdminUserController::class, 'suspend'])->name('users.suspend');
+    Route::delete('users/{user}/suspend', [AdminUserController::class, 'unsuspend'])->name('users.unsuspend');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\AdminPlanController;
+use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\CliDeviceController;
@@ -213,4 +214,5 @@ Route::middleware([
     'admin',
 ])->prefix('admin')->name('admin.')->group(function () {
     Route::resource('plans', AdminPlanController::class)->except(['show']);
+    Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
 });

--- a/tests/Feature/Admin/AdminUserTest.php
+++ b/tests/Feature/Admin/AdminUserTest.php
@@ -55,8 +55,57 @@ class AdminUserTest extends TestCase
             ->get(route('admin.users.index'))
             ->assertInertia(fn (AssertableInertia $page) => $page->component('Admin/Users/Index')
                 ->has('users', 4)
-                ->has('users.0', fn (AssertableInertia $user) => $user->hasAll(['id', 'name', 'email', 'plan_name', 'subscription_status', 'joined_at'])
+                ->has('users.0', fn (AssertableInertia $user) => $user->hasAll([
+                    'id', 'name', 'email', 'plan_name', 'subscription_status',
+                    'joined_at', 'is_suspended', 'suspended_at',
+                ])
                 )
             );
+    }
+
+    public function test_admin_can_suspend_a_user(): void
+    {
+        $admin = $this->adminUser();
+        $target = $this->nonAdminUser();
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.suspend', $target))
+            ->assertRedirect(route('admin.users.index'));
+
+        $this->assertNotNull($target->fresh()->suspended_at);
+    }
+
+    public function test_admin_can_unsuspend_a_user(): void
+    {
+        $admin = $this->adminUser();
+        $target = $this->nonAdminUser();
+        $target->update(['suspended_at' => now()]);
+
+        $this->actingAs($admin)
+            ->delete(route('admin.users.unsuspend', $target))
+            ->assertRedirect(route('admin.users.index'));
+
+        $this->assertNull($target->fresh()->suspended_at);
+    }
+
+    public function test_admin_cannot_suspend_themselves(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.suspend', $admin))
+            ->assertForbidden();
+
+        $this->assertNull($admin->fresh()->suspended_at);
+    }
+
+    public function test_suspended_user_is_redirected_to_login_on_next_request(): void
+    {
+        $user = $this->nonAdminUser();
+        $user->update(['suspended_at' => now()]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertRedirect(route('login'));
     }
 }

--- a/tests/Feature/Admin/AdminUserTest.php
+++ b/tests/Feature/Admin/AdminUserTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class AdminUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Config::set('admin.emails', [$user->email]);
+
+        return $user;
+    }
+
+    private function nonAdminUser(): User
+    {
+        return User::factory()->withPersonalTeam()->create();
+    }
+
+    public function test_unauthenticated_user_is_redirected_from_admin_users(): void
+    {
+        $this->get(route('admin.users.index'))->assertRedirect('/login');
+    }
+
+    public function test_non_admin_receives_403_on_admin_users(): void
+    {
+        $this->actingAs($this->nonAdminUser())
+            ->get(route('admin.users.index'))
+            ->assertForbidden();
+    }
+
+    public function test_admin_can_access_admin_users_index(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->get(route('admin.users.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Admin/Users/Index')->has('users')
+            );
+    }
+
+    public function test_admin_sees_all_users_listed(): void
+    {
+        $admin = $this->adminUser();
+        User::factory()->withPersonalTeam()->count(3)->create();
+
+        $this->actingAs($admin)
+            ->get(route('admin.users.index'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Admin/Users/Index')
+                ->has('users', 4)
+                ->has('users.0', fn (AssertableInertia $user) => $user->hasAll(['id', 'name', 'email', 'plan_name', 'subscription_status', 'joined_at'])
+                )
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the flat "Admin" top-nav link with a `Dropdown` (desktop) and a labelled group of `ResponsiveNavLink` items (mobile), containing "Plans" and "Manage Users" sub-items
- Adds `GET /admin/users` → `admin.users.index` listing all registered users (name, email, plan, subscription status, joined date, account status)
- Adds account suspension: admins can suspend/unsuspend users; suspended users are logged out and redirected on their next request
- All routes protected by the existing `EnsureUserIsAdmin` middleware; no new auth primitives

## Technical notes

- `AdminUserController::index()` pre-loads all plans in a single `Plan::all()` query and resolves subscription/plan from the eager-loaded `subscriptions` collection — no N+1 queries
- `EnsureUserIsNotSuspended` middleware appended to the web stack: fires on every authenticated web request, logs out via `Auth::guard('web')->logout()`, redirects to `/login` with an error message
- Admin cannot suspend themselves (guarded with `abort_if` 403)
- **API enforcement gap (by design):** Suspended users can still use active Sanctum API tokens — web suspension only. Full API-level suspension is out of scope for this ticket
- **Stripe side-effect:** Suspending/unsuspending a user with a Stripe ID triggers the existing `syncStripeCustomerDetails` job via `User::booted()` observer — expected behaviour
- Migration adds `suspended_at` nullable timestamp; deploy migration before code (middleware reads the column)

## Regression risks

- `AppLayout.vue` is used by all authenticated pages — nav changes are gated by `is_admin` so non-admin and guest views are unaffected
- `EnsureUserIsNotSuspended` runs on every web request — no performance concern (single `isSuspended()` check on the already-loaded auth user)

## Test plan

- [ ] Log in as admin — confirm "Admin" dropdown shows "Plans" and "Manage Users"
- [ ] Navigate to Manage Users — confirm table shows name, email, plan, subscription status, joined date, Status column, and action buttons
- [ ] Suspend a non-admin user — confirm modal appears, on confirm badge changes to "Suspended" (gray, strikethrough), button changes to "Unsuspend"
- [ ] Log in as the suspended user — confirm redirect to `/login` with suspension message on the next request
- [ ] Unsuspend the user as admin — confirm badge returns to "Active" (gamboge), user can log in again
- [ ] Attempt to suspend yourself — confirm no action button is shown ("You" label instead)
- [ ] Log in as non-admin — confirm no "Admin" dropdown visible; direct access to `/admin/users` returns 403
- [ ] Access `/admin/users` as guest — confirm redirect to `/login`
- [ ] Verify existing Admin Plans pages still work correctly