### PR TITLE
feat(PIO-88): notify users when a new higher-value plan is introduced

### DIFF
--- a/app/Http/Controllers/Admin/AdminPlanController.php
+++ b/app/Http/Controllers/Admin/AdminPlanController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePlanRequest;
 use App\Http\Requests\UpdatePlanRequest;
+use App\Jobs\NotifyUsersOfHigherValuePlan;
 use App\Models\Plan;
 use App\Services\FeatureRegistry;
 use App\Services\StripePlanService;
@@ -55,12 +56,14 @@ class AdminPlanController extends Controller
             ];
         }
 
-        DB::transaction(function () use ($request, $stripeIds) {
+        $plan = null;
+
+        DB::transaction(function () use ($request, $stripeIds, &$plan) {
             if ($request->boolean('is_free_plan')) {
                 Plan::query()->update(['is_free_plan' => false]);
             }
 
-            Plan::create([
+            $plan = Plan::create([
                 'name' => $request->name,
                 'price_per_month' => $request->price_per_month,
                 'price_per_year' => $request->price_per_year,
@@ -73,6 +76,8 @@ class AdminPlanController extends Controller
                 'end_date' => $request->end_date ?: null,
             ]);
         });
+
+        NotifyUsersOfHigherValuePlan::dispatch($plan);
 
         return redirect()->route('admin.plans.index')->with('flash', ['success' => 'Plan created.']);
     }

--- a/app/Jobs/NotifyUsersOfHigherValuePlan.php
+++ b/app/Jobs/NotifyUsersOfHigherValuePlan.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Plan;
+use App\Models\User;
+use App\Notifications\NewHigherValuePlanNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class NotifyUsersOfHigherValuePlan implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Plan $plan) {}
+
+    public function handle(): void
+    {
+        $lowerPricePlans = Plan::where('price_per_month', '<', $this->plan->price_per_month)->get();
+
+        if ($lowerPricePlans->isEmpty()) {
+            return;
+        }
+
+        $lowerPriceIds = $lowerPricePlans
+            ->flatMap(fn (Plan $p) => [$p->stripe_monthly_price_id, $p->stripe_yearly_price_id])
+            ->filter()
+            ->values();
+
+        $notification = new NewHigherValuePlanNotification($this->plan);
+
+        // Notify subscribed users on lower-value plans.
+        // This app uses single-price subscriptions exclusively (via PlanController::subscribe()),
+        // so stripe_price on the subscriptions row is always non-null for active subscriptions.
+        // If multi-price subscriptions are introduced, this query must also check subscription_items.
+        if ($lowerPriceIds->isNotEmpty()) {
+            User::whereNotNull('email_verified_at')
+                ->whereNull('suspended_at')
+                ->whereHas('subscriptions', fn ($q) => $q->active()->whereIn('stripe_price', $lowerPriceIds))
+                ->each(fn (User $user) => $user->notify(clone $notification));
+        }
+
+        // Notify free-plan users (no active subscription) when the free plan is lower value.
+        // These two queries are mutually exclusive: a user either has an active subscription or does not.
+        $freePlan = $lowerPricePlans->firstWhere('is_free_plan', true);
+
+        if ($freePlan) {
+            User::whereNotNull('email_verified_at')
+                ->whereNull('suspended_at')
+                ->whereDoesntHave('subscriptions', fn ($q) => $q->active())
+                ->each(fn (User $user) => $user->notify(clone $notification));
+        }
+    }
+}

--- a/app/Notifications/NewHigherValuePlanNotification.php
+++ b/app/Notifications/NewHigherValuePlanNotification.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Plan;
+use App\Services\FeatureRegistry;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
+
+class NewHigherValuePlanNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public Plan $plan) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $registry = app(FeatureRegistry::class);
+
+        $features = collect($this->plan->features ?? [])
+            ->filter(fn ($feature) => ($feature['type'] ?? 'missing') !== 'missing')
+            ->filter(fn ($feature, $key) => $registry->has($key))
+            ->map(function ($feature, $key) use ($registry) {
+                $class = $registry->get($key);
+                $config = $feature['config'] ?? [];
+
+                return $feature['type'] === 'limit'
+                    ? $class->resolveLabel($config)
+                    : $class->label();
+            })
+            ->sortBy(fn ($_, $key) => $this->plan->features[$key]['order'] ?? 99)
+            ->values();
+
+        $currentPlan = $notifiable->resolvePlan();
+        $currentPlanName = $currentPlan?->name ?? 'your current plan';
+
+        $message = (new MailMessage)
+            ->subject(__('Upgrade available: :name is now on :app', ['name' => $this->plan->name, 'app' => config('app.name')]))
+            ->greeting(__('Hi :name,', ['name' => $notifiable->name]))
+            ->line(__("We've just launched :planName — a new plan on :app with more of what you need.", [
+                'planName' => $this->plan->name,
+                'app' => config('app.name'),
+            ]))
+            ->line(__('Available from A$:price/month, it\'s a step up from :currentPlan and includes:', [
+                'price' => number_format($this->plan->price_per_month, 2),
+                'currentPlan' => $currentPlanName,
+            ]));
+
+        foreach ($features as $featureLabel) {
+            $message->line('• '.$featureLabel);
+        }
+
+        if ($this->plan->end_date) {
+            $message->line(__('This is a limited-time offer, available until :date.', [
+                'date' => $this->plan->end_date->format('j F Y'),
+            ]));
+        }
+
+        return $message
+            ->action(__('View Plans'), url(route('plans.index')))
+            ->line(__('Thank you for using :app', ['app' => config('app.name')]));
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/tests/Feature/Admin/NewPlanNotificationTest.php
+++ b/tests/Feature/Admin/NewPlanNotificationTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Jobs\NotifyUsersOfHigherValuePlan;
+use App\Models\Plan;
+use App\Models\User;
+use App\Notifications\NewHigherValuePlanNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class NewPlanNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // Controller-level tests — assert the job is dispatched on plan creation
+    // -------------------------------------------------------------------------
+
+    public function test_job_is_dispatched_when_admin_creates_a_plan(): void
+    {
+        Queue::fake();
+
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)->postJson(route('admin.plans.store'), $this->planPayload([
+            'name' => 'Enterprise',
+            'price_per_month' => 50.00,
+        ]));
+
+        Queue::assertPushed(NotifyUsersOfHigherValuePlan::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Job-level tests — call handle() directly with Notification::fake() active
+    // -------------------------------------------------------------------------
+
+    public function test_subscribed_users_on_lower_value_plans_receive_notification(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_free_plan_users_receive_notification_when_new_plan_is_higher_value(): void
+    {
+        Notification::fake();
+
+        Plan::factory()->free()->create(['price_per_month' => 0]);
+        $newPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $freeUser = $this->verifiedUser();
+
+        (new NotifyUsersOfHigherValuePlan($newPlan))->handle();
+
+        Notification::assertSentTo($freeUser, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_users_on_equal_value_plan_do_not_receive_notification(): void
+    {
+        Notification::fake();
+
+        $existingPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+        $samePricePlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $existingPlan);
+
+        (new NotifyUsersOfHigherValuePlan($samePricePlan))->handle();
+
+        Notification::assertNotSentTo($subscriber, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_users_on_higher_value_plan_do_not_receive_notification(): void
+    {
+        Notification::fake();
+
+        $expensivePlan = Plan::factory()->create(['price_per_month' => 50.00]);
+        $cheaperPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $expensivePlan);
+
+        (new NotifyUsersOfHigherValuePlan($cheaperPlan))->handle();
+
+        Notification::assertNotSentTo($subscriber, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_suspended_users_are_excluded(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $suspended = User::factory()->withPersonalTeam()->create([
+            'email_verified_at' => now(),
+            'suspended_at' => now(),
+        ]);
+        $this->subscribeUserToPlan($suspended, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertNotSentTo($suspended, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_unverified_users_are_excluded(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $unverified = User::factory()->withPersonalTeam()->create([
+            'email_verified_at' => null,
+        ]);
+        $this->subscribeUserToPlan($unverified, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertNotSentTo($unverified, NewHigherValuePlanNotification::class);
+    }
+
+    public function test_email_contains_limited_offer_line_when_end_date_is_set(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $limitedPlan = Plan::factory()->create([
+            'price_per_month' => 25.00,
+            'end_date' => now()->addMonth()->toDateString(),
+        ]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($limitedPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class, function ($notification) use ($subscriber, $limitedPlan) {
+            $mail = $notification->toMail($subscriber);
+            $lines = collect($mail->introLines)->implode(' ');
+
+            return str_contains($lines, 'limited-time offer')
+                && str_contains($lines, $limitedPlan->end_date->format('j F Y'));
+        });
+    }
+
+    public function test_email_does_not_contain_limited_offer_line_when_end_date_is_null(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $openPlan = Plan::factory()->create([
+            'price_per_month' => 25.00,
+            'end_date' => null,
+        ]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($openPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class, function ($notification) use ($subscriber) {
+            $mail = $notification->toMail($subscriber);
+            $lines = collect($mail->introLines)->implode(' ');
+
+            return ! str_contains($lines, 'limited-time offer');
+        });
+    }
+
+    public function test_email_subject_includes_plan_name(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00, 'name' => 'ProMax']);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class, function ($notification) use ($subscriber) {
+            $mail = $notification->toMail($subscriber);
+
+            return str_contains($mail->subject, 'ProMax');
+        });
+    }
+
+    public function test_email_greeting_includes_user_name(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00]);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $subscriber = $this->verifiedUser(['name' => 'Jane Doe']);
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class, function ($notification) use ($subscriber) {
+            $mail = $notification->toMail($subscriber);
+
+            return str_contains($mail->greeting, 'Jane Doe');
+        });
+    }
+
+    public function test_email_contextualises_against_users_current_plan(): void
+    {
+        Notification::fake();
+
+        $lowerPlan = Plan::factory()->create(['price_per_month' => 10.00, 'name' => 'Starter']);
+        $higherPlan = Plan::factory()->create(['price_per_month' => 25.00]);
+
+        $subscriber = $this->verifiedUser();
+        $this->subscribeUserToPlan($subscriber, $lowerPlan);
+
+        (new NotifyUsersOfHigherValuePlan($higherPlan))->handle();
+
+        Notification::assertSentTo($subscriber, NewHigherValuePlanNotification::class, function ($notification) use ($subscriber) {
+            $mail = $notification->toMail($subscriber);
+            $lines = collect($mail->introLines)->implode(' ');
+
+            return str_contains($lines, 'Starter');
+        });
+    }
+
+    public function test_no_notification_sent_when_new_plan_is_the_cheapest(): void
+    {
+        Notification::fake();
+
+        Plan::factory()->create(['price_per_month' => 25.00]);
+        $cheapestPlan = Plan::factory()->create(['price_per_month' => 5.00]);
+
+        $subscriber = $this->verifiedUser();
+
+        (new NotifyUsersOfHigherValuePlan($cheapestPlan))->handle();
+
+        Notification::assertNothingSent();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Config::set('admin.emails', [$user->email]);
+
+        return $user;
+    }
+
+    private function verifiedUser(array $attributes = []): User
+    {
+        return User::factory()->withPersonalTeam()->create(array_merge([
+            'email_verified_at' => now(),
+            'suspended_at' => null,
+        ], $attributes));
+    }
+
+    private function subscribeUserToPlan(User $user, Plan $plan): void
+    {
+        $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => $plan->stripe_monthly_price_id,
+            'quantity' => 1,
+        ]);
+    }
+
+    private function planPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Test Plan',
+            'price_per_month' => 10.00,
+            'price_per_year' => 100.00,
+            'create_stripe_product' => false,
+            'stripe_product_id' => '',
+            'stripe_monthly_price_id' => '',
+            'stripe_yearly_price_id' => '',
+            'features' => [
+                'messages' => ['order' => 1, 'type' => 'limit', 'config' => ['message_length' => 5000]],
+                'expiry' => ['order' => 3, 'type' => 'limit', 'config' => ['expiry_minutes' => 20160]],
+                'throttling' => ['order' => 4, 'type' => 'feature', 'config' => []],
+                'support' => ['order' => 5, 'type' => 'limit', 'config' => ['support_type' => 'standard']],
+                'api' => ['order' => 6, 'type' => 'feature', 'config' => []],
+            ],
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `NewHigherValuePlanNotification` — a queued mail notification that sends a personalised email introducing a new plan, including feature list, current-plan context, price, and a limited-time offer line when the plan has an `end_date`
- Adds `NotifyUsersOfHigherValuePlan` queued job — dispatched after plan creation; targets subscribed users on lower-value plans and free-plan users (verified, non-suspended only)
- `AdminPlanController::store()` now dispatches the job after the DB transaction commits
- 13 tests covering controller dispatch, user targeting, email content, and edge cases

## Regression note

Existing tests that POST to `admin.plans.store` (in `AdminPlanCrudTest` and `AdminPlanStripeTest`) run under the sync queue driver. They remain safe because `RefreshDatabase` produces an empty plans table, causing the job to exit early via the `lowerPricePlans->isEmpty()` guard. Any future test that seeds lower-price plans before calling `store()` should add `Queue::fake()` to remain explicit.

## Test plan

- [ ] Create a plan priced above an existing plan — verify emails land in mail catcher for users on the lower-value plan and free-plan users
- [ ] Create a plan priced equal to or below existing plans — verify no emails are sent
- [ ] Create a plan with an `end_date` — verify the limited-time offer line and formatted date appear in the email
- [ ] Create a plan without an `end_date` — verify no limited-time line appears
- [ ] Verify suspended and unverified users receive no email
- [ ] Run `php artisan test tests/Feature/Admin/NewPlanNotificationTest.php` — all 13 tests pass