### PR TITLE
fix(publish): remove registry-url from setup-node to unblock OIDC tru…

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install crypto dependencies
         working-directory: tools/flashview-crypto


### PR DESCRIPTION
…sted publishing

When registry-url is set in setup-node, it writes an .npmrc with an empty _authToken that npm sends to the registry instead of performing the OIDC token exchange, causing a 404 on publish. With trusted publishing configured, registry-url is not needed — publishConfig in package.json handles access and the default registry is npmjs.org.