### PR TITLE
feat(PIO-83): payment confirmation page after Stripe checkout return

### DIFF
--- a/app/Http/Controllers/PaymentConfirmingController.php
+++ b/app/Http/Controllers/PaymentConfirmingController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class PaymentConfirmingController extends Controller
 {
@@ -17,6 +17,6 @@ class PaymentConfirmingController extends Controller
 
         return Inertia::render('Plan/PaymentConfirming', [
             'sessionId' => $request->query('session_id'),
-        ])->toResponse($request)->withHeaders(['Cache-Control' => 'no-store']);
+        ]);
     }
 }

--- a/app/Http/Controllers/PaymentConfirmingController.php
+++ b/app/Http/Controllers/PaymentConfirmingController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Inertia\Inertia;
+
+class PaymentConfirmingController extends Controller
+{
+    public function show(Request $request): Response|RedirectResponse
+    {
+        if ($request->user()->subscriptions()->active()->exists()) {
+            return redirect()->route('dashboard');
+        }
+
+        return Inertia::render('Plan/PaymentConfirming', [
+            'sessionId' => $request->query('session_id'),
+        ])->toResponse($request)->withHeaders(['Cache-Control' => 'no-store']);
+    }
+}

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -60,7 +60,7 @@ class PlanController extends Controller
                 ->newSubscription('default', $price_id)
                 ->allowPromotionCodes()
                 ->checkout([
-                    'success_url' => route('dashboard'),
+                    'success_url' => route('payment.confirming').'?session_id={CHECKOUT_SESSION_ID}',
                     'cancel_url' => route('dashboard'),
                 ]);
         } else {

--- a/resources/js/Pages/Plan/PaymentConfirming.vue
+++ b/resources/js/Pages/Plan/PaymentConfirming.vue
@@ -1,0 +1,81 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import Page from '../Page.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import { router } from '@inertiajs/vue3';
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+defineProps({
+    sessionId: { type: String, default: null },
+});
+
+const TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 2_000;
+const timedOut = ref(false);
+
+let intervalHandle = null;
+let timeoutHandle = null;
+let isFetching = false;
+
+onMounted(() => {
+    intervalHandle = setInterval(() => {
+        if (isFetching) { return; }
+        isFetching = true;
+        router.reload({ onFinish: () => { isFetching = false; } });
+    }, POLL_INTERVAL_MS);
+
+    timeoutHandle = setTimeout(() => {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+        timedOut.value = true;
+    }, TIMEOUT_MS);
+});
+
+onBeforeUnmount(() => {
+    clearInterval(intervalHandle);
+    clearTimeout(timeoutHandle);
+});
+</script>
+
+<template>
+    <AppLayout title="Setting Up Your Plan">
+        <Page>
+            <div class="flex flex-col items-center justify-center py-16 px-4 gap-8">
+                <!-- Loading state -->
+                <template v-if="!timedOut">
+                    <div class="text-center space-y-2">
+                        <p class="font-mono text-xs uppercase tracking-widest text-gamboge-300">
+                            Activating Your Plan
+                        </p>
+                        <p class="text-gray-500 dark:text-gray-400 text-sm">
+                            Your payment is being processed by Stripe. Please wait while we activate your plan&hellip;
+                        </p>
+                    </div>
+
+                    <div class="w-full max-w-sm">
+                        <div class="relative h-1.5 w-full rounded-sm bg-gray-100 dark:bg-gray-800 border border-gamboge-300/30 dark:border-gamboge-300/20 overflow-hidden">
+                            <div class="absolute inset-y-0 left-0 w-full bg-gray-200 dark:bg-gray-700">
+                                <div class="absolute inset-y-0 w-1/3 bg-gradient-to-r from-transparent via-gamboge-300 to-transparent animate-shimmer" />
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                <!-- Timeout state -->
+                <template v-else>
+                    <div class="text-center space-y-3 max-w-sm">
+                        <p class="font-mono text-xs uppercase tracking-widest text-gamboge-300">
+                            Taking Longer Than Expected
+                        </p>
+                        <p class="text-gray-600 dark:text-gray-300 text-sm">
+                            Your payment is being processed and your plan will activate shortly. You can safely go to the dashboard &mdash; your account will update automatically. If your plan has not updated after a few minutes, please contact support.
+                        </p>
+                        <PrimaryButton :href="route('dashboard')" class="w-full justify-center">
+                            Go to Dashboard
+                        </PrimaryButton>
+                    </div>
+                </template>
+            </div>
+        </Page>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\FileUploadController;
 use App\Http\Controllers\MarkdownDocumentController;
 use App\Http\Controllers\NotificationPreferencesController;
 use App\Http\Controllers\NotificationSettingsController;
+use App\Http\Controllers\PaymentConfirmingController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
 use App\Http\Controllers\SenderIdentityController;
@@ -131,6 +132,10 @@ Route::middleware([
     config('jetstream.auth_session'),
     'verified',
 ])->group(function () {
+    Route::get('/payment/confirming', [PaymentConfirmingController::class, 'show'])
+        ->middleware('throttle:30,1')
+        ->name('payment.confirming');
+
     Route::get('/dashboard', function () {
         return Inertia::render('Dashboard');
     })->name('dashboard');

--- a/tests/Feature/PaymentConfirmingTest.php
+++ b/tests/Feature/PaymentConfirmingTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Mockery;
+use Stripe\StripeClient;
+use Tests\TestCase;
+
+class PaymentConfirmingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('payment.confirming'))
+            ->assertRedirectToRoute('login');
+    }
+
+    public function test_user_without_active_subscription_sees_confirming_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)
+            ->get(route('payment.confirming'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Plan/PaymentConfirming'));
+    }
+
+    public function test_user_with_active_subscription_is_redirected_to_dashboard(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->create(['price_per_month' => 10]);
+
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_confirming',
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payment.confirming'))
+            ->assertRedirectToRoute('dashboard');
+    }
+
+    public function test_session_id_is_passed_to_page_props(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)
+            ->get(route('payment.confirming').'?session_id=cs_test_abc123')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Plan/PaymentConfirming')
+                ->where('sessionId', 'cs_test_abc123')
+            );
+    }
+
+    public function test_success_url_points_to_confirming_route(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $plan = Plan::factory()->create(['price_per_month' => 10]);
+
+        $fakeCustomer = (object) ['id' => 'cus_test_fake'];
+
+        $fakeSession = (object) [
+            'id' => 'cs_test_fake',
+            'url' => 'https://checkout.stripe.com/pay/cs_test_fake',
+        ];
+
+        $capturedData = null;
+
+        $mockCustomersService = Mockery::mock();
+        $mockCustomersService->shouldReceive('create')->andReturn($fakeCustomer);
+        $mockCustomersService->shouldReceive('retrieve')->andReturn($fakeCustomer);
+        $mockCustomersService->shouldReceive('update')->andReturn($fakeCustomer);
+
+        $mockCheckoutService = Mockery::mock();
+        $mockCheckoutService->shouldReceive('create')
+            ->once()
+            ->andReturnUsing(function ($data) use (&$capturedData, $fakeSession) {
+                $capturedData = $data;
+
+                return $fakeSession;
+            });
+
+        $mockStripeClient = new \stdClass;
+        $mockStripeClient->customers = $mockCustomersService;
+        $mockStripeClient->checkout = new \stdClass;
+        $mockStripeClient->checkout->sessions = $mockCheckoutService;
+
+        $this->app->bind(StripeClient::class, fn () => $mockStripeClient);
+
+        $this->actingAs($user)
+            ->get(route('plans.subscribe', ['plan' => $plan->id, 'period' => 'monthly']));
+
+        $this->assertNotNull($capturedData, 'Stripe checkout sessions create was not called.');
+        $this->assertStringContainsString(
+            route('payment.confirming'),
+            $capturedData['success_url'] ?? ''
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an intermediate `/payment/confirming` page between Stripe checkout redirect and the dashboard, eliminating the race condition where users briefly saw themselves as unsubscribed before the webhook arrived
- Controller redirects instantly to dashboard if subscription is already active; otherwise renders the confirming page with `Cache-Control: no-store`
- Page polls every 2 seconds via `setInterval` + `router.reload()` and auto-redirects on confirmation; falls back to a friendly message with a "Go to Dashboard" button after 30 seconds
- `PlanController::subscribe()` `success_url` updated to route through `payment.confirming` (with `?session_id={CHECKOUT_SESSION_ID}`) instead of going directly to the dashboard

## Test plan

- [ ] Complete a Stripe test-mode checkout and verify the confirming page appears while the webhook is pending
- [ ] Verify the page auto-redirects to the dashboard once the subscription is active (no user interaction needed)
- [ ] Verify guests accessing `/payment/confirming` are redirected to login
- [ ] Verify a user with an already-active subscription hitting `/payment/confirming` is redirected immediately to the dashboard
- [ ] Simulate a slow webhook: wait 30 seconds and confirm the timeout message with "Go to Dashboard" appears
- [ ] Verify navigating away from the confirming page stops the polling (no ghost intervals)
- [ ] All 5 feature tests pass: `php artisan test tests/Feature/PaymentConfirmingTest.php`