### PR TITLE
fix(locker): eliminate RangeError for large file uploads with DEK/KEK envelope encryption (PIO-102)

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -125,6 +125,7 @@ class LockerController extends Controller
             'account_id' => $request->input('account_id'),
             'payload' => $request->input('payload'),
             'storage_path' => $request->input('storage_path'),
+            'wrapped_file_key' => $request->input('wrapped_file_key'),
             'auth_challenge' => $request->input('auth_challenge'),
             'auth_verifier' => $request->input('auth_verifier'),
             'update_token_hash' => hash('sha256', $request->input('update_token')),
@@ -253,6 +254,7 @@ class LockerController extends Controller
 
         if ($locker->isFileLocker()) {
             $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
+            $data['wrapped_file_key'] = $locker->wrapped_file_key;
         }
 
         return response()->json($data);
@@ -300,25 +302,31 @@ class LockerController extends Controller
             return response()->json(['error' => 'Invalid update token.'], 403);
         }
 
-        if ($locker->isFileLocker()) {
+        $updates = [
+            'payload' => $request->input('payload'),
+        ];
+
+        // Only update storage_path when it is explicitly present in the request body.
+        // Omitting it (passphrase-change only) must never null the column or trigger S3 deletion.
+        if ($request->has('storage_path')) {
             $newStoragePath = $request->input('storage_path');
-            if ($locker->storage_path && $locker->storage_path !== $newStoragePath) {
+            if ($locker->isFileLocker() && $locker->storage_path && $locker->storage_path !== $newStoragePath) {
                 try {
                     Storage::delete($locker->storage_path);
                 } catch (\Throwable $e) {
                     Log::warning('Failed to delete old locker S3 object', ['path' => $locker->storage_path, 'error' => $e->getMessage()]);
                 }
             }
+            $updates['storage_path'] = $newStoragePath;
         }
-
-        $updates = [
-            'payload' => $request->input('payload'),
-            'storage_path' => $request->input('storage_path'),
-        ];
 
         if ($request->filled('new_auth_verifier') && $request->filled('new_update_token')) {
             $updates['auth_verifier'] = $request->input('new_auth_verifier');
             $updates['update_token_hash'] = hash('sha256', $request->input('new_update_token'));
+        }
+
+        if ($request->filled('new_wrapped_file_key')) {
+            $updates['wrapped_file_key'] = $request->input('new_wrapped_file_key');
         }
 
         $locker->update($updates);

--- a/app/Http/Requests/Locker/StoreLockerRequest.php
+++ b/app/Http/Requests/Locker/StoreLockerRequest.php
@@ -29,6 +29,7 @@ class StoreLockerRequest extends FormRequest
             'update_token' => ['required', 'string', 'size:64'],
             'tier' => ['required', 'in:text,file'],
             'storage_path' => ['required_if:tier,file', 'nullable', 'string'],
+            'wrapped_file_key' => ['nullable', 'string', 'max:512'],
         ];
     }
 

--- a/app/Http/Requests/Locker/UpdateLockerRequest.php
+++ b/app/Http/Requests/Locker/UpdateLockerRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Locker;
 
-use App\Models\Locker;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -19,25 +18,13 @@ class UpdateLockerRequest extends FormRequest
     public function rules(): array
     {
         $maxHexLength = config('lockers.limits.text_max_bytes') * 2 + 92 + 32;
-        $isFileLocker = $this->resolveIsFileLocker();
 
         return [
             'payload' => ['required', 'string', "max:{$maxHexLength}"],
-            'storage_path' => $isFileLocker ? ['required', 'string'] : ['nullable', 'string'],
+            'storage_path' => ['nullable', 'string'],
             'new_auth_verifier' => ['nullable', 'string', 'size:64'],
             'new_update_token' => ['nullable', 'string', 'size:64'],
+            'new_wrapped_file_key' => ['nullable', 'string', 'max:512'],
         ];
-    }
-
-    private function resolveIsFileLocker(): bool
-    {
-        $accountId = $this->route('accountId');
-        if (! $accountId) {
-            return false;
-        }
-
-        $locker = Locker::where('account_id', $accountId)->first();
-
-        return $locker?->isFileLocker() ?? false;
     }
 }

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -16,6 +16,7 @@ class Locker extends Model
         'account_id',
         'payload',
         'storage_path',
+        'wrapped_file_key',
         'auth_challenge',
         'auth_verifier',
         'update_token_hash',
@@ -26,6 +27,7 @@ class Locker extends Model
     {
         return [
             'expires_at' => 'datetime',
+            'wrapped_file_key' => 'encrypted',
         ];
     }
 

--- a/database/migrations/2026_06_02_081538_add_wrapped_file_key_to_lockers_table.php
+++ b/database/migrations/2026_06_02_081538_add_wrapped_file_key_to_lockers_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->text('wrapped_file_key')->nullable()->after('storage_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->dropColumn('wrapped_file_key');
+        });
+    }
+};

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -111,6 +111,8 @@ const submit = async () => {
         let payload;
         let storagePath = null;
 
+        let wrappedFileKey = null;
+
         if (isFileTier.value) {
             // Encrypt file metadata into the payload field
             const meta = JSON.stringify({
@@ -120,16 +122,11 @@ const submit = async () => {
             });
             payload = await enc.encryptLockerContent(meta, passphrase.value);
 
-            // Encrypt the file contents
-            const fileBuffer    = await selectedFile.value.arrayBuffer();
-            const encryptedBlob = await enc.encryptLockerFile(selectedFile.value, passphrase.value);
-
-            // Convert hex blob to binary for efficient S3 storage
-            const hexStr = encryptedBlob;
-            const bytes  = new Uint8Array(hexStr.length / 2);
-            for (let i = 0; i < hexStr.length; i += 2) {
-                bytes[i / 2] = parseInt(hexStr.slice(i, i + 2), 16);
-            }
+            // Generate DEK, wrap it with passphrase, encrypt file with DEK
+            const dek = enc.generateLockerFileKey();
+            wrappedFileKey = await enc.wrapLockerFileKey(dek, passphrase.value, accountId.value);
+            const fileBuffer = await selectedFile.value.arrayBuffer();
+            const encryptedBytes = await enc.encryptLockerFileToBuffer(fileBuffer, { dek });
 
             // Get presigned upload URL
             const prepRes = await fetch(route('lockers.file.prepare'), {
@@ -147,7 +144,7 @@ const submit = async () => {
             const { upload_url, upload_headers, storage_path } = await prepRes.json();
             storagePath = storage_path;
 
-            // Upload encrypted binary via XHR for progress tracking
+            // Upload encrypted binary via XHR for progress tracking (encryptedBytes is already Uint8Array)
             step.value = 'uploading';
             await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
@@ -162,7 +159,7 @@ const submit = async () => {
                 };
                 xhr.onload  = () => (xhr.status >= 200 && xhr.status < 300) ? resolve() : reject(new Error('Upload failed.'));
                 xhr.onerror = () => reject(new Error('Upload failed.'));
-                xhr.send(new Blob([bytes], { type: 'application/octet-stream' }));
+                xhr.send(new Blob([encryptedBytes], { type: 'application/octet-stream' }));
             });
         } else {
             payload = await enc.encryptLockerContent(content.value, passphrase.value);
@@ -176,14 +173,15 @@ const submit = async () => {
                 'X-XSRF-TOKEN': xsrfToken(),
             },
             body: JSON.stringify({
-                account_id:    accountId.value,
-                credit_token:  props.credit_token,
+                account_id:       accountId.value,
+                credit_token:     props.credit_token,
                 payload,
-                auth_challenge: challengeHex,
-                auth_verifier: verifier,
-                update_token:  updateToken,
-                tier:          props.tier,
-                storage_path:  storagePath,
+                auth_challenge:   challengeHex,
+                auth_verifier:    verifier,
+                update_token:     updateToken,
+                tier:             props.tier,
+                storage_path:     storagePath,
+                wrapped_file_key: wrappedFileKey,
             }),
         });
 

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -49,9 +49,9 @@ const passphraseStrength = computed(() => {
 });
 
 const strengthLabel = computed(() => ['', 'Weak', 'Fair', 'Good', 'Strong'][passphraseStrength.value] ?? '');
-const strengthColor = computed(() => ['', 'text-red-400', 'text-yellow-400', 'text-blue-400', 'text-gamboge-300'][passphraseStrength.value] ?? '');
+const strengthColor = computed(() => ['', 'text-red-400', 'text-gamboge-500', 'text-gamboge-400', 'text-gamboge-300'][passphraseStrength.value] ?? '');
 const strengthWidth = computed(() => ['w-0', 'w-1/4', 'w-2/4', 'w-3/4', 'w-full'][passphraseStrength.value] ?? 'w-0');
-const strengthBg    = computed(() => ['', 'bg-red-400', 'bg-yellow-400', 'bg-blue-400', 'bg-gamboge-300'][passphraseStrength.value] ?? '');
+const strengthBg    = computed(() => ['', 'bg-red-400', 'bg-gamboge-500', 'bg-gamboge-400', 'bg-gamboge-300'][passphraseStrength.value] ?? '');
 
 const generatePassphrase = () => { passphrase.value = enc.generatePasssphrase(); };
 const onFileChange = (e) => { selectedFile.value = e.target.files[0] ?? null; };

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -52,7 +52,7 @@ const showDeleteConfirm = ref(false);
 const newPassphrase            = ref('');
 const passphraseChangeError    = ref('');
 const passphraseChangeSuccess  = ref(false);
-const passphraseChangeState    = ref(null); // null | 're-encrypting' | 'uploading'
+const passphraseChangeState    = ref(null); // null | 'encrypting' | 'uploading'
 const passphraseChangeProgress = ref(0);
 
 const newPassphraseStrength = computed(() => {

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -66,9 +66,9 @@ const newPassphraseStrength = computed(() => {
     return score;
 });
 const newPassphraseStrengthLabel = computed(() => ['', 'Weak', 'Fair', 'Good', 'Strong'][newPassphraseStrength.value] ?? '');
-const newPassphraseStrengthColor = computed(() => ['', 'text-red-400', 'text-yellow-400', 'text-blue-400', 'text-gamboge-300'][newPassphraseStrength.value] ?? '');
+const newPassphraseStrengthColor = computed(() => ['', 'text-red-400', 'text-gamboge-500', 'text-gamboge-400', 'text-gamboge-300'][newPassphraseStrength.value] ?? '');
 const newPassphraseStrengthWidth = computed(() => ['w-0', 'w-1/4', 'w-2/4', 'w-3/4', 'w-full'][newPassphraseStrength.value] ?? 'w-0');
-const newPassphraseStrengthBg    = computed(() => ['', 'bg-red-400', 'bg-yellow-400', 'bg-blue-400', 'bg-gamboge-300'][newPassphraseStrength.value] ?? '');
+const newPassphraseStrengthBg    = computed(() => ['', 'bg-red-400', 'bg-gamboge-500', 'bg-gamboge-400', 'bg-gamboge-300'][newPassphraseStrength.value] ?? '');
 const generateNewPassphrase = () => { newPassphrase.value = enc.generatePasssphrase(); };
 
 const lockLocker = () => {
@@ -365,7 +365,7 @@ const changePassphrase = async () => {
         return;
     }
 
-    passphraseChangeState.value = 're-encrypting';
+    passphraseChangeState.value = 'encrypting';
     passphraseChangeProgress.value = 0;
 
     try {

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -13,9 +13,10 @@ const props = defineProps({
 const enc = new encryption();
 
 // Populated after successful unlock — not passed from server initially (prevents enumeration)
-const isFileLocker  = ref(false);
-const expiresAt     = ref(null); // ISO string or null
-const authChallenge = ref('');
+const isFileLocker   = ref(false);
+const expiresAt      = ref(null); // ISO string or null
+const authChallenge  = ref('');
+const wrappedFileKey = ref('');  // base64 KEK-wrapped DEK; empty for legacy lockers
 
 // Unlock state
 const passphrase        = ref('');
@@ -76,6 +77,7 @@ const lockLocker = () => {
     decryptedFileMeta.value   = null;
     downloadUrl.value         = '';
     authChallenge.value       = '';
+    wrappedFileKey.value      = '';
     decryptError.value        = '';
     updateError.value         = '';
     updateSuccess.value       = false;
@@ -162,9 +164,10 @@ const unlock = async () => {
         }
 
         // Success — populate state from unlock response (server uses snake_case JSON)
-        isFileLocker.value  = data.is_file_locker ?? false;
-        expiresAt.value     = data.expires_at ?? null;
-        authChallenge.value = data.auth_challenge ?? '';
+        isFileLocker.value   = data.is_file_locker ?? false;
+        expiresAt.value      = data.expires_at ?? null;
+        authChallenge.value  = data.auth_challenge ?? '';
+        wrappedFileKey.value = data.wrapped_file_key ?? '';
 
         const result = await enc.decryptLockerContent(data.payload, passphrase.value);
 
@@ -217,14 +220,19 @@ const downloadFile = async () => {
             xhr.send();
         });
 
-        // Convert binary back to hex blob for decryptFromBlob
-        const hexBlob = Array.from(encryptedBytes).map(b => b.toString(16).padStart(2, '0')).join('');
-        const result  = await enc.decryptLockerContent(hexBlob, passphrase.value);
+        // Decrypt — v2 lockers use DEK from wrapped_file_key; v1 legacy use passphrase in blob
+        let decryptedBuffer;
+        if (wrappedFileKey.value) {
+            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, passphrase.value, props.account_id);
+            decryptedBuffer = await enc.decryptLockerFileFromBuffer(encryptedBytes, { dek });
+        } else {
+            decryptedBuffer = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: passphrase.value });
+        }
 
         // Trigger browser download
         const name = decryptedFileMeta.value?.name ?? 'locker-file';
         const type = decryptedFileMeta.value?.type ?? 'application/octet-stream';
-        const blob = new Blob([result.data], { type });
+        const blob = new Blob([decryptedBuffer], { type });
         const url  = URL.createObjectURL(blob);
         const a    = document.createElement('a');
         a.href = url; a.download = name; a.click();
@@ -283,11 +291,11 @@ const submitFileUpdate = async () => {
         const meta    = JSON.stringify({ name: replacementFile.value.name, type: replacementFile.value.type, size: replacementFile.value.size });
         const payload = await enc.encryptLockerContent(meta, passphrase.value);
 
-        const encryptedBlob = await enc.encryptLockerFile(replacementFile.value, passphrase.value);
-        const bytes = new Uint8Array(encryptedBlob.length / 2);
-        for (let i = 0; i < encryptedBlob.length; i += 2) {
-            bytes[i / 2] = parseInt(encryptedBlob.slice(i, i + 2), 16);
-        }
+        // Generate fresh DEK for the replacement file and encrypt directly to Uint8Array
+        const newDek = enc.generateLockerFileKey();
+        const newWrappedFileKey = await enc.wrapLockerFileKey(newDek, passphrase.value, props.account_id);
+        const fileBuffer = await replacementFile.value.arrayBuffer();
+        const bytes = await enc.encryptLockerFileToBuffer(fileBuffer, { dek: newDek });
 
         // Get presigned upload URL
         const prepRes = await fetch(route('lockers.file.prepare'), {
@@ -317,7 +325,10 @@ const submitFileUpdate = async () => {
 
         const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
         const body = { payload };
-        if (storagePath) body.storage_path = storagePath;
+        if (storagePath) {
+            body.storage_path = storagePath;
+            body.new_wrapped_file_key = newWrappedFileKey;
+        }
 
         const res = await fetch(route('lockers.update', props.account_id), {
             method: 'PUT',
@@ -329,6 +340,7 @@ const submitFileUpdate = async () => {
         if (!res.ok) { updateError.value = data.error ?? 'Update failed.'; return; }
 
         updateSuccess.value  = true;
+        wrappedFileKey.value = newWrappedFileKey;
         decryptedFileMeta.value = JSON.parse(meta);
         replacementFile.value  = null;
         downloadUrl.value = '';  // URL is now stale; re-unlock to get fresh URL
@@ -363,14 +375,39 @@ const changePassphrase = async () => {
         const oldUpdateToken  = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
 
         let newPayload;
-        let newStoragePath = null;
+        const putBody = {
+            new_auth_verifier: newVerifier,
+            new_update_token: newUpdateToken,
+        };
 
-        if (isFileLocker.value) {
-            // Re-encrypt metadata payload
+        if (isFileLocker.value && wrappedFileKey.value) {
+            // New locker (v2): re-wrap DEK with new passphrase — no file download required
+            const meta = JSON.stringify(decryptedFileMeta.value);
+            newPayload = await enc.encryptLockerContent(meta, newPassphrase.value);
+            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, passphrase.value, props.account_id);
+            const newWrappedKey = await enc.wrapLockerFileKey(dek, newPassphrase.value, props.account_id);
+            putBody.new_wrapped_file_key = newWrappedKey;
+            putBody.payload = newPayload;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                body: JSON.stringify(putBody),
+            });
+
+            const data = await res.json();
+            if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
+
+            passphrase.value     = newPassphrase.value;
+            wrappedFileKey.value = newWrappedKey;
+            newPassphrase.value           = '';
+            passphraseChangeSuccess.value = true;
+
+        } else if (isFileLocker.value) {
+            // Legacy locker (v1): download, decrypt, re-encrypt with new passphrase
             const meta = JSON.stringify(decryptedFileMeta.value);
             newPayload = await enc.encryptLockerContent(meta, newPassphrase.value);
 
-            // Fetch encrypted file, decrypt with old passphrase, re-encrypt with new
             const encryptedBytes = await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
                 xhr.open('GET', downloadUrl.value);
@@ -383,15 +420,8 @@ const changePassphrase = async () => {
                 xhr.send();
             });
 
-            const hexBlob = Array.from(encryptedBytes).map(b => b.toString(16).padStart(2, '0')).join('');
-            const { data: fileBuffer } = await enc.decryptLockerContent(hexBlob, passphrase.value);
-            const file = new File([fileBuffer], decryptedFileMeta.value?.name ?? 'file', { type: decryptedFileMeta.value?.type ?? 'application/octet-stream' });
-            const reEncryptedHex = await enc.encryptLockerFile(file, newPassphrase.value);
-
-            const bytes = new Uint8Array(reEncryptedHex.length / 2);
-            for (let i = 0; i < reEncryptedHex.length; i += 2) {
-                bytes[i / 2] = parseInt(reEncryptedHex.slice(i, i + 2), 16);
-            }
+            const fileData = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: passphrase.value });
+            const reEncryptedBytes = await enc.encryptLockerFileToBuffer(fileData, { passphrase: newPassphrase.value });
 
             const prepRes = await fetch(route('lockers.file.prepare'), {
                 method: 'POST',
@@ -399,8 +429,7 @@ const changePassphrase = async () => {
                 body: JSON.stringify({}),
             });
             if (!prepRes.ok) throw new Error('Could not prepare file upload.');
-            const { upload_url, upload_headers, storage_path } = await prepRes.json();
-            newStoragePath = storage_path;
+            const { upload_url, upload_headers, storage_path: newStoragePath } = await prepRes.json();
 
             passphraseChangeState.value = 'uploading';
             await new Promise((resolve, reject) => {
@@ -412,30 +441,43 @@ const changePassphrase = async () => {
                 };
                 xhr.onload  = () => (xhr.status >= 200 && xhr.status < 300) ? resolve() : reject(new Error('Upload failed.'));
                 xhr.onerror = () => reject(new Error('Upload failed.'));
-                xhr.send(new Blob([bytes], { type: 'application/octet-stream' }));
+                xhr.send(new Blob([reEncryptedBytes], { type: 'application/octet-stream' }));
             });
+
+            putBody.payload = newPayload;
+            putBody.storage_path = newStoragePath;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                body: JSON.stringify(putBody),
+            });
+
+            const data = await res.json();
+            if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
+
+            passphrase.value = newPassphrase.value;
+            downloadUrl.value = '';
+            newPassphrase.value           = '';
+            passphraseChangeSuccess.value = true;
+
         } else {
             newPayload = await enc.encryptLockerContent(decryptedText.value, newPassphrase.value);
+            putBody.payload = newPayload;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                body: JSON.stringify(putBody),
+            });
+
+            const data = await res.json();
+            if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
+
+            passphrase.value = newPassphrase.value;
+            newPassphrase.value           = '';
+            passphraseChangeSuccess.value = true;
         }
-
-        const res = await fetch(route('lockers.update', props.account_id), {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
-            body: JSON.stringify({
-                payload: newPayload,
-                storage_path: newStoragePath,
-                new_auth_verifier: newVerifier,
-                new_update_token: newUpdateToken,
-            }),
-        });
-
-        const data = await res.json();
-        if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
-
-        passphrase.value = newPassphrase.value;
-        if (newStoragePath) downloadUrl.value = '';
-        newPassphrase.value           = '';
-        passphraseChangeSuccess.value = true;
 
     } catch (err) {
         passphraseChangeError.value = err.message || 'Failed to change passphrase. Please try again.';

--- a/resources/js/encryption.js
+++ b/resources/js/encryption.js
@@ -1,4 +1,11 @@
-import { encryptMessage as sharedEncrypt, decryptMessage as sharedDecrypt, generatePassphrase, encryptBuffer, decryptBuffer, encryptToBlob, decryptFromBlob, encryptFileToBlob, deriveAuthKey, computeVerifier, generateChallenge, deriveUpdateToken } from '@pioneer-dynamics/flashview-crypto';
+import {
+    encryptMessage as sharedEncrypt, decryptMessage as sharedDecrypt,
+    generatePassphrase, encryptBuffer, decryptBuffer,
+    encryptToBlob, decryptFromBlob,
+    encryptFileToBuffer, decryptFileFromBuffer,
+    generateFileKey, wrapFileKey, unwrapFileKey,
+    deriveAuthKey, computeVerifier, generateChallenge, deriveUpdateToken,
+} from '@pioneer-dynamics/flashview-crypto';
 export { LockerBlobVersionError, LockerDecryptionError } from '@pioneer-dynamics/flashview-crypto';
 
 export class encryption {
@@ -73,9 +80,24 @@ export class encryption {
         return decryptFromBlob(blob, passphrase);
     }
 
-    async encryptLockerFile(file, passphrase) {
-        const buffer = await file.arrayBuffer();
-        return encryptFileToBlob(buffer, passphrase);
+    async encryptLockerFileToBuffer(buffer, options) {
+        return encryptFileToBuffer(buffer, options);
+    }
+
+    async decryptLockerFileFromBuffer(buffer, options) {
+        return decryptFileFromBuffer(buffer, options);
+    }
+
+    generateLockerFileKey() {
+        return generateFileKey();
+    }
+
+    async wrapLockerFileKey(dek, passphrase, accountId) {
+        return wrapFileKey(dek, passphrase, accountId);
+    }
+
+    async unwrapLockerFileKey(wrappedKey, passphrase, accountId) {
+        return unwrapFileKey(wrappedKey, passphrase, accountId);
     }
 
     async deriveLockerAuthKey(passphrase, accountId) {

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -400,4 +400,194 @@ class LockerControllerTest extends TestCase
 
         $response->assertStatus(404);
     }
+
+    public function test_store_saves_wrapped_file_key_when_provided(): void
+    {
+        Storage::fake();
+        $credit = LockerCredit::factory()->create(['token' => 'filetok', 'tier' => 'file', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '9876543210',
+            'credit_token' => 'filetok',
+            'payload' => str_repeat('a', 100),
+            'auth_challenge' => str_repeat('c', 64),
+            'auth_verifier' => str_repeat('a', 64),
+            'update_token' => str_repeat('b', 64),
+            'tier' => 'file',
+            'storage_path' => 'lockers/test.bin',
+            'wrapped_file_key' => 'base64wrappedkeydata',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('lockers', ['account_id' => '9876543210']);
+
+        $locker = Locker::where('account_id', '9876543210')->first();
+        $this->assertEquals('base64wrappedkeydata', $locker->wrapped_file_key);
+    }
+
+    public function test_store_does_not_require_wrapped_file_key_for_text_lockers(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'texttok', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '1111111111',
+            'credit_token' => 'texttok',
+            'payload' => str_repeat('a', 100),
+            'auth_challenge' => str_repeat('c', 64),
+            'auth_verifier' => str_repeat('a', 64),
+            'update_token' => str_repeat('b', 64),
+            'tier' => 'text',
+            'storage_path' => null,
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_unlock_returns_wrapped_file_key_for_new_file_lockers(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/test.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '2222222222',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+            'wrapped_file_key' => 'myWrappedKey123',
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '2222222222'), [
+            'verifier' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['wrapped_file_key']);
+
+        $this->assertEquals('myWrappedKey123', $response->json('wrapped_file_key'));
+    }
+
+    public function test_unlock_does_not_return_wrapped_file_key_for_legacy_file_lockers(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/test.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '3333333333',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+            // No wrapped_file_key
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '3333333333'), [
+            'verifier' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertNull($response->json('wrapped_file_key'));
+    }
+
+    public function test_update_accepts_new_wrapped_file_key_for_passphrase_change(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        Locker::factory()->create([
+            'account_id' => '4444444444',
+            'payload' => 'original',
+            'wrapped_file_key' => 'oldWrappedKey',
+            'update_token_hash' => hash('sha256', $token),
+        ]);
+
+        $response = $this->putJson(
+            route('lockers.update', '4444444444'),
+            [
+                'payload' => str_repeat('b', 100),
+                'new_wrapped_file_key' => 'newWrappedKey',
+            ],
+            ['X-Update-Token' => $token]
+        );
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+
+        $locker = Locker::where('account_id', '4444444444')->first();
+        $this->assertEquals('newWrappedKey', $locker->wrapped_file_key);
+    }
+
+    public function test_update_does_not_require_new_wrapped_file_key(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        Locker::factory()->create([
+            'account_id' => '5555555555',
+            'payload' => 'original',
+            'update_token_hash' => hash('sha256', $token),
+        ]);
+
+        $response = $this->putJson(
+            route('lockers.update', '5555555555'),
+            ['payload' => str_repeat('b', 100)],
+            ['X-Update-Token' => $token]
+        );
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+    }
+
+    public function test_update_without_storage_path_does_not_null_out_existing_storage_path(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        Locker::factory()->create([
+            'account_id' => '6666666666',
+            'payload' => 'original',
+            'storage_path' => 'lockers/important-file.bin',
+            'update_token_hash' => hash('sha256', $token),
+        ]);
+
+        // Passphrase-change PUT omits storage_path intentionally
+        $response = $this->putJson(
+            route('lockers.update', '6666666666'),
+            [
+                'payload' => str_repeat('b', 100),
+                'new_wrapped_file_key' => 'newKey',
+            ],
+            ['X-Update-Token' => $token]
+        );
+
+        $response->assertStatus(200);
+
+        $locker = Locker::where('account_id', '6666666666')->first();
+        $this->assertEquals('lockers/important-file.bin', $locker->storage_path, 'storage_path must not be nulled out when omitted from PUT body');
+    }
+
+    public function test_file_update_sends_updated_wrapped_file_key(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/old.bin';
+        Storage::put($storagePath, 'old-content');
+
+        $token = bin2hex(random_bytes(32));
+        Locker::factory()->create([
+            'account_id' => '7777777777',
+            'payload' => 'original',
+            'storage_path' => $storagePath,
+            'wrapped_file_key' => 'oldWrappedKey',
+            'update_token_hash' => hash('sha256', $token),
+        ]);
+
+        $newStoragePath = 'lockers/new.bin';
+        Storage::put($newStoragePath, 'new-content');
+
+        $response = $this->putJson(
+            route('lockers.update', '7777777777'),
+            [
+                'payload' => str_repeat('b', 100),
+                'storage_path' => $newStoragePath,
+                'new_wrapped_file_key' => 'freshWrappedKey',
+            ],
+            ['X-Update-Token' => $token]
+        );
+
+        $response->assertStatus(200);
+
+        $locker = Locker::where('account_id', '7777777777')->first();
+        $this->assertEquals('freshWrappedKey', $locker->wrapped_file_key);
+        $this->assertEquals($newStoragePath, $locker->storage_path);
+    }
 }

--- a/tests/Feature/Regressions/PIO102Test.php
+++ b/tests/Feature/Regressions/PIO102Test.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Models\Locker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * PIO-102: unlock response for a file locker with envelope encryption must return
+ * wrapped_file_key so the client can perform passphrase rotation without re-downloading
+ * the full file.
+ */
+class PIO102Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unlock_response_includes_wrapped_file_key_for_file_lockers(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/test.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '1234567890',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+            'wrapped_file_key' => 'base64wrappedkeydata',
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '1234567890'), [
+            'verifier' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['wrapped_file_key']);
+    }
+}

--- a/tests/Unit/Locker/LockerModelTest.php
+++ b/tests/Unit/Locker/LockerModelTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Locker;
 
 use App\Models\Locker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class LockerModelTest extends TestCase
@@ -73,5 +74,21 @@ class LockerModelTest extends TestCase
 
         $this->assertCount(1, $expired);
         $this->assertEquals('2222222222', $expired->first()->account_id);
+    }
+
+    public function test_wrapped_file_key_is_encrypted_at_rest(): void
+    {
+        $plaintext = 'my-base64-wrapped-dek-value';
+        $locker = Locker::factory()->create([
+            'wrapped_file_key' => $plaintext,
+        ]);
+
+        // Raw DB value must differ from plaintext (it is wrapped by APP_KEY via encrypted cast)
+        $rawValue = DB::table('lockers')
+            ->where('id', $locker->id)
+            ->value('wrapped_file_key');
+
+        $this->assertNotEquals($plaintext, $rawValue, 'wrapped_file_key must be encrypted in the database');
+        $this->assertEquals($plaintext, $locker->fresh()->wrapped_file_key, 'Model accessor must decrypt to original value');
     }
 }

--- a/tests/e2e/helpers/locker.ts
+++ b/tests/e2e/helpers/locker.ts
@@ -18,7 +18,7 @@ export function createLockerCredit(
 }
 
 /**
- * Create a locker via the browser UI. Returns passphrase and update_token.
+ * Create a text locker via the browser UI. Returns passphrase and accountId.
  */
 export async function createLockerViaUI(
     page: Page,
@@ -43,4 +43,51 @@ export async function createLockerViaUI(
     const updateToken = await credRows.nth(2).innerText();
 
     return { accountId, passphrase, updateToken: updateToken.trim() };
+}
+
+/**
+ * Create a file locker via the browser UI with mocked S3 endpoints.
+ * S3 is not available in the test environment — routes are intercepted.
+ */
+export async function createFileLockerViaUI(
+    page: Page,
+    accountId: string,
+    passphrase: string,
+    creditToken: string,
+    storagePath: string = 'lockers/test-file.bin'
+): Promise<{ accountId: string; passphrase: string; storagePath: string }> {
+    const s3MockUrl = `https://mock-s3-locker.example.com/${storagePath}`;
+
+    await page.route('**/lockers/file/prepare', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                upload_type: 's3_direct',
+                upload_url: s3MockUrl,
+                upload_headers: { 'Content-Type': 'application/octet-stream' },
+                storage_path: storagePath,
+            }),
+        });
+    });
+    await page.route('https://mock-s3-locker.example.com/**', async route => {
+        await route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.goto(`/lockers/create?token=${encodeURIComponent(creditToken)}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill(accountId);
+    await page.getByPlaceholder('Enter or generate a passphrase').fill(passphrase);
+
+    await page.getByLabel(/file/i).setInputFiles({
+        name: 'test-file.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('file locker test content for ' + accountId),
+    });
+
+    await page.getByRole('button', { name: /Encrypt & Create/i }).click();
+    await page.waitForSelector('text=Locker created!', { timeout: 20000 });
+
+    return { accountId, passphrase, storagePath };
 }

--- a/tests/e2e/locker-create.spec.ts
+++ b/tests/e2e/locker-create.spec.ts
@@ -110,6 +110,44 @@ test('duplicate account ID shows validation error', async ({ page }) => {
     await expect(page.getByText(/taken|already/i)).toBeVisible({ timeout: 10000 });
 });
 
+test('file locker creation with DEK envelope encryption completes without error', async ({ page }) => {
+    createLockerCredit('filetoken01', 'file', 1);
+
+    // Mock S3 endpoints (not available in test environment)
+    await page.route('**/lockers/file/prepare', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                upload_type: 's3_direct',
+                upload_url: 'https://mock-s3.example.com/test-locker.bin',
+                upload_headers: { 'Content-Type': 'application/octet-stream' },
+                storage_path: 'lockers/test-locker.bin',
+            }),
+        });
+    });
+    await page.route('https://mock-s3.example.com/**', async route => {
+        await route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.goto('/lockers/create?token=filetoken01');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill('1020304050');
+    await page.getByPlaceholder('Enter or generate a passphrase').fill('my-strong-test-passphrase-here');
+
+    await page.getByLabel(/file/i).setInputFiles({
+        name: 'test-file.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('file locker test content'),
+    });
+
+    await page.getByRole('button', { name: /Encrypt & Create/i }).click();
+
+    await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText('Account ID', { exact: true })).toBeVisible();
+});
+
 test('credentials panel has download button and confirmation checkbox', async ({ page }) => {
     createLockerCredit('createtoken04', 'text', 1);
 

--- a/tests/e2e/locker-show.spec.ts
+++ b/tests/e2e/locker-show.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { resetDatabase, clearCache } from './helpers/db';
-import { createLockerCredit, createLockerViaUI } from './helpers/locker';
+import { createLockerCredit, createLockerViaUI, createFileLockerViaUI } from './helpers/locker';
 
 test.beforeEach(() => {
     resetDatabase();
@@ -125,4 +125,73 @@ test('expiry badge is visible on show page', async ({ page }) => {
 
     await expect(page.getByText(/days remaining|Expires/i)).toBeVisible();
     await expect(page.getByText('Renew')).toBeVisible();
+});
+
+// ─── DEK-based file locker flows (PIO-102) ───────────────────────────────────
+
+test('file locker shows file metadata after unlock', async ({ page }) => {
+    createLockerCredit('fileshow01', 'file', 1);
+    const passphrase = 'my-file-locker-passphrase';
+    await createFileLockerViaUI(page, '1122334455', passphrase, 'fileshow01');
+
+    await page.goto('/lockers/1122334455');
+    await page.waitForLoadState('networkidle');
+
+    // Mock the S3 temporary URL returned by the unlock endpoint
+    await page.route('**/1122334455/unlock', async route => {
+        const response = await route.fetch();
+        const body = await response.json();
+        // Override download_url to point to our mock S3
+        if (body.download_url) {
+            body.download_url = 'https://mock-s3-locker.example.com/lockers/test-file.bin';
+        }
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/test-file\.txt/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Decrypt.*Download/i })).toBeVisible();
+});
+
+test('passphrase change on DEK-based file locker does not re-download the file', async ({ page }) => {
+    createLockerCredit('fileshow02', 'file', 1);
+    const passphrase = 'my-file-locker-passphrase';
+    const newPassphrase = 'brand-new-passphrase-for-locker';
+    await createFileLockerViaUI(page, '2233445566', passphrase, 'fileshow02');
+
+    await page.goto('/lockers/2233445566');
+    await page.waitForLoadState('networkidle');
+
+    // Track any S3 download requests — must be 0 during passphrase change
+    const s3Downloads: string[] = [];
+    page.on('request', req => {
+        if (req.method() === 'GET' && req.url().includes('mock-s3-locker')) {
+            s3Downloads.push(req.url());
+        }
+    });
+
+    await page.route('**/2233445566/unlock', async route => {
+        const response = await route.fetch();
+        const body = await response.json();
+        if (body.download_url) {
+            body.download_url = 'https://mock-s3-locker.example.com/lockers/test-file.bin';
+        }
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    // Change passphrase — for a DEK-based locker this is crypto-only, no file download
+    await page.getByPlaceholder('Enter or generate a passphrase').last().fill(newPassphrase);
+    await page.getByRole('button', { name: /Change Passphrase/i }).click();
+
+    await expect(page.getByText(/Passphrase changed/i)).toBeVisible({ timeout: 15000 });
+
+    // Core assertion: no S3 file was downloaded during passphrase change
+    expect(s3Downloads).toHaveLength(0);
 });

--- a/tests/e2e/regressions/PIO102.spec.ts
+++ b/tests/e2e/regressions/PIO102.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * @ticket PIO-102
+ * @symptom Uploading any file to eLocker fails with "Invalid array length" because
+ *          encryptFileToBlob converted AES-GCM ciphertext to a hex string via
+ *          Array.from().map().join(''), which exceeds V8's max string length for large files.
+ *
+ * Must fail before the fix (encryptFileToBlob hex path), pass after (encryptFileToBuffer).
+ */
+
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from '../helpers/db';
+import { createLockerCredit } from '../helpers/locker';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+test('file upload does not produce Invalid array length error', async ({ page }) => {
+    createLockerCredit('pio102token1', 'file', 1);
+
+    // Collect console errors to detect the regression symptom
+    const consoleErrors: string[] = [];
+    page.on('console', msg => {
+        if (msg.type() === 'error') {
+            consoleErrors.push(msg.text());
+        }
+    });
+
+    // Mock the S3 prepare endpoint to avoid real S3 dependency
+    await page.route('**/lockers/file/prepare', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                upload_type: 's3_direct',
+                upload_url: 'https://mock-s3.example.com/locker-test.bin',
+                upload_headers: { 'Content-Type': 'application/octet-stream' },
+                storage_path: 'lockers/pio102-test.bin',
+            }),
+        });
+    });
+
+    // Mock the S3 PUT upload
+    await page.route('https://mock-s3.example.com/**', async route => {
+        await route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.goto('/lockers/create?token=pio102token1');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill('1020304050');
+    await page.getByPlaceholder('Enter or generate a passphrase').fill('my-test-passphrase-long');
+
+    // Upload a 1 KB synthetic file
+    const fileContent = Buffer.alloc(1024, 0xAB);
+    await page.getByLabel(/file/i).setInputFiles({
+        name: 'test-regression-pio102.bin',
+        mimeType: 'application/octet-stream',
+        buffer: fileContent,
+    });
+
+    await page.getByRole('button', { name: /Encrypt & Create/i }).click();
+
+    // Wait for the locker to be created (credentials panel)
+    await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 20000 });
+
+    // The core regression assertion: no Invalid array length error
+    const arrayLengthErrors = consoleErrors.filter(e => e.includes('Invalid array length'));
+    expect(arrayLengthErrors).toHaveLength(0);
+});
+
+test('file locker creation completes and shows credentials panel', async ({ page }) => {
+    createLockerCredit('pio102token2', 'file', 1);
+
+    // Mock S3 prepare
+    await page.route('**/lockers/file/prepare', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                upload_type: 's3_direct',
+                upload_url: 'https://mock-s3.example.com/locker-test2.bin',
+                upload_headers: { 'Content-Type': 'application/octet-stream' },
+                storage_path: 'lockers/pio102-test2.bin',
+            }),
+        });
+    });
+
+    await page.route('https://mock-s3.example.com/**', async route => {
+        await route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.goto('/lockers/create?token=pio102token2');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill('5060708090');
+    await page.getByPlaceholder('Enter or generate a passphrase').fill('my-test-passphrase-long');
+
+    await page.getByLabel(/file/i).setInputFiles({
+        name: 'small-test-file.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('Hello, eLocker!'),
+    });
+
+    await page.getByRole('button', { name: /Encrypt & Create/i }).click();
+
+    await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText('Account ID', { exact: true })).toBeVisible();
+    await expect(page.getByText('Passphrase', { exact: true })).toBeVisible();
+});

--- a/tools/flashview-cli/src/crypto.js
+++ b/tools/flashview-cli/src/crypto.js
@@ -12,4 +12,9 @@ export {
     computePairingCode,
     encryptChunk,
     decryptChunk,
+    generateFileKey,
+    wrapFileKey,
+    unwrapFileKey,
+    encryptFileToBuffer,
+    decryptFileFromBuffer,
 } from '@pioneer-dynamics/flashview-crypto';

--- a/tools/flashview-crypto/package-lock.json
+++ b/tools/flashview-crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pioneer-dynamics/flashview-crypto",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pioneer-dynamics/flashview-crypto",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "dependencies": {
                 "random-words": "^2.0.0"
             },

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -492,34 +492,150 @@ export async function encryptToBlob(content, passphrase) {
 }
 
 /**
- * Encrypt a binary buffer (file) to a self-contained hex blob for eLocker storage.
+ * Encrypt a binary buffer (file) to a self-contained binary Uint8Array for eLocker S3 storage.
  *
- * Blob layout: version(2) + type(2) + salt(64) + iv(24) + AES-GCM ciphertext
+ * v1 format (passphrase path): [0x01][0x46][32 salt][12 IV][AES-GCM ciphertext]
+ * v2 format (DEK path):        [0x02][0x46][12 IV][AES-GCM ciphertext]
  *
- * @param {ArrayBuffer} buffer
- * @param {string} passphrase
- * @returns {Promise<string>} hex blob
+ * @param {ArrayBuffer|Uint8Array} buffer
+ * @param {{ passphrase?: string, dek?: Uint8Array }} options
+ * @returns {Promise<Uint8Array>}
  */
-export async function encryptFileToBlob(buffer, passphrase) {
-    const salt = globalThis.crypto.getRandomValues(new Uint8Array(LOCKER_SALT_LENGTH));
+export async function encryptFileToBuffer(buffer, { passphrase, dek } = {}) {
     const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+    if (dek) {
+        const aesKey = await globalThis.crypto.subtle.importKey('raw', dek, { name: 'AES-GCM' }, false, ['encrypt']);
+        const ciphertext = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, buffer);
+        const result = new Uint8Array(2 + IV_LENGTH + ciphertext.byteLength);
+        result[0] = 0x02;
+        result[1] = 0x46;
+        result.set(iv, 2);
+        result.set(new Uint8Array(ciphertext), 2 + IV_LENGTH);
+        return result;
+    }
+
+    const salt = globalThis.crypto.getRandomValues(new Uint8Array(LOCKER_SALT_LENGTH));
     const key = await deriveLockerEncKey(passphrase, salt);
-    const ciphertext = await globalThis.crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
-        key,
-        buffer
-    );
-    return LOCKER_BLOB_VERSION
-        + LOCKER_TYPE_FILE
-        + bufferToHex(salt)
-        + bufferToHex(iv)
-        + bufferToHex(new Uint8Array(ciphertext));
+    const ciphertext = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, buffer);
+    const result = new Uint8Array(2 + LOCKER_SALT_LENGTH + IV_LENGTH + ciphertext.byteLength);
+    result[0] = 0x01;
+    result[1] = 0x46;
+    result.set(salt, 2);
+    result.set(iv, 2 + LOCKER_SALT_LENGTH);
+    result.set(new Uint8Array(ciphertext), 2 + LOCKER_SALT_LENGTH + IV_LENGTH);
+    return result;
+}
+
+/**
+ * Decrypt a binary eLocker file blob from S3. Detects v1 (passphrase/PBKDF2) or v2 (raw DEK).
+ *
+ * @param {Uint8Array} buffer
+ * @param {{ passphrase?: string, dek?: Uint8Array }} options
+ * @returns {Promise<Uint8Array>} plaintext bytes
+ * @throws {LockerBlobVersionError} on unknown version/type byte
+ * @throws {LockerDecryptionError} on AES-GCM authentication failure
+ */
+export async function decryptFileFromBuffer(buffer, { passphrase, dek } = {}) {
+    const versionByte = buffer[0];
+    const typeByte = buffer[1];
+
+    if (typeByte !== 0x46) {
+        throw new LockerBlobVersionError(`Unsupported blob type: 0x${typeByte.toString(16)}`);
+    }
+
+    if (versionByte === 0x01) {
+        const salt = buffer.slice(2, 2 + LOCKER_SALT_LENGTH);
+        const iv = buffer.slice(2 + LOCKER_SALT_LENGTH, 2 + LOCKER_SALT_LENGTH + IV_LENGTH);
+        const ciphertext = buffer.slice(2 + LOCKER_SALT_LENGTH + IV_LENGTH);
+        const key = await deriveLockerEncKey(passphrase, salt);
+        const decrypted = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+            .catch(() => { throw new LockerDecryptionError('Decryption failed — incorrect passphrase or corrupted data'); });
+        return new Uint8Array(decrypted);
+    }
+
+    if (versionByte === 0x02) {
+        const iv = buffer.slice(2, 2 + IV_LENGTH);
+        const ciphertext = buffer.slice(2 + IV_LENGTH);
+        const aesKey = await globalThis.crypto.subtle.importKey('raw', dek, { name: 'AES-GCM' }, false, ['decrypt']);
+        const decrypted = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, aesKey, ciphertext)
+            .catch(() => { throw new LockerDecryptionError('Decryption failed — incorrect DEK or corrupted data'); });
+        return new Uint8Array(decrypted);
+    }
+
+    throw new LockerBlobVersionError(`Unsupported blob version: 0x${versionByte.toString(16)}`);
+}
+
+/**
+ * Generate a random 256-bit Data Encryption Key (DEK) for envelope encryption.
+ *
+ * @returns {Uint8Array} 32 random bytes
+ */
+export function generateFileKey() {
+    const dek = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(dek);
+    return dek;
+}
+
+/**
+ * Wrap a DEK with a passphrase-derived Key Encryption Key (KEK).
+ *
+ * Output: base64(randomSalt[32] + IV[12] + AES-GCM(dek)[48]) ≈ 124 base64 chars
+ * KEK = PBKDF2-SHA-512(passphrase, randomSalt‖accountId, 100_000)
+ *
+ * @param {Uint8Array} dek
+ * @param {string} passphrase
+ * @param {string} accountId
+ * @returns {Promise<string>} base64-encoded wrapped key
+ */
+export async function wrapFileKey(dek, passphrase, accountId) {
+    const randomSalt = globalThis.crypto.getRandomValues(new Uint8Array(LOCKER_SALT_LENGTH));
+    const accountIdBytes = new TextEncoder().encode(accountId);
+    const pbkdf2Salt = new Uint8Array(LOCKER_SALT_LENGTH + accountIdBytes.length);
+    pbkdf2Salt.set(randomSalt, 0);
+    pbkdf2Salt.set(accountIdBytes, LOCKER_SALT_LENGTH);
+
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+    const kek = await deriveLockerEncKey(passphrase, pbkdf2Salt);
+    const wrappedDek = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, kek, dek);
+
+    const blob = new Uint8Array(LOCKER_SALT_LENGTH + IV_LENGTH + wrappedDek.byteLength);
+    blob.set(randomSalt, 0);
+    blob.set(iv, LOCKER_SALT_LENGTH);
+    blob.set(new Uint8Array(wrappedDek), LOCKER_SALT_LENGTH + IV_LENGTH);
+    return uint8ArrayToBase64(blob);
+}
+
+/**
+ * Unwrap a DEK using a passphrase-derived KEK (inverse of wrapFileKey).
+ *
+ * @param {string} wrappedKeyBase64
+ * @param {string} passphrase
+ * @param {string} accountId
+ * @returns {Promise<Uint8Array>} 32-byte DEK
+ * @throws {LockerDecryptionError} on wrong passphrase or corrupted data
+ */
+export async function unwrapFileKey(wrappedKeyBase64, passphrase, accountId) {
+    const blob = base64ToUint8Array(wrappedKeyBase64);
+    const randomSalt = blob.slice(0, LOCKER_SALT_LENGTH);
+    const iv = blob.slice(LOCKER_SALT_LENGTH, LOCKER_SALT_LENGTH + IV_LENGTH);
+    const wrappedDek = blob.slice(LOCKER_SALT_LENGTH + IV_LENGTH);
+
+    const accountIdBytes = new TextEncoder().encode(accountId);
+    const pbkdf2Salt = new Uint8Array(LOCKER_SALT_LENGTH + accountIdBytes.length);
+    pbkdf2Salt.set(randomSalt, 0);
+    pbkdf2Salt.set(accountIdBytes, LOCKER_SALT_LENGTH);
+
+    const kek = await deriveLockerEncKey(passphrase, pbkdf2Salt);
+    const dek = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, kek, wrappedDek)
+        .catch(() => { throw new LockerDecryptionError('Decryption failed — incorrect passphrase or corrupted data'); });
+    return new Uint8Array(dek);
 }
 
 /**
  * Decrypt an eLocker hex blob back to its original content.
  *
- * @param {string} blob - hex blob produced by encryptToBlob or encryptFileToBlob
+ * @param {string} blob - hex blob produced by encryptToBlob
  * @param {string} passphrase
  * @returns {Promise<{ type: 'text'|'file', data: ArrayBuffer }>}
  * @throws {LockerBlobVersionError} on unknown version or type byte

--- a/tools/flashview-crypto/tests/crypto.test.js
+++ b/tools/flashview-crypto/tests/crypto.test.js
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { encryptMessage, decryptMessage, generatePassphrase, encryptBuffer, decryptBuffer } from '../src/index.js';
+import {
+    encryptMessage, decryptMessage, generatePassphrase,
+    encryptBuffer, decryptBuffer,
+    encryptFileToBuffer, decryptFileFromBuffer,
+    generateFileKey, wrapFileKey, unwrapFileKey,
+} from '../src/index.js';
 
 // Known vectors generated from the pre-migration CLI implementation (tools/flashview-cli/src/crypto.js)
 // using Node.js `node:crypto` (pbkdf2Sync + createCipheriv AES-256-GCM).
@@ -165,6 +170,20 @@ describe('known-vector compatibility (backward compatibility with pre-migration 
     });
 });
 
+// PIO-102 regression: encryptFileToBuffer must not throw RangeError: Invalid array length for large files.
+// Before fix: encryptFileToBlob used Array.from().map().join('') which crashes for ~400 MB files.
+// After fix: encryptFileToBuffer returns Uint8Array directly, no intermediate hex string.
+describe('encryptFileToBuffer large file regression (PIO-102)', () => {
+    it('handles a 50 MB buffer without throwing RangeError: Invalid array length', async () => {
+        const bigBuffer = new Uint8Array(50 * 1024 * 1024);
+        bigBuffer.fill(0xAB);
+        const dek = generateFileKey();
+        const result = await encryptFileToBuffer(bigBuffer, { dek });
+        assert.ok(result instanceof Uint8Array, 'Result must be a Uint8Array');
+        assert.ok(result.length > bigBuffer.length, 'Encrypted result must be larger than plaintext');
+    });
+});
+
 describe('ciphertext format compatibility (MessageLength validation)', () => {
     it('matches expected overhead for MessageLength validation', async () => {
         // The MessageLength rule subtracts 28 bytes (12 IV + 16 auth tag) from the
@@ -271,5 +290,151 @@ describe('decryptBuffer', () => {
             () => decryptBuffer(corrupted, passphrase),
             'Should reject with corrupted ciphertext'
         );
+    });
+});
+
+// ─── eLocker File Crypto (envelope encryption) ───────────────────────────────
+
+describe('generateFileKey', () => {
+    it('returns a 32-byte Uint8Array', () => {
+        const dek = generateFileKey();
+        assert.ok(dek instanceof Uint8Array, 'Should return Uint8Array');
+        assert.equal(dek.length, 32);
+    });
+
+    it('generates unique keys each call', () => {
+        const a = generateFileKey();
+        const b = generateFileKey();
+        assert.notDeepEqual(a, b, 'Two generated keys should differ');
+    });
+});
+
+describe('encryptFileToBuffer + decryptFileFromBuffer (v2 DEK path)', () => {
+    it('round-trips arbitrary binary data with DEK', async () => {
+        const original = new Uint8Array([0, 1, 127, 128, 255, 42]);
+        const dek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(original, { dek });
+        const decrypted = await decryptFileFromBuffer(encrypted, { dek });
+        assert.deepEqual(decrypted, original);
+    });
+
+    it('produces v2 version byte (0x02) and file type byte (0x46)', async () => {
+        const dek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(new Uint8Array(8), { dek });
+        assert.equal(encrypted[0], 0x02, 'Version byte must be 0x02');
+        assert.equal(encrypted[1], 0x46, 'Type byte must be 0x46 (F)');
+    });
+
+    it('v2 blob is 2 + 12 (IV) + plaintext + 16 (tag) bytes', async () => {
+        const plaintext = new Uint8Array(100);
+        const dek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(plaintext, { dek });
+        assert.equal(encrypted.length, 2 + 12 + 100 + 16);
+    });
+
+    it('round-trips empty buffer with DEK', async () => {
+        const dek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(new Uint8Array(0), { dek });
+        const decrypted = await decryptFileFromBuffer(encrypted, { dek });
+        assert.deepEqual(decrypted, new Uint8Array(0));
+    });
+
+    it('fails decryption with wrong DEK', async () => {
+        const dek = generateFileKey();
+        const wrongDek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(new Uint8Array([1, 2, 3]), { dek });
+        await assert.rejects(
+            () => decryptFileFromBuffer(encrypted, { dek: wrongDek }),
+            'Should reject with wrong DEK'
+        );
+    });
+});
+
+describe('encryptFileToBuffer + decryptFileFromBuffer (v1 passphrase path)', () => {
+    it('round-trips arbitrary binary data with passphrase', async () => {
+        const original = new Uint8Array([10, 20, 30, 40, 50]);
+        const passphrase = 'test-locker-passphrase';
+        const encrypted = await encryptFileToBuffer(original, { passphrase });
+        const decrypted = await decryptFileFromBuffer(encrypted, { passphrase });
+        assert.deepEqual(decrypted, original);
+    });
+
+    it('produces v1 version byte (0x01) and file type byte (0x46)', async () => {
+        const encrypted = await encryptFileToBuffer(new Uint8Array(8), { passphrase: 'p' });
+        assert.equal(encrypted[0], 0x01, 'Version byte must be 0x01');
+        assert.equal(encrypted[1], 0x46, 'Type byte must be 0x46 (F)');
+    });
+
+    it('v1 blob is 2 + 32 (salt) + 12 (IV) + plaintext + 16 (tag) bytes', async () => {
+        const plaintext = new Uint8Array(100);
+        const encrypted = await encryptFileToBuffer(plaintext, { passphrase: 'p' });
+        assert.equal(encrypted.length, 2 + 32 + 12 + 100 + 16);
+    });
+
+    it('fails decryption with wrong passphrase', async () => {
+        const encrypted = await encryptFileToBuffer(new Uint8Array([1, 2]), { passphrase: 'correct' });
+        await assert.rejects(
+            () => decryptFileFromBuffer(encrypted, { passphrase: 'wrong' }),
+            'Should reject with wrong passphrase'
+        );
+    });
+});
+
+describe('wrapFileKey + unwrapFileKey', () => {
+    it('round-trips a DEK through wrap/unwrap', async () => {
+        const dek = generateFileKey();
+        const passphrase = 'my-locker-passphrase';
+        const accountId = '1234567890';
+        const wrapped = await wrapFileKey(dek, passphrase, accountId);
+        const unwrapped = await unwrapFileKey(wrapped, passphrase, accountId);
+        assert.deepEqual(unwrapped, dek);
+    });
+
+    it('wrapFileKey returns a non-empty base64 string', async () => {
+        const dek = generateFileKey();
+        const wrapped = await wrapFileKey(dek, 'pass', 'account1');
+        assert.equal(typeof wrapped, 'string');
+        assert.ok(wrapped.length > 0, 'Should return a non-empty base64 string');
+    });
+
+    it('produces different output each call (random salt)', async () => {
+        const dek = generateFileKey();
+        const a = await wrapFileKey(dek, 'pass', 'account1');
+        const b = await wrapFileKey(dek, 'pass', 'account1');
+        assert.notEqual(a, b, 'Random salt should produce different wrapped keys');
+    });
+
+    it('fails to unwrap with wrong passphrase', async () => {
+        const dek = generateFileKey();
+        const wrapped = await wrapFileKey(dek, 'correct-pass', 'account1');
+        await assert.rejects(
+            () => unwrapFileKey(wrapped, 'wrong-pass', 'account1'),
+            'Should reject with wrong passphrase'
+        );
+    });
+
+    it('fails to unwrap with wrong accountId', async () => {
+        const dek = generateFileKey();
+        const wrapped = await wrapFileKey(dek, 'pass', 'correct-account');
+        await assert.rejects(
+            () => unwrapFileKey(wrapped, 'pass', 'wrong-account'),
+            'Should reject with wrong accountId'
+        );
+    });
+});
+
+describe('encryptFileToBuffer + decryptFileFromBuffer backward compat', () => {
+    it('v2 encrypted can be decrypted after re-wrapping DEK with new passphrase', async () => {
+        const original = new Uint8Array([1, 2, 3, 4, 5]);
+        const dek = generateFileKey();
+        const encrypted = await encryptFileToBuffer(original, { dek });
+
+        const oldWrapped = await wrapFileKey(dek, 'old-passphrase', 'acct1');
+        const unwrappedDek = await unwrapFileKey(oldWrapped, 'old-passphrase', 'acct1');
+        const newWrapped = await wrapFileKey(unwrappedDek, 'new-passphrase', 'acct1');
+        const finalDek = await unwrapFileKey(newWrapped, 'new-passphrase', 'acct1');
+
+        const decrypted = await decryptFileFromBuffer(encrypted, { dek: finalDek });
+        assert.deepEqual(decrypted, original, 'File must decrypt correctly after DEK re-wrap');
     });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: Replace `encryptFileToBlob` (hex string, OOM crash) with `encryptFileToBuffer` (Uint8Array) in `flashview-crypto` — eliminates `RangeError: Invalid array length` when uploading large files to eLocker
- **Architectural improvement**: Introduce DEK/KEK envelope encryption so passphrase changes are instant (re-wrap the 32-byte key only — no file download/re-upload regardless of file size)
- **Data-loss fix**: Guard `storage_path` update in `LockerController::update()` behind `$request->has('storage_path')` — previously a passphrase-change PUT with no `storage_path` would null the column and trigger S3 deletion

## What changed

### Crypto (`tools/flashview-crypto`)
- Remove `encryptFileToBlob` (returned a hex string — crashed for large files)
- Add `encryptFileToBuffer(buffer, { passphrase?, dek? })` → `Uint8Array`
- Add `decryptFileFromBuffer(buffer, { passphrase?, dek? })` — detects v1 (PBKDF2) or v2 (DEK) by version byte
- Add `generateFileKey()`, `wrapFileKey(dek, passphrase, accountId)`, `unwrapFileKey(wrappedKeyBase64, passphrase, accountId)` for envelope encryption
- 48 JS tests (17 new)

### Binary blob formats
- **v1** (existing, backward compat): `[0x01][0x46][32 salt][12 IV][ciphertext]` — PBKDF2 key in blob
- **v2** (new lockers): `[0x02][0x46][12 IV][ciphertext]` — raw DEK, salt managed separately via `wrapFileKey`

### Backend
- Migration: add nullable `wrapped_file_key text` column to `lockers`
- `Locker` model: `wrapped_file_key` fillable + `encrypted` cast (APP_KEY layer)
- `StoreLockerRequest`: accept optional `wrapped_file_key`
- `UpdateLockerRequest`: make `storage_path` nullable; add `new_wrapped_file_key`
- `LockerController`: store/return/update `wrapped_file_key`; S3 deletion guard fix

### Frontend
- `encryption.js`: remove `encryptLockerFile`; add `encryptLockerFileToBuffer`, `decryptLockerFileFromBuffer`, `generateLockerFileKey`, `wrapLockerFileKey`, `unwrapLockerFileKey`
- `Create.vue`: generate DEK → wrap → encrypt file to Uint8Array → send `wrapped_file_key`
- `Show.vue`: download uses `decryptLockerFileFromBuffer` (v1/v2 auto-detect); passphrase change for v2 lockers re-wraps DEK only (no file download); file replace generates fresh DEK
- `flashview-cli/src/crypto.js`: export all 5 new locker crypto functions for CLI parity

### Tests
- PHP regression: `test_unlock_response_includes_wrapped_file_key_for_file_lockers`
- 8 new controller tests including `test_update_without_storage_path_does_not_null_out_existing_storage_path`
- 1 model test: `test_wrapped_file_key_is_encrypted_at_rest`
- E2E: `tests/e2e/regressions/PIO102.spec.ts`, updated `locker-create.spec.ts` and `locker-show.spec.ts`

## Backward compatibility

Existing file lockers (v1, no `wrapped_file_key`) continue to work unchanged — download and passphrase change fall back to the PBKDF2 path automatically.

## Regression risks

- `payload()` (unauthenticated endpoint) intentionally does **not** return `wrapped_file_key` — only the HMAC-verified `unlock()` does. This is correct by design.
- APP_KEY rotation will break `wrapped_file_key` decryption for v2 lockers (pre-existing Laravel `encrypted` cast behaviour).

## Test plan

- [ ] Create a new file locker — upload completes without error
- [ ] Unlock and download the file — decrypts correctly
- [ ] Change passphrase on new locker — instant (no S3 GET)
- [ ] Change passphrase on legacy (v1) locker — downloads, re-encrypts, re-uploads as before
- [ ] Replace file on existing locker — new DEK generated, `wrapped_file_key` updated
- [ ] Create a text locker — unchanged flow works