### PR TITLE
fix(TextAreaInput): restore border and fix internal padding

### DIFF
--- a/resources/js/Components/TextAreaInput.vue
+++ b/resources/js/Components/TextAreaInput.vue
@@ -47,11 +47,11 @@ const inputClass = computed(() => {
 </script>
 
 <template>
-        <span @click="() => input.focus()" ref="base" class="block w-full" :class="[{'relative ring-0 focus-within:ring-1 border-gray-300 dark:border-gamboge-300/40 dark:bg-gray-800 dark:text-gray-200 focus-within:border-gamboge-500 dark:focus-within:border-gamboge-500 focus-within:ring-gamboge-500 dark:focus-within:ring-gamboge-500 rounded-md shadow-sm': maxLength == 0 || input?.value?.length <= maxLength, 'text-red-500 relative border-red-300 dark:border-red-700 dark:bg-red-100 dark:text-red-200 focus:border-red-500 dark:focus:border-red-600 focus:ring-red-500 dark:focus:ring-red-600 rounded-md shadow-sm bg-red-50': maxLength > 0 && input?.value?.length > maxLength}, disabled ? 'opacity-60 cursor-not-allowed' : '']">
+        <span @click="() => input.focus()" ref="base" class="block w-full border overflow-hidden" :class="[{'relative ring-0 focus-within:ring-1 border-gray-300 dark:border-gamboge-300/40 dark:bg-gray-800 dark:text-gray-200 focus-within:border-gamboge-500 dark:focus-within:border-gamboge-500 focus-within:ring-gamboge-500 dark:focus-within:ring-gamboge-500 rounded-md shadow-sm': maxLength == 0 || input?.value?.length <= maxLength, 'text-red-500 relative border-red-300 dark:border-red-700 dark:bg-red-100 dark:text-red-200 focus:border-red-500 dark:focus:border-red-600 focus:ring-red-500 dark:focus:ring-red-600 rounded-md shadow-sm bg-red-50': maxLength > 0 && input?.value?.length > maxLength}, disabled ? 'opacity-60 cursor-not-allowed' : '']">
             <textarea
                 v-bind="$attrs"
                 ref="input"
-                class="w-full border-0 focus:ring-0 -mt-2 -ml-2 -mr-2 mb-2 dark:bg-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-400"
+                class="w-full border-0 focus:ring-0 dark:bg-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-400"
                 :class="{'bg-red-50 dark:bg-red-100 text-red-500 dark:text-red-600': maxLength > 0 && input?.value?.length > maxLength}"
                 :value="modelValue"
                 :rows="rows"


### PR DESCRIPTION
After inheritAttrs:false was added in the Playwright commit, the span wrapper no longer received the parent's type="text" attribute, so @tailwindcss/forms stopped applying border-width and padding to it.

Add explicit `border` and `overflow-hidden` to the span so the border colour classes render correctly on all sides. Remove the negative margins from the textarea that were compensating for the now-absent span padding, letting the textarea's own @tailwindcss/forms padding provide the text inset naturally.