### PR TITLE
feat(PIO-82): confirmation dialogs for plan switching and cancellation

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -24,6 +24,8 @@ class PlanController extends Controller
     public function unsubscribe(Request $request)
     {
         $request->user()->subscription('default')->cancel();
+
+        return redirect()->route('plans.index');
     }
 
     public function resume(Request $request)

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StorePlanRequest;
+use App\Http\Requests\UnsubscribeRequest;
 use App\Http\Requests\UpdatePlanRequest;
 use App\Http\Resources\PlanResource;
 use App\Models\Plan;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -21,7 +23,7 @@ class PlanController extends Controller
         return Inertia::render('Plan/Index', compact('plans'));
     }
 
-    public function unsubscribe(Request $request)
+    public function unsubscribe(UnsubscribeRequest $request): RedirectResponse
     {
         $request->user()->subscription('default')->cancel();
 

--- a/app/Http/Requests/UnsubscribeRequest.php
+++ b/app/Http/Requests/UnsubscribeRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UnsubscribeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/resources/js/Pages/Plan/Index.vue
+++ b/resources/js/Pages/Plan/Index.vue
@@ -18,10 +18,11 @@ const props = defineProps({
     plans: Array,
 })
 
-const planFrequency = ref(usePage().props.auth?.user?.frequency || 'monthly');
+const page = usePage();
+const planFrequency = ref(page.props.auth?.user?.frequency || 'monthly');
 
 const userIsSubscribedTo = (plan) => {
-    let user = usePage().props.auth?.user;
+    let user = page.props.auth?.user;
 
     if(user?.plan?.id == plan.id) // plan matches
     {
@@ -36,11 +37,8 @@ const userIsSubscribedTo = (plan) => {
 
 const isFreePlan = (plan) => plan.price_per_month == 0
 
-const userHasActiveSubscription = computed(() => {
-    return usePage().props.auth?.user?.subscription != null;
-});
+const userHasActiveSubscription = computed(() => page.props.auth?.user?.subscription != null);
 
-// Cancellation modal
 const showCancellationModal = ref(false);
 const cancelForm = useForm({});
 
@@ -54,7 +52,6 @@ const submitCancellation = () => {
     });
 };
 
-// Plan switch modal
 const planBeingSwitchedTo = ref(null);
 
 const confirmPlanSwitch = (plan) => {
@@ -144,7 +141,7 @@ const proceedWithSwitch = () => {
                                 </button>
                             </span>
                         </span>
-                        <span v-else> <!-- User is not subscribed -->
+                        <span v-else>
                             <PrimaryButton
                                 v-if="!$page.props.auth.user"
                                 type="button"
@@ -154,16 +151,14 @@ const proceedWithSwitch = () => {
                                 Login to Subscribe
                             </PrimaryButton>
                             <template v-else>
-                                <!-- Subscribed user switching plans → show confirmation modal -->
-                                <button
+                                <PrimaryButton
                                     v-if="userHasActiveSubscription"
                                     type="button"
+                                    class="w-full justify-center"
                                     @click="confirmPlanSwitch(plan)"
-                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
                                 >
                                     Choose This Plan
-                                </button>
-                                <!-- New subscriber → go directly to Stripe checkout -->
+                                </PrimaryButton>
                                 <a
                                     v-else
                                     :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"

--- a/resources/js/Pages/Plan/Index.vue
+++ b/resources/js/Pages/Plan/Index.vue
@@ -3,8 +3,12 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import Page from '../Page.vue';
 import Faq from '../Partials/Faq.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
-import { Head, Link, useForm, usePage } from '@inertiajs/vue3';
-import { reactive, ref } from 'vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import DialogModal from '@/Components/DialogModal.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import { Head, Link, useForm, usePage, router } from '@inertiajs/vue3';
+import { reactive, ref, computed } from 'vue';
 import { DateTime } from 'luxon';
 import ToggleButton from '@/Components/ToggleButton.vue';
 import Feature from './Partials/Feature.vue';
@@ -32,6 +36,38 @@ const userIsSubscribedTo = (plan) => {
 
 const isFreePlan = (plan) => plan.price_per_month == 0
 
+const userHasActiveSubscription = computed(() => {
+    return usePage().props.auth?.user?.subscription != null;
+});
+
+// Cancellation modal
+const showCancellationModal = ref(false);
+const cancelForm = useForm({});
+
+const confirmCancellation = () => {
+    showCancellationModal.value = true;
+};
+
+const submitCancellation = () => {
+    cancelForm.post(route('plans.unsubscribe'), {
+        onSuccess: () => { showCancellationModal.value = false; },
+    });
+};
+
+// Plan switch modal
+const planBeingSwitchedTo = ref(null);
+
+const confirmPlanSwitch = (plan) => {
+    planBeingSwitchedTo.value = plan;
+};
+
+const proceedWithSwitch = () => {
+    router.visit(route('plans.subscribe', {
+        plan: planBeingSwitchedTo.value.id,
+        period: planFrequency.value,
+    }));
+};
+
 </script>
 <template>
     <AppLayout title="Pricing">
@@ -51,8 +87,8 @@ const isFreePlan = (plan) => plan.price_per_month == 0
                         <span v-if="userIsSubscribedTo(plan) && !$page.props?.auth?.user?.subscription?.ends_at" class="mb-4 font-mono text-xs uppercase tracking-widest text-gamboge-300 border border-gamboge-300/40 px-2 py-0.5 rounded self-start">
                             Current Plan
                         </span>
-                        <div 
-                            class="mb-4 text-xl font-medium text-xs text-red-500 dark:text-red-400" 
+                        <div
+                            class="mb-4 text-xl font-medium text-xs text-red-500 dark:text-red-400"
                             v-if="userIsSubscribedTo(plan) && $page.props?.auth?.user?.subscription?.ends_at"
                         >
                             Expires on: {{ DateTime.fromISO($page.props?.auth?.user?.subscription?.ends_at).toLocaleString(DateTime.DATEMED) }}
@@ -98,14 +134,14 @@ const isFreePlan = (plan) => plan.price_per_month == 0
                                 >
                                     Resume Plan
                                 </Link>
-                                <Link
+                                <button
                                     v-if="!$page.props.auth.user.subscription.ends_at"
-                                    method="post"
-                                    :href="route('plans.unsubscribe')"
+                                    type="button"
+                                    @click="confirmCancellation"
                                     class="inline-flex w-full items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
                                 >
                                     Cancel Plan
-                                </Link>
+                                </button>
                             </span>
                         </span>
                         <span v-else> <!-- User is not subscribed -->
@@ -117,17 +153,66 @@ const isFreePlan = (plan) => plan.price_per_month == 0
                             >
                                 Login to Subscribe
                             </PrimaryButton>
-                            <a
-                                v-else
-                                :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
-                                class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
-                            >
-                                Choose This Plan
-                            </a>
+                            <template v-else>
+                                <!-- Subscribed user switching plans → show confirmation modal -->
+                                <button
+                                    v-if="userHasActiveSubscription"
+                                    type="button"
+                                    @click="confirmPlanSwitch(plan)"
+                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                >
+                                    Choose This Plan
+                                </button>
+                                <!-- New subscriber → go directly to Stripe checkout -->
+                                <a
+                                    v-else
+                                    :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
+                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                >
+                                    Choose This Plan
+                                </a>
+                            </template>
                         </span>
                     </span>
                 </div>
             </div>
+
+            <ConfirmationModal :show="showCancellationModal" @close="showCancellationModal = false">
+                <template #title>Cancel Your Plan</template>
+                <template #content>
+                    Are you sure you want to cancel your plan? You will retain access to paid features
+                    until the end of your current billing period, after which your account will revert
+                    to the free plan.
+                </template>
+                <template #footer>
+                    <SecondaryButton @click="showCancellationModal = false">Keep Plan</SecondaryButton>
+                    <DangerButton
+                        class="ms-3"
+                        :class="{ 'opacity-25': cancelForm.processing }"
+                        :disabled="cancelForm.processing"
+                        @click="submitCancellation"
+                    >
+                        Yes, Cancel Plan
+                    </DangerButton>
+                </template>
+            </ConfirmationModal>
+
+            <DialogModal :show="planBeingSwitchedTo !== null" @close="planBeingSwitchedTo = null">
+                <template #title>Switch Plan</template>
+                <template #content>
+                    You are currently on
+                    <strong>{{ $page.props.auth.user?.plan?.name }}</strong>.
+                    Switching to
+                    <strong>{{ planBeingSwitchedTo?.name }}</strong>
+                    will take effect immediately. Any difference in cost will be pro-rated and applied to your next invoice.
+                </template>
+                <template #footer>
+                    <SecondaryButton @click="planBeingSwitchedTo = null">Keep Current Plan</SecondaryButton>
+                    <PrimaryButton class="ms-3" @click="proceedWithSwitch">
+                        Switch Plan
+                    </PrimaryButton>
+                </template>
+            </DialogModal>
         </Page>
     </AppLayout>
 </template>

--- a/resources/js/Pages/Plan/Index.vue
+++ b/resources/js/Pages/Plan/Index.vue
@@ -7,8 +7,8 @@ import ConfirmationModal from '@/Components/ConfirmationModal.vue';
 import DialogModal from '@/Components/DialogModal.vue';
 import DangerButton from '@/Components/DangerButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
-import { Head, Link, useForm, usePage, router } from '@inertiajs/vue3';
-import { reactive, ref, computed } from 'vue';
+import { Link, useForm, usePage, router } from '@inertiajs/vue3';
+import { ref, computed } from 'vue';
 import { DateTime } from 'luxon';
 import ToggleButton from '@/Components/ToggleButton.vue';
 import Feature from './Partials/Feature.vue';
@@ -159,13 +159,13 @@ const proceedWithSwitch = () => {
                                 >
                                     Choose This Plan
                                 </PrimaryButton>
-                                <a
+                                <PrimaryButton
                                     v-else
                                     :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
-                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                    class="w-full justify-center"
                                 >
                                     Choose This Plan
-                                </a>
+                                </PrimaryButton>
                             </template>
                         </span>
                     </span>

--- a/resources/js/Pages/Plan/Index.vue
+++ b/resources/js/Pages/Plan/Index.vue
@@ -159,13 +159,13 @@ const proceedWithSwitch = () => {
                                 >
                                     Choose This Plan
                                 </PrimaryButton>
-                                <PrimaryButton
+                                <a
                                     v-else
                                     :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
-                                    class="w-full justify-center"
+                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
                                 >
                                     Choose This Plan
-                                </PrimaryButton>
+                                </a>
                             </template>
                         </span>
                     </span>

--- a/tests/Feature/PlanPageTest.php
+++ b/tests/Feature/PlanPageTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class PlanPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_can_view_plans_page(): void
+    {
+        Plan::factory()->free()->create();
+
+        $this->get(route('plans.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Plan/Index'));
+    }
+
+    public function test_authenticated_user_without_subscription_can_view_plans_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Plan::factory()->free()->create();
+
+        $this->actingAs($user)
+            ->get(route('plans.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Plan/Index'));
+    }
+
+    public function test_cancellation_route_requires_authentication(): void
+    {
+        $this->post(route('plans.unsubscribe'))
+            ->assertRedirectToRoute('login');
+    }
+}

--- a/tests/Feature/PlanPageTest.php
+++ b/tests/Feature/PlanPageTest.php
@@ -6,6 +6,8 @@ use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
+use Mockery;
+use Stripe\StripeClient;
 use Tests\TestCase;
 
 class PlanPageTest extends TestCase
@@ -32,9 +34,64 @@ class PlanPageTest extends TestCase
             ->assertInertia(fn (AssertableInertia $page) => $page->component('Plan/Index'));
     }
 
+    public function test_authenticated_user_with_subscription_can_view_plans_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->create(['price_per_month' => 10]);
+        Plan::factory()->free()->create();
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_view',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('plans.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Plan/Index'));
+    }
+
     public function test_cancellation_route_requires_authentication(): void
     {
         $this->post(route('plans.unsubscribe'))
             ->assertRedirectToRoute('login');
+    }
+
+    public function test_subscribed_user_can_cancel_and_is_redirected_to_plans(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->create(['price_per_month' => 10]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_cancel',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $fakeStripeSubscription = (object) [
+            'id' => 'sub_test_cancel',
+            'status' => 'active',
+            'cancel_at_period_end' => true,
+            'current_period_end' => now()->addDays(30)->timestamp,
+        ];
+
+        $mockSubscriptionsService = Mockery::mock();
+        $mockSubscriptionsService->shouldReceive('update')->andReturn($fakeStripeSubscription);
+
+        $mockStripeClient = new \stdClass;
+        $mockStripeClient->subscriptions = $mockSubscriptionsService;
+
+        // bind() is used (not instance()) because Cashier passes constructor params to app(),
+        // which causes instance() bindings to be bypassed in the container.
+        $this->app->bind(StripeClient::class, fn () => $mockStripeClient);
+
+        $this->actingAs($user)
+            ->post(route('plans.unsubscribe'))
+            ->assertRedirectToRoute('plans.index');
     }
 }


### PR DESCRIPTION
## Summary

- Replace the direct "Cancel Plan" `<Link method="post">` with a button that opens a `ConfirmationModal` before submitting, showing a billing-period warning and disabling the button during submission to prevent double-clicks
- Replace the direct "Choose This Plan" link with a `DialogModal` for users who already have an active subscription, showing current → target plan names with a pro-ration note; new subscribers continue to reach Stripe checkout directly
- Fix `PlanController::unsubscribe()` to return `redirect()->route('plans.index')` (previously returned `null`/204 which left Inertia's page state stale after cancellation)
- Add `UnsubscribeRequest` Form Request and explicit `RedirectResponse` return type to `unsubscribe()`

## Regression risks (from regression-detector)

- `PlanController::resume()` still returns `null` — the "Resume Plan" `<Link>` will not trigger an Inertia page refresh after resuming. This pre-existed before this PR and is noted as a follow-on item.

## Test plan

- [ ] Guest visits `/plans` — page renders with "Sign Up" on free plan, no Cancel/Choose visible
- [ ] Logged-in user with no subscription visits `/plans` — "Choose This Plan" goes directly to Stripe checkout (no modal)
- [ ] Logged-in subscribed user clicks "Cancel Plan" — `ConfirmationModal` appears with billing-period warning
- [ ] In cancellation modal, click "Keep Plan" or backdrop — modal closes, nothing changes
- [ ] In cancellation modal, click "Yes, Cancel Plan" — submits, button disables during request, page refreshes to show grace-period state
- [ ] Logged-in subscribed user clicks "Choose This Plan" on a different plan — `DialogModal` appears showing current plan name → target plan name with proration note
- [ ] In switch modal, click "Keep Current Plan" — modal closes, nothing changes
- [ ] In switch modal, click "Switch Plan" — navigates to `plans.subscribe` route and follows Stripe/swap flow
- [ ] User in grace period (subscription has `ends_at`) — sees "Resume Plan" only, no "Cancel Plan" or "Choose This Plan"
- [ ] `POST /plans/cancel` without authentication → redirects to login