### PR TITLE
fix(PIO-89): guard empty stripe_id before syncing Stripe customer details

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -233,7 +233,7 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
     protected static function booted(): void
     {
         static::updated(queueable(function (User $customer) {
-            if ($customer->hasStripeId()) {
+            if (filled($customer->stripe_id)) {
                 $customer->syncStripeCustomerDetails();
             }
         }));

--- a/tests/Feature/Regressions/PIO89Test.php
+++ b/tests/Feature/Regressions/PIO89Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * PIO-89: Updating a user with stripe_id="" threw
+ * Stripe\Exception\InvalidArgumentException because Cashier's hasStripeId()
+ * only checks !is_null(), while Stripe's SDK rejects empty strings too.
+ *
+ * The Stripe SDK validates the resource ID before any HTTP call, so no real
+ * Stripe credentials are needed to reproduce the error. The test suite already
+ * uses the sync queue driver via phpunit.xml, so no queue configuration is needed.
+ */
+class PIO89Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_update_with_empty_stripe_id_does_not_throw_stripe_exception(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $user = User::factory()->create(['stripe_id' => '']);
+
+        // Must not throw Stripe\Exception\InvalidArgumentException.
+        $user->update(['name' => 'Updated Name']);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces `$customer->hasStripeId()` with `filled($customer->stripe_id)` in `User::booted()`'s `updated` listener
- Cashier v16's `hasStripeId()` only checks `!is_null()`, so an empty string `""` passed the guard; Stripe's SDK rejects empty strings in `buildPath()` before any HTTP call, throwing `InvalidArgumentException`
- Adds regression test at `tests/Feature/Regressions/PIO89Test.php` that fails on unfixed code and passes after

## Regression Risk

Low. The change only tightens the guard — valid `stripe_id` values (`"cus_xxx"`) continue to work, and `null` was already handled. The only newly-excluded case is `""` (and whitespace-only strings), which Stripe would have rejected anyway.

## Test Plan

- [ ] Run `php artisan test tests/Feature/Regressions/PIO89Test.php` — should pass (green)
- [ ] Run `php artisan test` — all 429 tests should pass
- [ ] Manually update a user account whose `stripe_id` is an empty string and confirm no exception is thrown in the queue worker