### PR TITLE
feat(PIO-92): move to Laravel Octane with FrankenPHP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ APP_MAINTENANCE_DRIVER=file
 
 PHP_CLI_SERVER_WORKERS=4
 
+OCTANE_SERVER=frankenphp
+OCTANE_HTTPS=false
+# OCTANE_WORKERS=4  # Defaults to CPU count when unset; override only if needed
+OCTANE_MAX_REQUESTS=500
+
 BCRYPT_ROUNDS=12
 
 LOG_CHANNEL=stack

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ yarn-error.log
 /.zed
 .claude
 .claude.d
+
+**/caddy
+frankenphp
+frankenphp-worker.php

--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
         "laravel/jetstream": "^5.3",
         "laravel/mcp": "^0.6.0",
         "laravel/nightwatch": "^1.24.4",
+        "laravel/octane": "^2.17",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "league/commonmark": "^2.8.1",

--- a/composer.json
+++ b/composer.json
@@ -211,7 +211,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan octane:start --watch\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b7725880924581e235cd82a8817150",
+    "content-hash": "963265876b0fa3b25b6ae381cda05a9a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1522,6 +1522,94 @@
             "time": "2026-03-11T15:51:16+00:00"
         },
         {
+            "name": "laminas/laminas-diactoros",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "60c182916b2749480895601649563970f3f12ec4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/60c182916b2749480895601649563970f3f12ec4",
+                "reference": "60c182916b2749480895601649563970f3f12ec4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message-implementation": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^2.2.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "php-http/psr7-integration-tests": "^1.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\Diactoros",
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "psr",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-diactoros/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-diactoros/issues",
+                "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
+                "source": "https://github.com/laminas/laminas-diactoros"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-12T15:31:36+00:00"
+        },
+        {
             "name": "laravel/cashier",
             "version": "v16.5.0",
             "source": {
@@ -2206,6 +2294,95 @@
                 "source": "https://github.com/laravel/nightwatch"
             },
             "time": "2026-03-18T23:25:05+00:00"
+        },
+        {
+            "name": "laravel/octane",
+            "version": "v2.17.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/octane.git",
+                "reference": "040bfbebfdf545a752376f4396d942cd6f7da036"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/octane/zipball/040bfbebfdf545a752376f4396d942cd6f7da036",
+                "reference": "040bfbebfdf545a752376f4396d942cd6f7da036",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-diactoros": "^3.0",
+                "laravel/framework": "^10.10.1|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2.0|^0.3.0",
+                "laravel/serializable-closure": "^1.3|^2.0",
+                "nesbot/carbon": "^2.66.0|^3.0",
+                "php": "^8.1.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/psr-http-message-bridge": "^2.2.0|^6.4|^7.0|^8.0"
+            },
+            "conflict": {
+                "spiral/roadrunner": "<2023.1.0",
+                "spiral/roadrunner-cli": "<2.6.0",
+                "spiral/roadrunner-http": "<3.3.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.6.1",
+                "inertiajs/inertia-laravel": "^1.3.2|^2.0",
+                "laravel/scout": "^10.2.1",
+                "laravel/socialite": "^5.6.1",
+                "livewire/livewire": "^2.12.3|^3.0",
+                "nunomaduro/collision": "^6.4.0|^7.5.2|^8.0",
+                "orchestra/testbench": "^8.21|^9.0|^10.0|^11.0",
+                "phpstan/phpstan": "^2.1.7",
+                "phpunit/phpunit": "^10.4|^11.5|^12.0|^13.0",
+                "spiral/roadrunner-cli": "^2.6.0",
+                "spiral/roadrunner-http": "^3.3.0"
+            },
+            "bin": [
+                "bin/roadrunner-worker",
+                "bin/swoole-server"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Octane": "Laravel\\Octane\\Facades\\Octane"
+                    },
+                    "providers": [
+                        "Laravel\\Octane\\OctaneServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Octane\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Supercharge your Laravel application's performance.",
+            "keywords": [
+                "frankenphp",
+                "laravel",
+                "octane",
+                "roadrunner",
+                "swoole"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/octane/issues",
+                "source": "https://github.com/laravel/octane"
+            },
+            "time": "2026-04-23T14:52:16+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -7804,6 +7981,93 @@
                 }
             ],
             "time": "2026-01-26T15:08:38+00:00"
+        },
+        {
+            "name": "symfony/psr-http-message-bridge",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/psr-http-message-bridge.git",
+                "reference": "94facc221260c1d5f20e31ee43cd6c6a824b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/94facc221260c1d5f20e31ee43cd6c6a824b4a19",
+                "reference": "94facc221260c1d5f20e31ee43cd6c6a824b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/http-message": "^1.0|^2.0",
+                "symfony/http-foundation": "^7.4|^8.0"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.1",
+                "php-http/discovery": "^1.15",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\PsrHttpMessage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "PSR HTTP message bridge",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/routing",

--- a/config/octane.php
+++ b/config/octane.php
@@ -222,4 +222,17 @@ return [
 
     'max_execution_time' => 30,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum Requests Per Worker
+    |--------------------------------------------------------------------------
+    |
+    | After the specified number of requests have been handled by a worker,
+    | the worker will be terminated and restarted. This option can help
+    | manage long-lived memory usage. Set to 0 to disable restarting.
+    |
+    */
+
+    'max_requests' => env('OCTANE_MAX_REQUESTS', 500),
+
 ];

--- a/config/octane.php
+++ b/config/octane.php
@@ -56,6 +56,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Octane Workers
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of worker processes that will be spawned
+    | to handle requests. Set to null to use the number of CPU cores available
+    | on the machine. You may set this value as needed based on your server.
+    |
+    */
+
+    'workers' => env('OCTANE_WORKERS', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Listeners
     |--------------------------------------------------------------------------
     |

--- a/config/octane.php
+++ b/config/octane.php
@@ -1,0 +1,225 @@
+<?php
+
+use Inertia\ResponseFactory;
+use Laravel\Octane\Contracts\OperationTerminated;
+use Laravel\Octane\Events\RequestHandled;
+use Laravel\Octane\Events\RequestReceived;
+use Laravel\Octane\Events\RequestTerminated;
+use Laravel\Octane\Events\TaskReceived;
+use Laravel\Octane\Events\TaskTerminated;
+use Laravel\Octane\Events\TickReceived;
+use Laravel\Octane\Events\TickTerminated;
+use Laravel\Octane\Events\WorkerErrorOccurred;
+use Laravel\Octane\Events\WorkerStarting;
+use Laravel\Octane\Events\WorkerStopping;
+use Laravel\Octane\Listeners\CloseMonologHandlers;
+use Laravel\Octane\Listeners\CollectGarbage;
+use Laravel\Octane\Listeners\DisconnectFromDatabases;
+use Laravel\Octane\Listeners\EnsureUploadedFilesAreValid;
+use Laravel\Octane\Listeners\EnsureUploadedFilesCanBeMoved;
+use Laravel\Octane\Listeners\FlushOnce;
+use Laravel\Octane\Listeners\FlushTemporaryContainerInstances;
+use Laravel\Octane\Listeners\FlushUploadedFiles;
+use Laravel\Octane\Listeners\ReportException;
+use Laravel\Octane\Listeners\StopWorkerIfNecessary;
+use Laravel\Octane\Octane;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Server
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the default "server" that will be used by Octane
+    | when starting, restarting, or stopping your server via the CLI. You
+    | are free to change this to the supported server of your choosing.
+    |
+    | Supported: "roadrunner", "swoole", "frankenphp"
+    |
+    */
+
+    'server' => env('OCTANE_SERVER', 'frankenphp'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | When this configuration value is set to "true", Octane will inform the
+    | framework that all absolute links must be generated using the HTTPS
+    | protocol. Otherwise your links may be generated using plain HTTP.
+    |
+    */
+
+    'https' => env('OCTANE_HTTPS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Listeners
+    |--------------------------------------------------------------------------
+    |
+    | All of the event listeners for Octane's events are defined below. These
+    | listeners are responsible for resetting your application's state for
+    | the next request. You may even add your own listeners to the list.
+    |
+    */
+
+    'listeners' => [
+        WorkerStarting::class => [
+            EnsureUploadedFilesAreValid::class,
+            EnsureUploadedFilesCanBeMoved::class,
+        ],
+
+        RequestReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            ...Octane::prepareApplicationForNextRequest(),
+            //
+        ],
+
+        RequestHandled::class => [
+            //
+        ],
+
+        RequestTerminated::class => [
+            // FlushUploadedFiles::class,
+        ],
+
+        TaskReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            //
+        ],
+
+        TaskTerminated::class => [
+            //
+        ],
+
+        TickReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            //
+        ],
+
+        TickTerminated::class => [
+            //
+        ],
+
+        OperationTerminated::class => [
+            FlushOnce::class,
+            FlushTemporaryContainerInstances::class,
+            // DisconnectFromDatabases::class,
+            // CollectGarbage::class,
+        ],
+
+        WorkerErrorOccurred::class => [
+            ReportException::class,
+            StopWorkerIfNecessary::class,
+        ],
+
+        WorkerStopping::class => [
+            CloseMonologHandlers::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Warm / Flush Bindings
+    |--------------------------------------------------------------------------
+    |
+    | The bindings listed below will either be pre-warmed when a worker boots
+    | or they will be flushed before every new request. Flushing a binding
+    | will force the container to resolve that binding again when asked.
+    |
+    */
+
+    'warm' => [
+        ...Octane::defaultServicesToWarm(),
+    ],
+
+    'flush' => [
+        ResponseFactory::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Swoole Tables
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may define additional tables as required by the
+    | application. These tables can be used to store data that needs to be
+    | quickly accessed by other workers on the particular Swoole server.
+    |
+    */
+
+    'tables' => [
+        'example:1000' => [
+            'name' => 'string:1000',
+            'votes' => 'int',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Octane Swoole Cache Table
+    |--------------------------------------------------------------------------
+    |
+    | While using Swoole, you may leverage the Octane cache, which is powered
+    | by a Swoole table. You may set the maximum number of rows as well as
+    | the number of bytes per row using the configuration options below.
+    |
+    */
+
+    'cache' => [
+        'rows' => 1000,
+        'bytes' => 10000,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Watching
+    |--------------------------------------------------------------------------
+    |
+    | The following list of files and directories will be watched when using
+    | the --watch option offered by Octane. If any of the directories and
+    | files are changed, Octane will automatically reload your workers.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config/**/*.php',
+        'database/**/*.php',
+        'public/**/*.php',
+        'resources/**/*.php',
+        'routes',
+        'composer.lock',
+        '.env',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Garbage Collection Threshold
+    |--------------------------------------------------------------------------
+    |
+    | When executing long-lived PHP scripts such as Octane, memory can build
+    | up before being cleared by PHP. You can force Octane to run garbage
+    | collection if your application consumes this amount of megabytes.
+    |
+    */
+
+    'garbage' => 50,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum Execution Time
+    |--------------------------------------------------------------------------
+    |
+    | The following setting configures the maximum execution time for requests
+    | being handled by Octane. You may set this value to 0 to indicate that
+    | there isn't a specific time limit on Octane request execution time.
+    |
+    */
+
+    'max_execution_time' => 30,
+
+];


### PR DESCRIPTION
## Summary

- Installs `laravel/octane` v2.17.3 with FrankenPHP as the application server (the native runtime on Laravel Cloud)
- Fixes the only confirmed Octane incompatibility: adds `Inertia\ResponseFactory` to the `flush` list in `config/octane.php` to prevent shared props leaking across Octane worker requests
- Adds `workers` and `max_requests` config keys backed by `OCTANE_WORKERS` / `OCTANE_MAX_REQUESTS` env vars; updates `.env.example` accordingly (`OCTANE_WORKERS` commented out so CPU-count auto-detection applies by default)
- Updates the `composer dev` script from `php artisan serve` to `php artisan octane:start --watch`
- Gitignores the FrankenPHP binary downloaded locally by `octane:install`

## Regression risks (informational)

- `request()` calls in `Secret::booted()` model hooks are safe — Octane rebinds the request singleton before each worker request and these hooks only fire within the HTTP request lifecycle
- `FeatureRegistry` singleton holds only immutable value objects — safe across worker requests
- `monicahq/laravel-cloudflare` Cloudflare IP list is fetched once at boot; under long-lived workers this list will not refresh until a worker restart (pre-existing, not introduced by this change)

## Test plan

- [ ] Start Octane locally: `./vendor/bin/sail artisan octane:start --watch`
- [ ] Guest secret creation → retrieval → verify correct IP recorded in database
- [ ] Auth secret creation → retrieval notification email received
- [ ] Password login, 2FA challenge, passkey login all complete successfully
- [ ] Rate limiting triggers correctly after repeated secret creation
- [ ] Inertia shared props are correct per-user — log in as two different users in separate browsers and verify auth data does not bleed across requests
- [ ] Billing portal redirect works
- [ ] Local-disk streaming file download works (if S3 is not configured: `FILESYSTEM_DISK=local`)
- [ ] Full test suite passes: `./vendor/bin/sail artisan test`