### PR TITLE
refactor(locker): remove PHP-proxy fallback upload/download paths (PIO-100)

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -13,11 +13,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response as HttpResponse;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -158,57 +156,17 @@ class LockerController extends Controller
 
         $storagePath = 'lockers/'.Str::uuid().'.bin';
 
-        try {
-            ['url' => $uploadUrl, 'headers' => $uploadHeaders] = Storage::temporaryUploadUrl(
-                $storagePath,
-                now()->addMinutes(15),
-                ['ContentType' => 'application/octet-stream']
-            );
+        ['url' => $uploadUrl, 'headers' => $uploadHeaders] = Storage::temporaryUploadUrl(
+            $storagePath,
+            now()->addMinutes(15),
+            ['ContentType' => 'application/octet-stream']
+        );
 
-            return response()->json([
-                'upload_type' => 's3_direct',
-                'upload_url' => $uploadUrl,
-                'upload_headers' => $uploadHeaders,
-                'storage_path' => $storagePath,
-            ]);
-        } catch (\RuntimeException) {
-            $token = Str::uuid()->toString();
-            Cache::put("pending_locker_file:{$token}", ['storage_path' => $storagePath], now()->addMinutes(30));
-
-            return response()->json([
-                'upload_type' => 'server',
-                'upload_url' => URL::temporarySignedRoute('lockers.file.upload', now()->addMinutes(15), ['token' => $token]),
-                'upload_headers' => [],
-                'storage_path' => $storagePath,
-            ]);
-        }
-    }
-
-    public function handleFileUpload(Request $request, string $token): JsonResponse
-    {
-        $pending = Cache::get("pending_locker_file:{$token}");
-
-        if (! $pending) {
-            abort(404);
-        }
-
-        Storage::put($pending['storage_path'], $request->getContent());
-        Cache::forget("pending_locker_file:{$token}");
-
-        return response()->json(['ok' => true]);
-    }
-
-    public function downloadFile(string $accountId): HttpResponse
-    {
-        $locker = Locker::where('account_id', $accountId)->first();
-
-        if (! $locker || $locker->isExpired() || ! $locker->isFileLocker()) {
-            abort(404);
-        }
-
-        return response(Storage::get($locker->storage_path), 200, [
-            'Content-Type' => 'application/octet-stream',
-            'Content-Disposition' => 'attachment; filename="locker-file.bin"',
+        return response()->json([
+            'upload_type' => 's3_direct',
+            'upload_url' => $uploadUrl,
+            'upload_headers' => $uploadHeaders,
+            'storage_path' => $storagePath,
         ]);
     }
 
@@ -294,15 +252,7 @@ class LockerController extends Controller
         ];
 
         if ($locker->isFileLocker()) {
-            try {
-                $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
-            } catch (\RuntimeException) {
-                $data['download_url'] = URL::temporarySignedRoute(
-                    'lockers.file.download',
-                    now()->addMinutes(15),
-                    ['accountId' => $accountId]
-                );
-            }
+            $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
         }
 
         return response()->json($data);
@@ -326,15 +276,7 @@ class LockerController extends Controller
         ];
 
         if ($locker->isFileLocker()) {
-            try {
-                $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
-            } catch (\RuntimeException) {
-                $data['download_url'] = URL::temporarySignedRoute(
-                    'lockers.file.download',
-                    now()->addMinutes(15),
-                    ['accountId' => $accountId]
-                );
-            }
+            $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
         }
 
         return response()->json($data);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -41,7 +41,6 @@ return Application::configure(basePath: dirname(__DIR__))
             'stripe/*',
             'lockers',
             'lockers/*',
-            'lockers/file/upload/*',
             'cli/token',
             'cli/device/initiate',
             'cli/device/poll',

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -144,17 +144,14 @@ const submit = async () => {
 
             if (!prepRes.ok) throw new Error('Could not prepare file upload.');
 
-            const { upload_type, upload_url, upload_headers, storage_path } = await prepRes.json();
+            const { upload_url, upload_headers, storage_path } = await prepRes.json();
             storagePath = storage_path;
 
             // Upload encrypted binary via XHR for progress tracking
             step.value = 'uploading';
             await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
-                xhr.open(upload_type === 's3_direct' ? 'PUT' : 'POST', upload_url);
-                if (upload_type === 'server') {
-                    xhr.setRequestHeader('X-XSRF-TOKEN', xsrfToken());
-                }
+                xhr.open('PUT', upload_url);
                 for (const [key, val] of Object.entries(upload_headers ?? {})) {
                     xhr.setRequestHeader(key, val);
                 }

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -298,14 +298,13 @@ const submitFileUpdate = async () => {
 
         let storagePath = null;
         if (prepRes.ok) {
-            const { upload_type, upload_url, upload_headers, storage_path } = await prepRes.json();
+            const { upload_url, upload_headers, storage_path } = await prepRes.json();
             storagePath   = storage_path;
             updateState.value = 'uploading';
 
             await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
-                xhr.open(upload_type === 's3_direct' ? 'PUT' : 'POST', upload_url);
-                if (upload_type === 'server') xhr.setRequestHeader('X-XSRF-TOKEN', getXsrf());
+                xhr.open('PUT', upload_url);
                 for (const [k, v] of Object.entries(upload_headers ?? {})) xhr.setRequestHeader(k, v);
                 xhr.upload.onprogress = (e) => {
                     if (e.lengthComputable) updateProgress.value = Math.round((e.loaded / e.total) * 100);
@@ -400,14 +399,13 @@ const changePassphrase = async () => {
                 body: JSON.stringify({}),
             });
             if (!prepRes.ok) throw new Error('Could not prepare file upload.');
-            const { upload_type, upload_url, upload_headers, storage_path } = await prepRes.json();
+            const { upload_url, upload_headers, storage_path } = await prepRes.json();
             newStoragePath = storage_path;
 
             passphraseChangeState.value = 'uploading';
             await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
-                xhr.open(upload_type === 's3_direct' ? 'PUT' : 'POST', upload_url);
-                if (upload_type === 'server') xhr.setRequestHeader('X-XSRF-TOKEN', getXsrf());
+                xhr.open('PUT', upload_url);
                 for (const [k, v] of Object.entries(upload_headers ?? {})) xhr.setRequestHeader(k, v);
                 xhr.upload.onprogress = (e) => {
                     if (e.lengthComputable) passphraseChangeProgress.value = 50 + Math.round((e.loaded / e.total) * 50);

--- a/routes/web.php
+++ b/routes/web.php
@@ -239,7 +239,6 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
     Route::get('/', [LockerController::class, 'index'])->name('index');
     Route::get('/buy', [LockerController::class, 'buy'])->name('buy');
     Route::post('/file/prepare', [LockerController::class, 'prepareFile'])->name('file.prepare');
-    Route::post('/file/upload/{token}', [LockerController::class, 'handleFileUpload'])->name('file.upload');
     Route::post('/checkout', [LockerController::class, 'checkout'])->name('checkout');
     Route::get('/await-credit', [LockerController::class, 'awaitCredit'])->name('await-credit');
     Route::get('/credit-status', [LockerController::class, 'creditStatus'])
@@ -264,6 +263,4 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
         ->middleware('throttle:6,1')->name('renew.challenge');
     Route::post('/{accountId}/renew', [LockerController::class, 'renewPurchase'])
         ->middleware('throttle:6,1')->name('renew.purchase');
-    Route::get('/{accountId}/file', [LockerController::class, 'downloadFile'])
-        ->middleware(['throttle:locker-payload', 'signed'])->name('file.download');
 });

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Locker;
 use App\Models\Locker;
 use App\Models\LockerCredit;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class LockerControllerTest extends TestCase
@@ -332,5 +333,71 @@ class LockerControllerTest extends TestCase
         $response = $this->getJson(route('lockers.credit-status').'?session=cs_test_123');
 
         $response->assertStatus(200)->assertJson(['token' => 'mytoken']);
+    }
+
+    public function test_prepare_file_returns_s3_direct_upload_url(): void
+    {
+        Storage::fake();
+        $credit = LockerCredit::factory()->create(['token' => 'filetoken', 'tier' => 'file', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.file.prepare'), [
+            'credit_token' => 'filetoken',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['upload_type' => 's3_direct'])
+            ->assertJsonStructure(['upload_url', 'upload_headers', 'storage_path']);
+    }
+
+    public function test_unlock_returns_presigned_download_url_for_file_locker(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/test.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '1234567890',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '1234567890'), [
+            'verifier' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['download_url']);
+    }
+
+    public function test_payload_returns_presigned_download_url_for_file_locker(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/test.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '1234567890',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+        ]);
+
+        $response = $this->getJson(route('lockers.payload', '1234567890'));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['payload', 'auth_challenge', 'download_url']);
+    }
+
+    public function test_server_upload_route_does_not_exist(): void
+    {
+        $response = $this->post('/lockers/file/upload/some-token');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_server_download_route_does_not_exist(): void
+    {
+        $response = $this->get('/lockers/1234567890/file');
+
+        $response->assertStatus(404);
     }
 }


### PR DESCRIPTION
## Summary

- Delete `LockerController::handleFileUpload()` and `downloadFile()` — the PHP-proxy server-side file transport methods are no longer needed
- Strip `try/catch` fallbacks from `prepareFile()`, `unlock()`, and `payload()` so S3 presigned URLs are always used directly
- Remove the `lockers.file.upload` and `lockers.file.download` routes from `routes/web.php`
- Remove `upload_type` branching in `Locker/Create.vue` and `Locker/Show.vue` — XHR always uses `PUT` to the presigned URL
- Remove dead `lockers/file/upload/*` CSRF exclusion from `bootstrap/app.php` (the route no longer exists and was already a subset of the existing `lockers/*` exclusion)
- Add 5 PHPUnit feature tests: presigned upload URL generation, presigned download URL in `unlock` and `payload` responses, and 404 assertions for both removed routes

## Regression risks

- **Local dev without S3**: environments using the `local` disk driver will now receive a 500 on file locker operations (previously the server-proxy fallback would silently handle this). Developers must set `FILESYSTEM_DISK=s3` — this is already documented in `.env.example`. This is the intended behaviour.

## Test plan

- [ ] All 29 `LockerControllerTest` feature tests pass (including 5 new tests added by this PR)
- [ ] `POST /lockers/file/upload/{token}` returns 404
- [ ] `GET /lockers/{accountId}/file` returns 404
- [ ] File locker creation: encrypted file uploads to S3 via `PUT` to presigned URL (requires S3/MinIO)
- [ ] File locker unlock: `download_url` in response is a presigned S3 GET URL
- [ ] File locker update (change file): re-upload goes via `PUT` to presigned URL
- [ ] File locker passphrase change: re-upload goes via `PUT` to presigned URL