### PR TITLE
feat(PIO-85): add optional start/end date to plans for time-limited availability

### DIFF
--- a/app/Http/Controllers/Admin/AdminPlanController.php
+++ b/app/Http/Controllers/Admin/AdminPlanController.php
@@ -69,6 +69,8 @@ class AdminPlanController extends Controller
                 'stripe_yearly_price_id' => $stripeIds['yearly_price_id'],
                 'is_free_plan' => $request->boolean('is_free_plan'),
                 'features' => $request->features,
+                'start_date' => $request->start_date ?: null,
+                'end_date' => $request->end_date ?: null,
             ]);
         });
 
@@ -113,6 +115,8 @@ class AdminPlanController extends Controller
                     'stripe_yearly_price_id' => $stripeIds['yearly_price_id'],
                     'is_free_plan' => $request->boolean('is_free_plan'),
                     'features' => $request->features,
+                    'start_date' => $request->start_date ?: null,
+                    'end_date' => $request->end_date ?: null,
                 ]);
             });
 
@@ -135,6 +139,8 @@ class AdminPlanController extends Controller
                     'stripe_yearly_price_id' => $request->stripe_yearly_price_id ?? $plan->stripe_yearly_price_id ?? '',
                     'is_free_plan' => $request->boolean('is_free_plan'),
                     'features' => $request->features,
+                    'start_date' => $request->start_date ?: null,
+                    'end_date' => $request->end_date ?: null,
                 ]);
             });
         }

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -37,6 +37,17 @@ class PlanController extends Controller
 
     public function subscribe(Request $request, Plan $plan, $period)
     {
+        if (! $plan->isCurrentlyAvailable()) {
+            $reason = $plan->start_date && now()->startOfDay()->lt($plan->start_date)
+                ? 'This plan is not yet available.'
+                : 'This plan is no longer available for subscription.';
+
+            return redirect()->route('plans.index')->with('flash', [
+                'banner' => $reason,
+                'bannerStyle' => 'danger',
+            ]);
+        }
+
         $user = $request->user();
 
         $price_id = match ($period) {

--- a/app/Http/Requests/StorePlanRequest.php
+++ b/app/Http/Requests/StorePlanRequest.php
@@ -30,6 +30,8 @@ class StorePlanRequest extends FormRequest
             'features.*.order' => ['required', 'numeric'],
             'features.*.type' => ['required', 'in:feature,limit'],
             'features.*.config' => ['present', 'array'],
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
         ];
     }
 }

--- a/app/Http/Requests/UpdatePlanRequest.php
+++ b/app/Http/Requests/UpdatePlanRequest.php
@@ -32,6 +32,8 @@ class UpdatePlanRequest extends FormRequest
             'features.*.order' => ['required', 'numeric'],
             'features.*.type' => ['required', 'in:feature,limit'],
             'features.*.config' => ['present', 'array'],
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
         ];
     }
 }

--- a/app/Http/Resources/PlanResource.php
+++ b/app/Http/Resources/PlanResource.php
@@ -42,6 +42,9 @@ class PlanResource extends JsonResource
         return array_merge(parent::toArray($request), [
             'settings' => $this->getSettings(),
             'features' => $features,
+            'is_available' => $this->resource?->isCurrentlyAvailable() ?? true,
+            'start_date' => $this->resource ? $this->start_date?->toDateString() : null,
+            'end_date' => $this->resource ? $this->end_date?->toDateString() : null,
         ]);
     }
 

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -20,6 +20,8 @@ class Plan extends Model
         'price_per_month',
         'price_per_year',
         'is_free_plan',
+        'start_date',
+        'end_date',
     ];
 
     protected function casts(): array
@@ -27,6 +29,31 @@ class Plan extends Model
         return [
             'features' => 'array',
             'is_free_plan' => 'boolean',
+            'start_date' => 'date',
+            'end_date' => 'date',
         ];
+    }
+
+    /**
+     * Returns true when today falls within the plan's availability window.
+     * Comparison uses app.timezone (config). Dates are entered as bare YYYY-MM-DD
+     * and stored without time. `startOfDay()` anchors the comparison to midnight
+     * in the server timezone so the full calendar day is included.
+     * Note: if the server is UTC and the admin is in a UTC+N timezone, a plan set
+     * to expire on "2026-05-01" will close at midnight UTC — earlier than local midnight.
+     */
+    public function isCurrentlyAvailable(): bool
+    {
+        $today = now()->startOfDay();
+
+        if ($this->start_date && $today->lt($this->start_date)) {
+            return false;
+        }
+
+        if ($this->end_date && $today->gt($this->end_date)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -101,6 +101,33 @@ class PlanFactory extends Factory
     }
 
     /**
+     * A plan that starts in the future (not yet available).
+     */
+    public function futureWindow(): static
+    {
+        return $this->state(['start_date' => now()->addDay()->toDateString(), 'end_date' => null]);
+    }
+
+    /**
+     * A plan whose window has already expired.
+     */
+    public function expiredWindow(): static
+    {
+        return $this->state(['start_date' => null, 'end_date' => now()->subDay()->toDateString()]);
+    }
+
+    /**
+     * A plan with an active window (started yesterday, ends tomorrow).
+     */
+    public function activeWindow(): static
+    {
+        return $this->state([
+            'start_date' => now()->subDay()->toDateString(),
+            'end_date' => now()->addDay()->toDateString(),
+        ]);
+    }
+
+    /**
      * Build the sparse features array. Only included features are present — no missing entries, no labels.
      *
      * @return array<string, array<string, mixed>>

--- a/database/migrations/2026_04_26_081654_add_dates_to_plans_table.php
+++ b/database/migrations/2026_04_26_081654_add_dates_to_plans_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->date('start_date')->nullable()->after('is_free_plan');
+            $table->date('end_date')->nullable()->after('start_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropColumn(['start_date', 'end_date']);
+        });
+    }
+};

--- a/resources/js/Pages/Admin/Plans/Form.vue
+++ b/resources/js/Pages/Admin/Plans/Form.vue
@@ -307,7 +307,7 @@ const submit = () => {
                             <InputError :message="errors.end_date" class="mt-2" />
                         </div>
                     </div>
-                    <p class="text-xs text-gray-400 dark:text-gray-500 col-span-2">
+                    <p class="text-xs text-gray-400 dark:text-gray-500">
                         Dates are evaluated in UTC (server time). Boundary days include the full calendar day in UTC.
                     </p>
                 </section>

--- a/resources/js/Pages/Admin/Plans/Form.vue
+++ b/resources/js/Pages/Admin/Plans/Form.vue
@@ -162,6 +162,8 @@ const form = reactive({
     stripe_product_id: props.plan?.stripe_product_id ?? '',
     stripe_monthly_price_id: props.plan?.stripe_monthly_price_id ?? '',
     stripe_yearly_price_id: props.plan?.stripe_yearly_price_id ?? '',
+    start_date: props.plan?.start_date ?? '',
+    end_date: props.plan?.end_date ?? '',
 });
 
 // Auto-suggest yearly = monthly × 10 in create mode
@@ -217,6 +219,8 @@ const buildPayload = () => {
             stripe_monthly_price_id: props.plan?.stripe_monthly_price_id ?? '',
             stripe_yearly_price_id: props.plan?.stripe_yearly_price_id ?? '',
             features,
+            start_date: form.start_date || null,
+            end_date: form.end_date || null,
         };
     }
 
@@ -230,6 +234,8 @@ const buildPayload = () => {
         stripe_monthly_price_id: form.stripe_monthly_price_id,
         stripe_yearly_price_id: form.stripe_yearly_price_id,
         features,
+        start_date: form.start_date || null,
+        end_date: form.end_date || null,
     };
 };
 
@@ -285,6 +291,25 @@ const submit = () => {
                     <Alert v-if="form.is_free_plan && existingFreePlanName" type="warning">
                         <strong>{{ existingFreePlanName }}</strong> is currently the free plan. Saving will replace it.
                     </Alert>
+
+                    <!-- Availability Window -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-1">
+                        <div>
+                            <InputLabel for="start_date" value="Available From (optional)" />
+                            <TextInput id="start_date" type="date" v-model="form.start_date" class="mt-1 block w-full" />
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Leave blank for no start restriction.</p>
+                            <InputError :message="errors.start_date" class="mt-2" />
+                        </div>
+                        <div>
+                            <InputLabel for="end_date" value="Available Until (optional)" />
+                            <TextInput id="end_date" type="date" v-model="form.end_date" class="mt-1 block w-full" />
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Leave blank for no expiry.</p>
+                            <InputError :message="errors.end_date" class="mt-2" />
+                        </div>
+                    </div>
+                    <p class="text-xs text-gray-400 dark:text-gray-500 col-span-2">
+                        Dates are evaluated in UTC (server time). Boundary days include the full calendar day in UTC.
+                    </p>
                 </section>
 
                 <!-- Pricing -->

--- a/resources/js/Pages/Admin/Plans/Form.vue
+++ b/resources/js/Pages/Admin/Plans/Form.vue
@@ -162,8 +162,8 @@ const form = reactive({
     stripe_product_id: props.plan?.stripe_product_id ?? '',
     stripe_monthly_price_id: props.plan?.stripe_monthly_price_id ?? '',
     stripe_yearly_price_id: props.plan?.stripe_yearly_price_id ?? '',
-    start_date: props.plan?.start_date ?? '',
-    end_date: props.plan?.end_date ?? '',
+    start_date: props.plan?.start_date ? props.plan.start_date.substring(0, 10) : '',
+    end_date: props.plan?.end_date ? props.plan.end_date.substring(0, 10) : '',
 });
 
 // Auto-suggest yearly = monthly × 10 in create mode

--- a/resources/js/Pages/Admin/Plans/Index.vue
+++ b/resources/js/Pages/Admin/Plans/Index.vue
@@ -28,6 +28,17 @@ const deletePlan = () => {
 };
 
 const featureCount = (plan) => plan.features ? Object.keys(plan.features).length : 0;
+
+const formatDate = (d) => d ? d.substring(0, 10) : null;
+
+const availabilityLabel = (plan) => {
+    const start = formatDate(plan.start_date);
+    const end = formatDate(plan.end_date);
+    if (!start && !end) { return 'Always available'; }
+    if (start && end) { return `${start} – ${end}`; }
+    if (start) { return `From ${start}`; }
+    return `Until ${end}`;
+};
 </script>
 
 <template>
@@ -51,12 +62,13 @@ const featureCount = (plan) => plan.features ? Object.keys(plan.features).length
                             <th scope="col" class="px-6 py-3">Yearly</th>
                             <th scope="col" class="px-6 py-3">Stripe Product</th>
                             <th scope="col" class="px-6 py-3 text-center">Features</th>
+                            <th scope="col" class="px-6 py-3">Availability</th>
                             <th scope="col" class="px-6 py-3 text-right">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr v-if="plans.length === 0">
-                            <td colspan="6" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                            <td colspan="7" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
                                 No plans yet.
                                 <Link :href="route('admin.plans.create')" class="text-gamboge-300 hover:underline ml-1">Create one.</Link>
                             </td>
@@ -81,6 +93,11 @@ const featureCount = (plan) => plan.features ? Object.keys(plan.features).length
                             <td class="px-6 py-4 text-center">
                                 <span class="font-mono text-xs bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded">
                                     {{ featureCount(plan) }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4">
+                                <span class="font-mono text-xs text-gray-500 dark:text-gray-400">
+                                    {{ availabilityLabel(plan) }}
                                 </span>
                             </td>
                             <td class="px-6 py-4 text-right">

--- a/resources/js/Pages/Plan/Index.vue
+++ b/resources/js/Pages/Plan/Index.vue
@@ -65,6 +65,8 @@ const proceedWithSwitch = () => {
     }));
 };
 
+const formatDate = (d) => d ? DateTime.fromISO(d).toLocaleString(DateTime.DATE_MED) : null;
+
 </script>
 <template>
     <AppLayout title="Pricing">
@@ -73,7 +75,10 @@ const proceedWithSwitch = () => {
             <div class="flex flex-col md:flex-row gap-4 justify-center p-4">
                 <div v-for="plan in plans.data" :key="plan.id"
                     class="w-full max-w-sm p-4 bg-gray-50 border border-gray-200 rounded-lg shadow sm:p-8 dark:bg-gray-800 flex flex-col transition-colors duration-200"
-                    :class="userIsSubscribedTo(plan) ? 'dark:border-gamboge-300/60' : 'dark:border-gamboge-300/20'">
+                    :class="[
+                        userIsSubscribedTo(plan) ? 'dark:border-gamboge-300/60' : 'dark:border-gamboge-300/20',
+                        !plan.is_available ? 'opacity-60' : '',
+                    ]">
                     <div class="flex flex-wrap gap-2">
                         <h5 class="mb-4 text-xl font-mono font-medium text-gamboge-700 dark:text-gamboge-200">
                             {{ plan.name }} {{ planFrequency }}
@@ -91,6 +96,19 @@ const proceedWithSwitch = () => {
                             Expires on: {{ DateTime.fromISO($page.props?.auth?.user?.subscription?.ends_at).toLocaleString(DateTime.DATEMED) }}
                         </div>
                     </div>
+                    <!-- Availability labels -->
+                    <span v-if="!plan.is_available && plan.start_date"
+                        class="mb-2 text-xs font-mono text-gamboge-300 uppercase tracking-widest border border-gamboge-300/40 px-2 py-0.5 rounded self-start">
+                        Coming Soon — available from {{ formatDate(plan.start_date) }}
+                    </span>
+                    <span v-else-if="!plan.is_available"
+                        class="mb-2 text-xs font-mono text-red-400 uppercase tracking-widest border border-red-400/40 px-2 py-0.5 rounded self-start">
+                        No Longer Available
+                    </span>
+                    <span v-else-if="plan.is_available && plan.end_date"
+                        class="mb-2 text-xs font-mono text-gray-400 dark:text-gray-500 uppercase tracking-widest self-start">
+                        Available until {{ formatDate(plan.end_date) }}
+                    </span>
                     <div class="flex justify-between">
                         <div class="flex items-baseline text-gray-900 dark:text-white">
                             <span class="text-3xl font-semibold">A$</span>
@@ -121,52 +139,59 @@ const proceedWithSwitch = () => {
                         </PrimaryButton>
                     </span>
                     <span v-else class="mt-auto"> <!-- Not a free plan -->
-                        <span v-if="userIsSubscribedTo(plan)">
-                            <span class="flex flex-col gap-2">
-                                <Link
-                                    v-if="$page.props.auth.user.subscription.ends_at"
-                                    method="post"
-                                    :href="route('plans.resume')"
-                                    class="inline-flex w-full items-center justify-center px-4 py-2 bg-green-800 dark:bg-transparent border border-transparent dark:border-green-400/60 rounded-md font-semibold text-xs text-white dark:text-green-400 uppercase tracking-widest hover:bg-green-700 dark:hover:bg-green-400/10 dark:hover:border-green-400 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
-                                >
-                                    Resume Plan
-                                </Link>
-                                <button
-                                    v-if="!$page.props.auth.user.subscription.ends_at"
-                                    type="button"
-                                    @click="confirmCancellation"
-                                    class="inline-flex w-full items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
-                                >
-                                    Cancel Plan
-                                </button>
+                        <template v-if="plan.is_available">
+                            <span v-if="userIsSubscribedTo(plan)">
+                                <span class="flex flex-col gap-2">
+                                    <Link
+                                        v-if="$page.props.auth.user.subscription.ends_at"
+                                        method="post"
+                                        :href="route('plans.resume')"
+                                        class="inline-flex w-full items-center justify-center px-4 py-2 bg-green-800 dark:bg-transparent border border-transparent dark:border-green-400/60 rounded-md font-semibold text-xs text-white dark:text-green-400 uppercase tracking-widest hover:bg-green-700 dark:hover:bg-green-400/10 dark:hover:border-green-400 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                    >
+                                        Resume Plan
+                                    </Link>
+                                    <button
+                                        v-if="!$page.props.auth.user.subscription.ends_at"
+                                        type="button"
+                                        @click="confirmCancellation"
+                                        class="inline-flex w-full items-center justify-center px-4 py-2 bg-transparent border border-red-400/60 rounded-md font-semibold text-xs text-red-400 uppercase tracking-widest hover:bg-red-400/10 hover:border-red-400 dark:hover:shadow-[0_0_8px_rgba(248,113,113,0.3)] focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                    >
+                                        Cancel Plan
+                                    </button>
+                                </span>
                             </span>
-                        </span>
-                        <span v-else>
-                            <PrimaryButton
-                                v-if="!$page.props.auth.user"
-                                type="button"
-                                disabled
-                                class="opacity-25 w-full justify-center cursor-not-allowed"
-                            >
-                                Login to Subscribe
-                            </PrimaryButton>
-                            <template v-else>
+                            <span v-else>
                                 <PrimaryButton
-                                    v-if="userHasActiveSubscription"
+                                    v-if="!$page.props.auth.user"
                                     type="button"
-                                    class="w-full justify-center"
-                                    @click="confirmPlanSwitch(plan)"
+                                    disabled
+                                    class="opacity-25 w-full justify-center cursor-not-allowed"
                                 >
-                                    Choose This Plan
+                                    Login to Subscribe
                                 </PrimaryButton>
-                                <a
-                                    v-else
-                                    :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
-                                    class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
-                                >
-                                    Choose This Plan
-                                </a>
-                            </template>
+                                <template v-else>
+                                    <PrimaryButton
+                                        v-if="userHasActiveSubscription"
+                                        type="button"
+                                        class="w-full justify-center"
+                                        @click="confirmPlanSwitch(plan)"
+                                    >
+                                        Choose This Plan
+                                    </PrimaryButton>
+                                    <a
+                                        v-else
+                                        :href="route('plans.subscribe', { plan: plan.id, period: planFrequency })"
+                                        class="w-full justify-center inline-flex items-center px-4 py-2 bg-gamboge-800 dark:bg-transparent border border-transparent dark:border-gamboge-300 rounded-md font-semibold text-xs text-white dark:text-gamboge-300 uppercase tracking-widest hover:bg-gamboge-700 dark:hover:bg-gamboge-300 dark:hover:text-gray-900 dark:hover:shadow-neon-cyan-sm focus:bg-gamboge-700 dark:focus:bg-gamboge-300 dark:focus:text-gray-900 active:bg-gamboge-900 dark:active:bg-gamboge-300 dark:active:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gamboge-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 transition ease-in-out duration-150"
+                                    >
+                                        Choose This Plan
+                                    </a>
+                                </template>
+                            </span>
+                        </template>
+                        <span v-else>
+                            <PrimaryButton disabled class="opacity-50 w-full justify-center cursor-not-allowed">
+                                Not Available
+                            </PrimaryButton>
                         </span>
                     </span>
                 </div>

--- a/tests/Feature/Admin/AdminPlanCrudTest.php
+++ b/tests/Feature/Admin/AdminPlanCrudTest.php
@@ -226,4 +226,53 @@ class AdminPlanCrudTest extends TestCase
 
         $response->assertStatus(403);
     }
+
+    public function test_admin_can_save_plan_with_start_and_end_date(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.plans.store'), $this->planPayload([
+            'name' => 'Limited Plan',
+            'start_date' => '2026-06-01',
+            'end_date' => '2026-12-31',
+        ]));
+
+        $response->assertRedirect(route('admin.plans.index'));
+
+        $plan = Plan::where('name', 'Limited Plan')->firstOrFail();
+        $this->assertEquals('2026-06-01', $plan->start_date->toDateString());
+        $this->assertEquals('2026-12-31', $plan->end_date->toDateString());
+    }
+
+    public function test_admin_can_clear_dates_on_plan(): void
+    {
+        $admin = $this->adminUser();
+        $plan = Plan::factory()->activeWindow()->create();
+
+        $response = $this->actingAs($admin)->putJson(route('admin.plans.update', $plan), $this->planPayload([
+            'name' => $plan->name,
+            'price_per_month' => $plan->price_per_month,
+            'price_per_year' => $plan->price_per_year,
+            'start_date' => null,
+            'end_date' => null,
+        ]));
+
+        $response->assertRedirect(route('admin.plans.index'));
+        $plan->refresh();
+        $this->assertNull($plan->start_date);
+        $this->assertNull($plan->end_date);
+    }
+
+    public function test_end_date_before_start_date_returns_validation_error(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.plans.store'), $this->planPayload([
+            'start_date' => '2026-12-31',
+            'end_date' => '2026-06-01',
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['end_date']);
+    }
 }

--- a/tests/Feature/PlanPageTest.php
+++ b/tests/Feature/PlanPageTest.php
@@ -60,6 +60,75 @@ class PlanPageTest extends TestCase
             ->assertRedirectToRoute('login');
     }
 
+    public function test_subscribe_to_unavailable_plan_does_not_reach_stripe(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->expiredWindow()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('plans.subscribe', ['plan' => $plan->id, 'period' => 'monthly']));
+
+        // Guard fires before Stripe is touched — no stripe-related exception, just a redirect
+        $response->assertRedirectToRoute('plans.index');
+    }
+
+    public function test_subscribe_to_not_yet_started_plan_redirects_with_banner_error(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->futureWindow()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('plans.subscribe', ['plan' => $plan->id, 'period' => 'monthly']));
+
+        $response->assertRedirectToRoute('plans.index');
+        $this->assertEquals('This plan is not yet available.', session('flash.banner'));
+        $this->assertEquals('danger', session('flash.bannerStyle'));
+    }
+
+    public function test_subscribe_to_expired_plan_redirects_with_banner_error(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->expiredWindow()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('plans.subscribe', ['plan' => $plan->id, 'period' => 'monthly']));
+
+        $response->assertRedirectToRoute('plans.index');
+        $this->assertEquals('This plan is no longer available for subscription.', session('flash.banner'));
+        $this->assertEquals('danger', session('flash.bannerStyle'));
+    }
+
+    public function test_plan_swap_to_unavailable_plan_is_blocked(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $existingPlan = Plan::factory()->create();
+        $expiredPlan = Plan::factory()->expiredWindow()->create();
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_swap',
+            'stripe_status' => 'active',
+            'stripe_price' => $existingPlan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('plans.subscribe', ['plan' => $expiredPlan->id, 'period' => 'monthly']));
+
+        $response->assertRedirectToRoute('plans.index');
+        $this->assertEquals('This plan is no longer available for subscription.', session('flash.banner'));
+    }
+
+    public function test_free_plan_with_date_restrictions_does_not_affect_unsubscribed_users(): void
+    {
+        $freePlan = Plan::factory()->free()->expiredWindow()->create();
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $resolvedPlan = $user->resolvePlan();
+
+        $this->assertEquals($freePlan->id, $resolvedPlan->id);
+    }
+
     public function test_subscribed_user_can_cancel_and_is_redirected_to_plans(): void
     {
         $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Unit/Models/PlanAvailabilityTest.php
+++ b/tests/Unit/Models/PlanAvailabilityTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Plan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlanAvailabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_currently_available_returns_true_when_no_dates_set(): void
+    {
+        $plan = Plan::factory()->create(['start_date' => null, 'end_date' => null]);
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_true_when_within_window(): void
+    {
+        $plan = Plan::factory()->activeWindow()->create();
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_false_when_before_start_date(): void
+    {
+        $plan = Plan::factory()->futureWindow()->create();
+
+        $this->assertFalse($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_false_when_after_end_date(): void
+    {
+        $plan = Plan::factory()->expiredWindow()->create();
+
+        $this->assertFalse($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_true_when_start_equals_today(): void
+    {
+        $plan = Plan::factory()->create([
+            'start_date' => now()->startOfDay()->toDateString(),
+            'end_date' => null,
+        ]);
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_true_when_end_equals_today(): void
+    {
+        $plan = Plan::factory()->create([
+            'start_date' => null,
+            'end_date' => now()->startOfDay()->toDateString(),
+        ]);
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_true_with_only_start_date_set_in_past(): void
+    {
+        $plan = Plan::factory()->create([
+            'start_date' => now()->subDay()->toDateString(),
+            'end_date' => null,
+        ]);
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+
+    public function test_is_currently_available_returns_true_with_only_end_date_set_in_future(): void
+    {
+        $plan = Plan::factory()->create([
+            'start_date' => null,
+            'end_date' => now()->addDay()->toDateString(),
+        ]);
+
+        $this->assertTrue($plan->isCurrentlyAvailable());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds optional `start_date` and `end_date` fields to the `plans` table, allowing admins to create time-limited subscription windows
- `Plan::isCurrentlyAvailable()` centralises the availability rule — a plan is available when today falls within its window (null bounds = unbounded)
- `PlanController::subscribe()` guards against subscribing to unavailable plans before any Stripe interaction, redirecting with a Jetstream danger banner
- `PlanResource` exposes `is_available`, `start_date`, and `end_date` to the frontend
- Admin form includes date inputs with a UTC timezone note; admin index shows an Availability column
- User-facing plan cards show "Coming Soon — available from [date]", "No Longer Available", or "Available until [date]" labels and disable subscribe/switch buttons for unavailable plans
- Existing subscribers are unaffected when a plan's `end_date` passes — the check only fires at subscribe/swap time

## Regression Notes

- Additive change: all existing plans get `NULL` dates, which `isCurrentlyAvailable()` treats as always available
- `PlanResource` gains three new keys (`is_available`, `start_date`, `end_date`) on every page load via `User::getPlanAttribute()` — existing consumers are unaffected
- `AdminPlanStripeTest` passes with the expanded schema

## Test plan

- [ ] Admin: set a future `start_date` on a plan — plan shows "Coming Soon — available from [date]" on the plans page, button is disabled
- [ ] Admin: set a past `end_date` on a plan — plan shows "No Longer Available", button is disabled
- [ ] Admin: set both dates on a plan — admin index shows `start – end` in Availability column
- [ ] Admin: set `end_date` before `start_date` — validation error returned
- [ ] Admin: clear dates on a plan — reverts to "Always available"
- [ ] Server guard: direct GET to `/plans/{expired-plan}/monthly` redirects to plans page with red banner "This plan is no longer available for subscription."
- [ ] Server guard: direct GET to `/plans/{future-plan}/monthly` redirects with "This plan is not yet available."
- [ ] Plans with no dates — subscribe flow works as before
- [ ] Currently-active plan with `end_date` set — shows "Available until [date]" label while button remains enabled
- [ ] Existing subscriber — remains on plan after its `end_date` passes