### PR TITLE
fix(ci): restore registry-url to setup-node to fix ENEEDAUTH on npm publish (PIO-101)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          # Removed registry-url here so it defaults to standard OIDC publishing behaviour
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install crypto dependencies
         working-directory: tools/flashview-crypto
@@ -51,7 +51,6 @@ jobs:
       - name: Publish crypto to npm
         if: steps.crypto-version-check.outputs.skip != 'true'
         working-directory: tools/flashview-crypto
-        # No 'env' block needed here anymore!
         run: npm publish --access public --provenance
 
       - name: Install CLI dependencies
@@ -88,5 +87,4 @@ jobs:
       - name: Publish CLI to npm
         if: steps.cli-version-check.outputs.skip != 'true'
         working-directory: tools/flashview-cli
-        # No 'env' block needed here either!
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Restores `registry-url: 'https://registry.npmjs.org'` to the `actions/setup-node` step in `publish-cli.yml` — required for `setup-node` to write the `.npmrc` and wire `NODE_AUTH_TOKEN` from the OIDC token
- Removes three stale inline comments left over from when `registry-url` was incorrectly removed

## Root Cause

`actions/setup-node` requires `registry-url` to activate its npm auth wiring. Without it, the action skips writing `.npmrc` and populating `NODE_AUTH_TOKEN` entirely — so `npm publish` has no credentials and fails with `ENEEDAUTH`, even though `id-token: write` is present and the trusted publisher is configured on npmjs.com.

## Test plan

- [ ] Verify `.github/workflows/publish-cli.yml` contains `registry-url: 'https://registry.npmjs.org'` under `actions/setup-node`
- [ ] Merge a change to `tools/flashview-cli/**` or `tools/flashview-crypto/**` into `master` and confirm the `publish-cli` workflow run completes without `ENEEDAUTH`
- [ ] Confirm both `@pioneer-dynamics/flashview-crypto` and `@pioneer-dynamics/flashview-cli` publish to npmjs.com with provenance attestation

Closes PIO-101