### PR TITLE
feat(PIO-86): send queued email notification when user account is suspended

### DIFF
--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Plan;
 use App\Models\User;
+use App\Notifications\AccountSuspendedNotification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -55,6 +56,7 @@ class AdminUserController extends Controller
         abort_if($user->is($this->currentAdmin()), 403, 'You cannot suspend your own account.');
 
         $user->update(['suspended_at' => now()]);
+        $user->notify(new AccountSuspendedNotification);
 
         return redirect()->route('admin.users.index')
             ->with('flash', ['success' => "Account for {$user->name} has been suspended."]);

--- a/app/Notifications/AccountSuspendedNotification.php
+++ b/app/Notifications/AccountSuspendedNotification.php
@@ -11,6 +11,9 @@ class AccountSuspendedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    /**
+     * @return array<int, string>
+     */
     public function via(object $notifiable): array
     {
         return ['mail'];
@@ -19,13 +22,16 @@ class AccountSuspendedNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Your account has been suspended')
-            ->line('Your account on '.config('app.name').' has been suspended by an administrator.')
-            ->line('Your data remains secure and will be available if your account is reinstated.')
-            ->action('Contact Support', 'mailto:'.config('mail.from.address'))
-            ->line('If you believe this was done in error, please contact our support team.');
+            ->subject(__('Your account has been suspended'))
+            ->line(__('Your account on :app has been suspended by an administrator.', ['app' => config('app.name')]))
+            ->line(__('Your data remains secure and will be available if your account is reinstated.'))
+            ->action(__('Contact Support'), 'mailto:'.config('mail.from.address'))
+            ->line(__('If you believe this was done in error, please contact our support team.'));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(object $notifiable): array
     {
         return [];

--- a/app/Notifications/AccountSuspendedNotification.php
+++ b/app/Notifications/AccountSuspendedNotification.php
@@ -25,7 +25,7 @@ class AccountSuspendedNotification extends Notification implements ShouldQueue
             ->subject(__('Your account has been suspended'))
             ->line(__('Your account on :app has been suspended by an administrator.', ['app' => config('app.name')]))
             ->line(__('Your data remains secure and will be available if your account is reinstated.'))
-            ->action(__('Contact Support'), 'mailto:'.config('mail.from.address'))
+            ->action(__('Contact Support'), 'mailto:'.config('support.email'))
             ->line(__('If you believe this was done in error, please contact our support team.'));
     }
 

--- a/app/Notifications/AccountSuspendedNotification.php
+++ b/app/Notifications/AccountSuspendedNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class AccountSuspendedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your account has been suspended')
+            ->line('Your account on '.config('app.name').' has been suspended by an administrator.')
+            ->line('Your data remains secure and will be available if your account is reinstated.')
+            ->action('Contact Support', 'mailto:'.config('mail.from.address'))
+            ->line('If you believe this was done in error, please contact our support team.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/app/Notifications/AccountSuspendedNotification.php
+++ b/app/Notifications/AccountSuspendedNotification.php
@@ -25,7 +25,6 @@ class AccountSuspendedNotification extends Notification implements ShouldQueue
             ->subject(__('Your account has been suspended'))
             ->line(__('Your account on :app has been suspended by an administrator.', ['app' => config('app.name')]))
             ->line(__('Your data remains secure and will be available if your account is reinstated.'))
-            ->action(__('Contact Support'), 'mailto:'.config('support.email'))
             ->line(__('If you believe this was done in error, please contact our support team.'));
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,10 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $plan_seeder = app()->environment('production') ? PlanSeederProd::class : PlanSeederLocal::class;
-        
-        $this->call([
-            $plan_seeder
-        ]);
+        // We don't need to seed anything anymore
     }
 }

--- a/tests/Feature/Admin/AdminUserTest.php
+++ b/tests/Feature/Admin/AdminUserTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Admin;
 
 use App\Models\User;
+use App\Notifications\AccountSuspendedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -65,6 +67,8 @@ class AdminUserTest extends TestCase
 
     public function test_admin_can_suspend_a_user(): void
     {
+        Notification::fake();
+
         $admin = $this->adminUser();
         $target = $this->nonAdminUser();
 
@@ -73,6 +77,46 @@ class AdminUserTest extends TestCase
             ->assertRedirect(route('admin.users.index'));
 
         $this->assertNotNull($target->fresh()->suspended_at);
+    }
+
+    public function test_suspended_user_receives_email_notification(): void
+    {
+        Notification::fake();
+
+        $admin = $this->adminUser();
+        $target = $this->nonAdminUser();
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.suspend', $target));
+
+        Notification::assertSentTo($target, AccountSuspendedNotification::class);
+    }
+
+    public function test_notification_is_not_sent_when_admin_suspends_themselves(): void
+    {
+        Notification::fake();
+
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.suspend', $admin))
+            ->assertForbidden();
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_notification_is_not_sent_when_non_admin_attempts_suspend(): void
+    {
+        Notification::fake();
+
+        $nonAdmin = $this->nonAdminUser();
+        $target = $this->nonAdminUser();
+
+        $this->actingAs($nonAdmin)
+            ->post(route('admin.users.suspend', $target))
+            ->assertForbidden();
+
+        Notification::assertNothingSent();
     }
 
     public function test_admin_can_unsuspend_a_user(): void


### PR DESCRIPTION
## Summary

- Add `AccountSuspendedNotification` — a queued `ShouldQueue` mail notification dispatched to a user when an admin suspends their account
- Dispatch the notification from `AdminUserController::suspend()` immediately after the `suspended_at` update
- Update `AdminUserTest` to call `Notification::fake()` on the existing suspend test and add three new notification assertion tests (sent on suspend, not sent on self-suspend, not sent on non-admin attempt)

## Regression risks (informational)

- **`DatabaseSeeder` empty** — a pre-existing commit on this branch (`989f093`) removes plan seeding; any environment relying on `php artisan db:seed` to populate plans will now have no plan rows. This is unrelated to PIO-86 and should be reviewed separately.
- **API routes do not enforce suspension** — `EnsureUserIsNotSuspended` middleware applies to web routes only; Sanctum tokens for suspended users remain valid on `/api/v1/*`. Pre-existing gap, not introduced by this PR.

## Test plan

- [ ] Admin suspends a user → `php artisan queue:work --once` → email appears in `storage/logs/laravel.log` with subject "Your account has been suspended"
- [ ] Suspended user attempts login → receives "Your account has been suspended" error
- [ ] Admin unsuspends user → user can log in again, no second email in the log
- [ ] Admin cannot see a Suspend button on their own row in the user list
- [ ] `php artisan test tests/Feature/Admin/AdminUserTest.php` — all 11 tests pass