### PR TITLE
feat(locker): replace static HMAC auth token with ECDSA challenge-response signing

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Locker\CheckoutLockerRequest;
 use App\Http\Requests\Locker\RenewLockerRequest;
 use App\Http\Requests\Locker\StoreLockerRequest;
+use App\Http\Requests\Locker\UnlockLockerRequest;
 use App\Http\Requests\Locker\UpdateLockerRequest;
+use App\Http\Requests\Locker\UpgradeAuthLockerRequest;
 use App\Models\Locker;
 use App\Models\LockerCredit;
 use App\Models\LockerPlan;
@@ -208,7 +210,7 @@ class LockerController extends Controller
         return response()->json(['challenge' => $challenge]);
     }
 
-    public function unlock(Request $request, string $accountId): JsonResponse
+    public function unlock(UnlockLockerRequest $request, string $accountId): JsonResponse
     {
         $ip = $request->ip();
 
@@ -237,11 +239,6 @@ class LockerController extends Controller
 
         if ($locker->public_key !== null) {
             // ECDSA path
-            $request->validate([
-                'challenge_id' => ['required', 'string', 'uuid'],
-                'signature' => ['required', 'string'],
-            ]);
-
             $challengeHex = $this->ecdsaService->consumeChallenge(
                 $request->input('challenge_id'),
                 $accountId
@@ -256,7 +253,6 @@ class LockerController extends Controller
             }
         } else {
             // Legacy HMAC path
-            $request->validate(['verifier' => ['required', 'string', 'size:64']]);
             $verified = $locker->verifyAuthVerifier($request->input('verifier'));
         }
 
@@ -528,13 +524,8 @@ class LockerController extends Controller
         return response()->json(['checkout_url' => $session->url]);
     }
 
-    public function upgradeAuth(Request $request, string $accountId): JsonResponse
+    public function upgradeAuth(UpgradeAuthLockerRequest $request, string $accountId): JsonResponse
     {
-        $request->validate([
-            'verifier' => ['required', 'string', 'size:64'],
-            'public_key' => ['required', 'string'],
-        ]);
-
         $locker = Locker::where('account_id', $accountId)->first();
         if (! $locker) {
             abort(404);

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\Locker\UpdateLockerRequest;
 use App\Models\Locker;
 use App\Models\LockerCredit;
 use App\Models\LockerPlan;
+use App\Services\LockerEcdsaService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -24,6 +25,8 @@ use Stripe\Exception\ApiErrorException;
 
 class LockerController extends Controller
 {
+    public function __construct(public LockerEcdsaService $ecdsaService) {}
+
     public function index(Request $request): Response
     {
         return Inertia::render('Locker/Index');
@@ -103,7 +106,6 @@ class LockerController extends Controller
     public function create(Request $request): Response
     {
         $token = $request->query('token');
-
         $credit = LockerCredit::where('token', $token)->unused()->first();
 
         if (! $credit) {
@@ -121,16 +123,23 @@ class LockerController extends Controller
     {
         $credit = LockerCredit::where('token', $request->input('credit_token'))->unused()->firstOrFail();
 
-        $locker = Locker::create([
+        $lockerData = [
             'account_id' => $request->input('account_id'),
             'payload' => $request->input('payload'),
             'storage_path' => $request->input('storage_path'),
             'wrapped_file_key' => $request->input('wrapped_file_key'),
-            'auth_challenge' => $request->input('auth_challenge'),
-            'auth_verifier' => $request->input('auth_verifier'),
-            'update_token_hash' => hash('sha256', $request->input('update_token')),
             'expires_at' => now()->addYears($credit->years),
-        ]);
+        ];
+
+        if ($request->filled('public_key')) {
+            $lockerData['public_key'] = $request->input('public_key');
+        } else {
+            $lockerData['auth_challenge'] = $request->input('auth_challenge');
+            $lockerData['auth_verifier'] = $request->input('auth_verifier');
+            $lockerData['update_token_hash'] = hash('sha256', $request->input('update_token'));
+        }
+
+        $locker = Locker::create($lockerData);
 
         $credit->update([
             'locker_id' => $locker->id,
@@ -145,8 +154,6 @@ class LockerController extends Controller
 
     public function prepareFile(Request $request): JsonResponse
     {
-        // If a credit_token is provided, validate it (creation flow).
-        // If not (update flow for an existing file locker), skip credit check.
         $creditToken = $request->input('credit_token');
         if ($creditToken) {
             $credit = LockerCredit::where('token', $creditToken)->unused()->where('tier', 'file')->first();
@@ -173,8 +180,6 @@ class LockerController extends Controller
 
     public function show(Request $request, string $accountId): Response
     {
-        // Always render — never reveal whether an account ID exists.
-        // The unlock endpoint is the only place credentials are validated.
         return Inertia::render('Locker/Show', [
             'account_id' => $accountId,
             'renewed' => $request->query('renewed') === '1',
@@ -191,7 +196,13 @@ class LockerController extends Controller
 
         $locker = Locker::where('account_id', $accountId)->first();
 
-        // Always return a challenge — fake one for non-existent accounts to prevent enumeration.
+        if ($locker && $locker->public_key !== null) {
+            $data = $this->ecdsaService->issueChallenge($accountId);
+
+            return response()->json($data);
+        }
+
+        // Legacy locker or non-existent account — always return a challenge to prevent enumeration.
         $challenge = $locker ? $locker->auth_challenge : bin2hex(random_bytes(32));
 
         return response()->json(['challenge' => $challenge]);
@@ -199,10 +210,7 @@ class LockerController extends Controller
 
     public function unlock(Request $request, string $accountId): JsonResponse
     {
-        $request->validate(['verifier' => ['required', 'string', 'size:64']]);
-
         $ip = $request->ip();
-        $verifier = $request->input('verifier');
 
         if (RateLimiter::tooManyAttempts('locker-ip:'.$ip, 3)) {
             return response()->json(['error' => 'Too many failed attempts. Try again in 1 hour.'], 429);
@@ -212,7 +220,7 @@ class LockerController extends Controller
 
         if (! $locker) {
             RateLimiter::hit('locker-ip:'.$ip, 3600);
-            usleep(random_int(80_000, 200_000)); // timing-safe delay
+            usleep(random_int(80_000, 200_000));
 
             return response()->json(['error' => 'Credentials do not match.'], 401);
         }
@@ -225,7 +233,34 @@ class LockerController extends Controller
             return response()->json(['error' => 'Too many attempts. Please wait 5 minutes before trying again.'], 429);
         }
 
-        if (! $locker->verifyAuthVerifier($verifier)) {
+        $verified = false;
+
+        if ($locker->public_key !== null) {
+            // ECDSA path
+            $request->validate([
+                'challenge_id' => ['required', 'string', 'uuid'],
+                'signature' => ['required', 'string'],
+            ]);
+
+            $challengeHex = $this->ecdsaService->consumeChallenge(
+                $request->input('challenge_id'),
+                $accountId
+            );
+
+            if ($challengeHex !== null) {
+                $verified = $this->ecdsaService->verify(
+                    $locker->public_key,
+                    $challengeHex,
+                    $request->input('signature')
+                );
+            }
+        } else {
+            // Legacy HMAC path
+            $request->validate(['verifier' => ['required', 'string', 'size:64']]);
+            $verified = $locker->verifyAuthVerifier($request->input('verifier'));
+        }
+
+        if (! $verified) {
             RateLimiter::clear('locker-account-cooldown:'.$accountId);
             RateLimiter::hit('locker-account-cooldown:'.$accountId, 300);
             RateLimiter::hit('locker-account-lock:'.$accountId, 3600);
@@ -236,12 +271,10 @@ class LockerController extends Controller
             return response()->json(['error' => 'Credentials do not match.'], 401);
         }
 
-        // Correct passphrase but expired — safe to reveal now
         if ($locker->isExpired()) {
             return response()->json(['error' => 'This locker has expired and is no longer accessible.'], 410);
         }
 
-        // Success — clear failure state
         RateLimiter::clear('locker-account-lock:'.$accountId);
         RateLimiter::clear('locker-account-cooldown:'.$accountId);
 
@@ -296,18 +329,35 @@ class LockerController extends Controller
             abort(410);
         }
 
-        $updateToken = $request->header('X-Update-Token');
+        $verified = false;
 
-        if (! $updateToken || ! $locker->verifyUpdateToken($updateToken)) {
-            return response()->json(['error' => 'Invalid update token.'], 403);
+        if ($locker->public_key !== null) {
+            // ECDSA path
+            $challengeId = $request->header('X-Signing-Challenge-Id');
+            $signature = $request->header('X-Signature');
+
+            if ($challengeId && $signature) {
+                $challengeHex = $this->ecdsaService->consumeChallenge($challengeId, $accountId);
+                if ($challengeHex !== null) {
+                    $verified = $this->ecdsaService->verify($locker->public_key, $challengeHex, $signature);
+                }
+            }
+        } else {
+            // Legacy path
+            $updateToken = $request->header('X-Update-Token');
+            if ($updateToken) {
+                $verified = $locker->verifyUpdateToken($updateToken);
+            }
+        }
+
+        if (! $verified) {
+            return response()->json(['error' => 'Invalid credentials.'], 403);
         }
 
         $updates = [
             'payload' => $request->input('payload'),
         ];
 
-        // Only update storage_path when it is explicitly present in the request body.
-        // Omitting it (passphrase-change only) must never null the column or trigger S3 deletion.
         if ($request->has('storage_path')) {
             $newStoragePath = $request->input('storage_path');
             if ($locker->isFileLocker() && $locker->storage_path && $locker->storage_path !== $newStoragePath) {
@@ -320,9 +370,17 @@ class LockerController extends Controller
             $updates['storage_path'] = $newStoragePath;
         }
 
-        if ($request->filled('new_auth_verifier') && $request->filled('new_update_token')) {
-            $updates['auth_verifier'] = $request->input('new_auth_verifier');
-            $updates['update_token_hash'] = hash('sha256', $request->input('new_update_token'));
+        if ($locker->public_key !== null) {
+            // ECDSA passphrase change: update public key when provided
+            if ($request->filled('new_public_key')) {
+                $updates['public_key'] = $request->input('new_public_key');
+            }
+        } else {
+            // Legacy passphrase change: update verifier and token hash
+            if ($request->filled('new_auth_verifier') && $request->filled('new_update_token')) {
+                $updates['auth_verifier'] = $request->input('new_auth_verifier');
+                $updates['update_token_hash'] = hash('sha256', $request->input('new_update_token'));
+            }
         }
 
         if ($request->filled('new_wrapped_file_key')) {
@@ -342,10 +400,27 @@ class LockerController extends Controller
             abort(404);
         }
 
-        $updateToken = $request->header('X-Update-Token');
+        $verified = false;
 
-        if (! $updateToken || ! $locker->verifyUpdateToken($updateToken)) {
-            return response()->json(['error' => 'Invalid update token.'], 403);
+        if ($locker->public_key !== null) {
+            $challengeId = $request->header('X-Signing-Challenge-Id');
+            $signature = $request->header('X-Signature');
+
+            if ($challengeId && $signature) {
+                $challengeHex = $this->ecdsaService->consumeChallenge($challengeId, $accountId);
+                if ($challengeHex !== null) {
+                    $verified = $this->ecdsaService->verify($locker->public_key, $challengeHex, $signature);
+                }
+            }
+        } else {
+            $updateToken = $request->header('X-Update-Token');
+            if ($updateToken) {
+                $verified = $locker->verifyUpdateToken($updateToken);
+            }
+        }
+
+        if (! $verified) {
+            return response()->json(['error' => 'Invalid credentials.'], 403);
         }
 
         if ($locker->isFileLocker()) {
@@ -370,6 +445,12 @@ class LockerController extends Controller
         }
 
         if ($request->wantsJson()) {
+            if ($locker->public_key !== null) {
+                $data = $this->ecdsaService->issueChallenge($accountId);
+
+                return response()->json($data);
+            }
+
             return response()->json(['challenge' => $locker->auth_challenge]);
         }
 
@@ -388,7 +469,26 @@ class LockerController extends Controller
             return response()->json(['error' => 'Locker not found.'], 404);
         }
 
-        if (! $locker->verifyAuthVerifier($request->input('verifier'))) {
+        $verified = false;
+
+        if ($locker->public_key !== null) {
+            $challengeHex = $this->ecdsaService->consumeChallenge(
+                $request->input('challenge_id'),
+                $accountId
+            );
+
+            if ($challengeHex !== null) {
+                $verified = $this->ecdsaService->verify(
+                    $locker->public_key,
+                    $challengeHex,
+                    $request->input('signature')
+                );
+            }
+        } else {
+            $verified = $locker->verifyAuthVerifier($request->input('verifier'));
+        }
+
+        if (! $verified) {
             return response()->json(['error' => 'Invalid passphrase.'], 403);
         }
 
@@ -426,5 +526,49 @@ class LockerController extends Controller
         }
 
         return response()->json(['checkout_url' => $session->url]);
+    }
+
+    public function upgradeAuth(Request $request, string $accountId): JsonResponse
+    {
+        $request->validate([
+            'verifier' => ['required', 'string', 'size:64'],
+            'public_key' => ['required', 'string'],
+        ]);
+
+        $locker = Locker::where('account_id', $accountId)->first();
+        if (! $locker) {
+            abort(404);
+        }
+        if ($locker->isExpired()) {
+            abort(410);
+        }
+
+        // Idempotent: already upgraded
+        if ($locker->public_key !== null) {
+            return response()->json(['ok' => true]);
+        }
+
+        // Apply the same account-level rate limiter as unlock() — prevents brute-force
+        // against the verifier via this endpoint bypassing unlock's protections.
+        if (RateLimiter::tooManyAttempts('locker-account-lock:'.$accountId, 3)) {
+            return response()->json(['error' => 'Too many failed attempts. Try again in 1 hour. Your locker is unchanged.'], 429);
+        }
+
+        if (! $locker->verifyAuthVerifier($request->input('verifier'))) {
+            RateLimiter::hit('locker-account-lock:'.$accountId, 3600);
+
+            return response()->json(['error' => 'Invalid passphrase.'], 403);
+        }
+
+        RateLimiter::clear('locker-account-lock:'.$accountId);
+
+        $locker->update([
+            'public_key' => $request->input('public_key'),
+            'auth_challenge' => null,
+            'auth_verifier' => null,
+            'update_token_hash' => null,
+        ]);
+
+        return response()->json(['ok' => true]);
     }
 }

--- a/app/Http/Requests/Locker/RenewLockerRequest.php
+++ b/app/Http/Requests/Locker/RenewLockerRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Locker;
 
+use App\Models\Locker;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -17,8 +18,13 @@ class RenewLockerRequest extends FormRequest
      */
     public function rules(): array
     {
+        $locker = Locker::where('account_id', $this->route('accountId'))->first();
+        $isEcdsa = $locker && $locker->public_key !== null;
+
         return [
-            'verifier' => ['required', 'string', 'size:64'],
+            'challenge_id' => $isEcdsa ? ['required', 'string', 'uuid'] : ['nullable'],
+            'signature' => $isEcdsa ? ['required', 'string'] : ['nullable'],
+            'verifier' => $isEcdsa ? ['nullable'] : ['required', 'string', 'size:64'],
             'years' => ['required', 'integer', 'in:1,3,5'],
             'tier' => ['required', 'in:text,file'],
         ];

--- a/app/Http/Requests/Locker/StoreLockerRequest.php
+++ b/app/Http/Requests/Locker/StoreLockerRequest.php
@@ -19,14 +19,16 @@ class StoreLockerRequest extends FormRequest
     public function rules(): array
     {
         $maxHexLength = config('lockers.limits.text_max_bytes') * 2 + 92 + 32;
+        $isEcdsa = $this->filled('public_key');
 
         return [
             'account_id' => ['required', 'string', 'size:10', 'regex:/^\d{10}$/', 'unique:lockers,account_id'],
             'credit_token' => ['required', 'string', 'exists:locker_credits,token'],
             'payload' => ['required', 'string', "max:{$maxHexLength}"],
-            'auth_challenge' => ['required', 'string', 'size:64'],
-            'auth_verifier' => ['required', 'string', 'size:64'],
-            'update_token' => ['required', 'string', 'size:64'],
+            'public_key' => ['nullable', 'string'],
+            'auth_challenge' => $isEcdsa ? ['nullable'] : ['required', 'string', 'size:64'],
+            'auth_verifier' => $isEcdsa ? ['nullable'] : ['required', 'string', 'size:64'],
+            'update_token' => $isEcdsa ? ['nullable'] : ['required', 'string', 'size:64'],
             'tier' => ['required', 'in:text,file'],
             'storage_path' => ['required_if:tier,file', 'nullable', 'string'],
             'wrapped_file_key' => ['nullable', 'string', 'max:512'],

--- a/app/Http/Requests/Locker/UnlockLockerRequest.php
+++ b/app/Http/Requests/Locker/UnlockLockerRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Locker;
+
+use App\Models\Locker;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UnlockLockerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $locker = Locker::where('account_id', $this->route('accountId'))->first();
+        $isEcdsa = $locker && $locker->public_key !== null;
+
+        return [
+            'challenge_id' => $isEcdsa ? ['required', 'string', 'uuid'] : ['nullable'],
+            'signature' => $isEcdsa ? ['required', 'string'] : ['nullable'],
+            'verifier' => $isEcdsa ? ['nullable'] : ['required', 'string', 'size:64'],
+        ];
+    }
+}

--- a/app/Http/Requests/Locker/UpdateLockerRequest.php
+++ b/app/Http/Requests/Locker/UpdateLockerRequest.php
@@ -25,6 +25,7 @@ class UpdateLockerRequest extends FormRequest
             'new_auth_verifier' => ['nullable', 'string', 'size:64'],
             'new_update_token' => ['nullable', 'string', 'size:64'],
             'new_wrapped_file_key' => ['nullable', 'string', 'max:512'],
+            'new_public_key' => ['nullable', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Locker/UpgradeAuthLockerRequest.php
+++ b/app/Http/Requests/Locker/UpgradeAuthLockerRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Locker;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpgradeAuthLockerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'verifier' => ['required', 'string', 'size:64'],
+            'public_key' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -20,6 +20,7 @@ class Locker extends Model
         'auth_challenge',
         'auth_verifier',
         'update_token_hash',
+        'public_key',
         'expires_at',
     ];
 
@@ -60,6 +61,10 @@ class Locker extends Model
 
     public function verifyAuthVerifier(string $verifier): bool
     {
+        if ($this->auth_verifier === null) {
+            return false;
+        }
+
         return hash_equals($this->auth_verifier, $verifier);
     }
 }

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -56,6 +56,10 @@ class Locker extends Model
 
     public function verifyUpdateToken(string $token): bool
     {
+        if ($this->update_token_hash === null) {
+            return false;
+        }
+
         return hash_equals($this->update_token_hash, hash('sha256', $token));
     }
 

--- a/app/Services/LockerEcdsaService.php
+++ b/app/Services/LockerEcdsaService.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class LockerEcdsaService
+{
+    public function issueChallenge(string $accountId): array
+    {
+        $challengeHex = bin2hex(random_bytes(32));
+        $challengeId = Str::uuid()->toString();
+        Cache::put(
+            "locker-signing-challenge:{$challengeId}",
+            ['account_id' => $accountId, 'challenge' => $challengeHex],
+            60
+        );
+
+        return ['challenge_id' => $challengeId, 'challenge' => $challengeHex];
+    }
+
+    public function consumeChallenge(string $challengeId, string $expectedAccountId): ?string
+    {
+        // Cache::pull() is atomic get+delete — prevents replay under concurrent requests (Octane)
+        $data = Cache::pull("locker-signing-challenge:{$challengeId}");
+        if (! $data || $data['account_id'] !== $expectedAccountId) {
+            return null;
+        }
+
+        return $data['challenge'];
+    }
+
+    public function verify(string $publicKeyJwkBase64, string $challengeHex, string $signatureBase64): bool
+    {
+        try {
+            $pem = $this->publicKeyToPem($publicKeyJwkBase64);
+        } catch (\Throwable) {
+            return false;
+        }
+        $pubKey = openssl_pkey_get_public($pem);
+        if (! $pubKey) {
+            return false;
+        }
+
+        $sigDer = $this->p1363ToDer(base64_decode($signatureBase64));
+        $message = hex2bin($challengeHex);
+
+        return openssl_verify($message, $sigDer, $pubKey, OPENSSL_ALGO_SHA256) === 1;
+    }
+
+    public function publicKeyToPem(string $jwkBase64): string
+    {
+        $jwk = json_decode(base64_decode($jwkBase64), true);
+        if (! is_array($jwk) || ! isset($jwk['x'], $jwk['y'])) {
+            throw new \InvalidArgumentException('Invalid JWK: missing x or y coordinates');
+        }
+        $x = $this->base64urlToBytes($jwk['x']);
+        $y = $this->base64urlToBytes($jwk['y']);
+
+        // Pad x and y to 32 bytes
+        $x = str_pad($x, 32, "\x00", STR_PAD_LEFT);
+        $y = str_pad($y, 32, "\x00", STR_PAD_LEFT);
+
+        $uncompressed = "\x04".$x.$y;
+
+        // OID for id-ecPublicKey: 1.2.840.10045.2.1
+        $ecPubKeyOid = "\x06\x07\x2a\x86\x48\xce\x3d\x02\x01";
+        // OID for P-256 (secp256r1 / prime256v1): 1.2.840.10045.3.1.7
+        $p256Oid = "\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07";
+
+        $algorithmIdentifier = "\x30".chr(strlen($ecPubKeyOid) + strlen($p256Oid))
+            .$ecPubKeyOid.$p256Oid;
+        $bitString = "\x03".chr(strlen($uncompressed) + 1)."\x00".$uncompressed;
+        $spki = "\x30".chr(strlen($algorithmIdentifier) + strlen($bitString))
+            .$algorithmIdentifier.$bitString;
+
+        return "-----BEGIN PUBLIC KEY-----\n"
+            .chunk_split(base64_encode($spki), 64, "\n")
+            ."-----END PUBLIC KEY-----\n";
+    }
+
+    public function p1363ToDer(string $p1363): string
+    {
+        // P1363 = 64 bytes: 32 bytes r || 32 bytes s
+        $r = substr($p1363, 0, 32);
+        $s = substr($p1363, 32, 32);
+
+        $r = ltrim($r, "\x00");
+        if ($r === '') {
+            $r = "\x00";
+        }
+        if (ord($r[0]) > 0x7F) {
+            $r = "\x00".$r;
+        }
+
+        $s = ltrim($s, "\x00");
+        if ($s === '') {
+            $s = "\x00";
+        }
+        if (ord($s[0]) > 0x7F) {
+            $s = "\x00".$s;
+        }
+
+        $intR = "\x02".chr(strlen($r)).$r;
+        $intS = "\x02".chr(strlen($s)).$s;
+        $seq = $intR.$intS;
+
+        return "\x30".chr(strlen($seq)).$seq;
+    }
+
+    private function base64urlToBytes(string $base64url): string
+    {
+        $base64 = strtr($base64url, '-_', '+/');
+        $pad = strlen($base64) % 4;
+        if ($pad) {
+            $base64 .= str_repeat('=', 4 - $pad);
+        }
+
+        return base64_decode($base64);
+    }
+}

--- a/database/factories/LockerFactory.php
+++ b/database/factories/LockerFactory.php
@@ -36,4 +36,22 @@ class LockerFactory extends Factory
             'storage_path' => 'lockers/'.$attributes['account_id'].'/payload',
         ]);
     }
+
+    public function ecdsa(): static
+    {
+        return $this->state(function (array $attributes) {
+            $key = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
+            $details = openssl_pkey_get_details($key);
+            $ecPoint = $details['ec'];
+            $toBase64url = fn ($b) => rtrim(strtr(base64_encode($b), '+/', '-_'), '=');
+            $jwk = ['kty' => 'EC', 'crv' => 'P-256', 'x' => $toBase64url($ecPoint['x']), 'y' => $toBase64url($ecPoint['y'])];
+
+            return [
+                'public_key' => base64_encode(json_encode($jwk)),
+                'auth_challenge' => null,
+                'auth_verifier' => null,
+                'update_token_hash' => null,
+            ];
+        });
+    }
 }

--- a/database/migrations/2026_06_03_113930_add_public_key_to_lockers_table.php
+++ b/database/migrations/2026_06_03_113930_add_public_key_to_lockers_table.php
@@ -22,6 +22,9 @@ return new class extends Migration
 
     public function down(): void
     {
+        // WARNING: Restoring NOT NULL constraints will fail if any ECDSA lockers
+        // exist (they have NULL in these columns). Only run this rollback before
+        // any ECDSA lockers have been created, or after deleting/backfilling them.
         Schema::table('lockers', function (Blueprint $table) {
             $table->dropColumn('public_key');
             $table->string('auth_challenge', 64)->nullable(false)->change();

--- a/database/migrations/2026_06_03_113930_add_public_key_to_lockers_table.php
+++ b/database/migrations/2026_06_03_113930_add_public_key_to_lockers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            // Use text (not longText) — JWK base64 is ~500 chars, well within text limit
+            $table->text('public_key')->nullable()->after('update_token_hash');
+
+            // Make legacy auth columns nullable — ECDSA lockers don't populate these.
+            // Without this, store() throws a DB integrity violation for new ECDSA lockers.
+            $table->string('auth_challenge', 64)->nullable()->change();
+            $table->string('auth_verifier', 64)->nullable()->change();
+            $table->string('update_token_hash', 64)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->dropColumn('public_key');
+            $table->string('auth_challenge', 64)->nullable(false)->change();
+            $table->string('auth_verifier', 64)->nullable(false)->change();
+            $table->string('update_token_hash', 64)->nullable(false)->change();
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "onetimesecret",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -630,6 +630,33 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4409,6 +4436,7 @@
             "name": "@pioneer-dynamics/flashview-crypto",
             "version": "2.0.0",
             "dependencies": {
+                "@noble/curves": "^1.9.7",
                 "random-words": "^2.0.0"
             },
             "engines": {

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -103,10 +103,7 @@ const submit = async () => {
     uploadProgress.value = 0;
 
     try {
-        const authKey     = await enc.deriveLockerAuthKey(passphrase.value, accountId.value);
-        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, accountId.value);
-        const challengeHex = enc.generateLockerChallenge();
-        const verifier    = await enc.computeLockerVerifier(authKey, challengeHex);
+        const { privateKey: _unusedKey, publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(passphrase.value, accountId.value);
 
         let payload;
         let storagePath = null;
@@ -176,9 +173,7 @@ const submit = async () => {
                 account_id:       accountId.value,
                 credit_token:     props.credit_token,
                 payload,
-                auth_challenge:   challengeHex,
-                auth_verifier:    verifier,
-                update_token:     updateToken,
+                public_key:       publicKeyJwkBase64,
                 tier:             props.tier,
                 storage_path:     storagePath,
                 wrapped_file_key: wrappedFileKey,

--- a/resources/js/Pages/Locker/Renew.vue
+++ b/resources/js/Pages/Locker/Renew.vue
@@ -38,12 +38,21 @@ const submit = async () => {
             return;
         }
 
-        const { challenge } = await challengeRes.json();
-
-        const authKey = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
-        const verifier = await enc.computeLockerVerifier(authKey, challenge);
+        const challengeData = await challengeRes.json();
+        const isEcdsa = Boolean(challengeData.challenge_id);
 
         const xsrf = decodeURIComponent(document.cookie.match(/XSRF-TOKEN=([^;]+)/)?.[1] ?? '');
+
+        let renewBody;
+        if (isEcdsa) {
+            const { privateKey } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+            const signature = await enc.signLockerChallenge(privateKey, challengeData.challenge);
+            renewBody = { challenge_id: challengeData.challenge_id, signature, years: years.value, tier: props.tier };
+        } else {
+            const authKey = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
+            const verifier = await enc.computeLockerVerifier(authKey, challengeData.challenge);
+            renewBody = { verifier, years: years.value, tier: props.tier };
+        }
 
         const renewRes = await fetch(route('lockers.renew.purchase', props.account_id), {
             method: 'POST',
@@ -52,11 +61,7 @@ const submit = async () => {
                 'Accept': 'application/json',
                 'X-XSRF-TOKEN': xsrf,
             },
-            body: JSON.stringify({
-                verifier,
-                years: years.value,
-                tier:  props.tier,
-            }),
+            body: JSON.stringify(renewBody),
         });
 
         const data = await renewRes.json();

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -18,6 +18,13 @@ const expiresAt      = ref(null); // ISO string or null
 const authChallenge  = ref('');
 const wrappedFileKey = ref('');  // base64 KEK-wrapped DEK; empty for legacy lockers
 
+// ECDSA / upgrade state
+const isLegacyLocker   = ref(false);
+const upgrading        = ref(false);
+const upgradeSuccess   = ref(false);
+const upgradeDismissed = ref(false);
+const upgradeError     = ref('');
+
 // Unlock state
 const passphrase        = ref('');
 const lockState         = ref('locked'); // 'locked' | 'animating' | 'unlocked' | 'shaking'
@@ -88,6 +95,11 @@ const lockLocker = () => {
     newPassphrase.value       = '';
     deleteError.value         = '';
     showDeleteConfirm.value   = false;
+    isLegacyLocker.value      = false;
+    upgrading.value           = false;
+    upgradeSuccess.value      = false;
+    upgradeDismissed.value    = false;
+    upgradeError.value        = '';
     lockState.value           = 'locked';
 };
 
@@ -136,11 +148,21 @@ const unlock = async () => {
             return;
         }
 
-        const { challenge } = await challengeRes.json();
+        const challengeData = await challengeRes.json();
+        const isEcdsa = Boolean(challengeData.challenge_id);
 
-        // Step 2: Derive verifier from passphrase (never send passphrase to server)
-        const authKey  = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
-        const verifier = await enc.computeLockerVerifier(authKey, challenge);
+        let unlockBody;
+        if (isEcdsa) {
+            // ECDSA path: derive private key, sign the server challenge
+            const { privateKey } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+            const signature = await enc.signLockerChallenge(privateKey, challengeData.challenge);
+            unlockBody = { challenge_id: challengeData.challenge_id, signature };
+        } else {
+            // Legacy HMAC path: derive verifier from passphrase
+            const authKey  = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
+            const verifier = await enc.computeLockerVerifier(authKey, challengeData.challenge);
+            unlockBody = { verifier };
+        }
 
         // Step 3: POST unlock — server verifies, returns payload only if correct
         const unlockRes = await fetch(route('lockers.unlock', props.account_id), {
@@ -150,7 +172,7 @@ const unlock = async () => {
                 'Accept': 'application/json',
                 'X-XSRF-TOKEN': getXsrf(),
             },
-            body: JSON.stringify({ verifier }),
+            body: JSON.stringify(unlockBody),
         });
 
         const data = await unlockRes.json();
@@ -168,6 +190,7 @@ const unlock = async () => {
         expiresAt.value      = data.expires_at ?? null;
         authChallenge.value  = data.auth_challenge ?? '';
         wrappedFileKey.value = data.wrapped_file_key ?? '';
+        isLegacyLocker.value = !isEcdsa;
 
         const result = await enc.decryptLockerContent(data.payload, passphrase.value);
 
@@ -244,6 +267,26 @@ const downloadFile = async () => {
     }
 };
 
+const fetchSigningHeaders = async () => {
+    const challengeRes = await fetch(route('lockers.challenge', props.account_id), {
+        headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+    });
+    if (!challengeRes.ok) throw new Error('Could not fetch challenge.');
+    const challengeData = await challengeRes.json();
+
+    if (challengeData.challenge_id) {
+        const { privateKey } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+        const signature = await enc.signLockerChallenge(privateKey, challengeData.challenge);
+        return {
+            'X-Signing-Challenge-Id': challengeData.challenge_id,
+            'X-Signature': signature,
+        };
+    } else {
+        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        return { 'X-Update-Token': updateToken };
+    }
+};
+
 const submitUpdate = async () => {
     updateError.value   = '';
     updateSuccess.value = false;
@@ -251,16 +294,16 @@ const submitUpdate = async () => {
 
     updating.value = true;
     try {
-        const payload     = await enc.encryptLockerContent(newContent.value, passphrase.value);
-        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        const payload  = await enc.encryptLockerContent(newContent.value, passphrase.value);
+        const authHeaders = await fetchSigningHeaders();
 
         const res = await fetch(route('lockers.update', props.account_id), {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'X-Update-Token': updateToken,
                 'X-XSRF-TOKEN': getXsrf(),
+                ...authHeaders,
             },
             body: JSON.stringify({ payload }),
         });
@@ -271,8 +314,8 @@ const submitUpdate = async () => {
         updateSuccess.value = true;
         decryptedText.value = newContent.value;
         newContent.value    = '';
-    } catch {
-        updateError.value = 'Update failed. Please try again.';
+    } catch (err) {
+        updateError.value = err.message || 'Update failed. Please try again.';
     } finally {
         updating.value = false;
     }
@@ -323,7 +366,7 @@ const submitFileUpdate = async () => {
             });
         }
 
-        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        const authHeaders = await fetchSigningHeaders();
         const body = { payload };
         if (storagePath) {
             body.storage_path = storagePath;
@@ -332,7 +375,7 @@ const submitFileUpdate = async () => {
 
         const res = await fetch(route('lockers.update', props.account_id), {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': updateToken, 'X-XSRF-TOKEN': getXsrf() },
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
             body: JSON.stringify(body),
         });
 
@@ -369,16 +412,23 @@ const changePassphrase = async () => {
     passphraseChangeProgress.value = 0;
 
     try {
-        const newAuthKey      = await enc.deriveLockerAuthKey(newPassphrase.value, props.account_id);
-        const newVerifier     = await enc.computeLockerVerifier(newAuthKey, authChallenge.value);
-        const newUpdateToken  = await enc.deriveLockerUpdateToken(newPassphrase.value, props.account_id);
-        const oldUpdateToken  = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        const authHeaders = await fetchSigningHeaders();
 
         let newPayload;
-        const putBody = {
-            new_auth_verifier: newVerifier,
-            new_update_token: newUpdateToken,
-        };
+        const putBody = {};
+
+        // ECDSA lockers: register new public key derived from new passphrase
+        if (!isLegacyLocker.value) {
+            const { publicKeyJwkBase64: newPublicKey } = await enc.deriveLockerSigningKeypair(newPassphrase.value, props.account_id);
+            putBody.new_public_key = newPublicKey;
+        } else {
+            // Legacy lockers: update verifier + update token
+            const newAuthKey     = await enc.deriveLockerAuthKey(newPassphrase.value, props.account_id);
+            const newVerifier    = await enc.computeLockerVerifier(newAuthKey, authChallenge.value);
+            const newUpdateToken = await enc.deriveLockerUpdateToken(newPassphrase.value, props.account_id);
+            putBody.new_auth_verifier = newVerifier;
+            putBody.new_update_token  = newUpdateToken;
+        }
 
         if (isFileLocker.value && wrappedFileKey.value) {
             // New locker (v2): re-wrap DEK with new passphrase — no file download required
@@ -391,7 +441,7 @@ const changePassphrase = async () => {
 
             const res = await fetch(route('lockers.update', props.account_id), {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
                 body: JSON.stringify(putBody),
             });
 
@@ -449,7 +499,7 @@ const changePassphrase = async () => {
 
             const res = await fetch(route('lockers.update', props.account_id), {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
                 body: JSON.stringify(putBody),
             });
 
@@ -467,7 +517,7 @@ const changePassphrase = async () => {
 
             const res = await fetch(route('lockers.update', props.account_id), {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Update-Token': oldUpdateToken, 'X-XSRF-TOKEN': getXsrf() },
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
                 body: JSON.stringify(putBody),
             });
 
@@ -490,14 +540,14 @@ const confirmDelete = async () => {
     deleteError.value = '';
     deleting.value    = true;
     try {
-        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        const authHeaders = await fetchSigningHeaders();
 
         const res = await fetch(route('lockers.destroy', props.account_id), {
             method: 'DELETE',
             headers: {
                 'Accept': 'application/json',
-                'X-Update-Token': updateToken,
                 'X-XSRF-TOKEN': getXsrf(),
+                ...authHeaders,
             },
         });
 
@@ -511,6 +561,33 @@ const confirmDelete = async () => {
         deleting.value = false;
     }
 };
+
+const upgradeAuth = async () => {
+    upgrading.value     = true;
+    upgradeError.value  = '';
+    try {
+        const authKey  = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
+        const verifier = await enc.computeLockerVerifier(authKey, authChallenge.value);
+        const { publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+
+        const res = await fetch(route('lockers.upgrade-auth', props.account_id), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf() },
+            body: JSON.stringify({ verifier, public_key: publicKeyJwkBase64 }),
+        });
+        const data = await res.json();
+        if (res.status === 429) { upgradeError.value = data.error ?? 'Too many failed attempts. Try again in 1 hour. Your locker is unchanged.'; return; }
+        if (!res.ok) { upgradeError.value = data.error ?? 'Upgrade failed.'; return; }
+
+        isLegacyLocker.value = false;
+        upgradeSuccess.value = true;
+        setTimeout(() => { upgradeSuccess.value = false; }, 4000);
+    } catch {
+        upgradeError.value = 'Upgrade failed. Please try again.';
+    } finally {
+        upgrading.value = false;
+    }
+};
 </script>
 
 <template>
@@ -521,6 +598,39 @@ const confirmDelete = async () => {
                 <!-- Renewal banner -->
                 <div v-if="renewed" class="bg-gamboge-300/10 border border-gamboge-300/40 rounded-xl p-4 text-gamboge-300 text-sm text-center">
                     Payment received — your expiry date will update within a few minutes.
+                </div>
+
+                <!-- Upgrade success banner -->
+                <div
+                    v-if="upgradeSuccess"
+                    class="bg-gamboge-300/10 border border-gamboge-300/40 rounded-xl p-4 text-gamboge-300 text-sm text-center"
+                >
+                    Your locker has been upgraded to stronger security.
+                </div>
+
+                <!-- Upgrade banner — visible after legacy unlock, dismissable -->
+                <div
+                    v-if="lockState === 'unlocked' && isLegacyLocker && !upgradeSuccess && !upgradeDismissed"
+                    class="bg-gamboge-300/10 border border-gamboge-300/40 rounded-xl p-4 flex items-start justify-between gap-4"
+                >
+                    <div class="text-sm text-gamboge-300">
+                        <p class="font-semibold mb-1">Security upgrade available</p>
+                        <p class="text-gamboge-300/70 text-xs">This locker uses an older security scheme. Upgrade it for stronger protection — takes a moment and requires no passphrase change.</p>
+                        <p v-if="upgradeError" class="text-red-400 text-xs mt-1">{{ upgradeError }}</p>
+                    </div>
+                    <div class="flex items-center gap-2 shrink-0">
+                        <button
+                            @click="upgradeAuth"
+                            :disabled="upgrading"
+                            class="border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-xs px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
+                        >{{ upgrading ? 'Upgrading…' : 'Upgrade' }}</button>
+                        <button
+                            @click="upgradeDismissed = true"
+                            :disabled="upgrading"
+                            class="text-gamboge-300/50 hover:text-gamboge-300 font-mono text-xs px-2 py-1.5 transition-colors disabled:opacity-50"
+                            title="Dismiss"
+                        >✕</button>
+                    </div>
                 </div>
 
                 <!-- Locker header -->

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -603,6 +603,7 @@ const upgradeAuth = async () => {
                 <!-- Upgrade success banner -->
                 <div
                     v-if="upgradeSuccess"
+                    data-testid="upgrade-success"
                     class="bg-gamboge-300/10 border border-gamboge-300/40 rounded-xl p-4 text-gamboge-300 text-sm text-center"
                 >
                     Your locker has been upgraded to stronger security.
@@ -611,6 +612,7 @@ const upgradeAuth = async () => {
                 <!-- Upgrade banner — visible after legacy unlock, dismissable -->
                 <div
                     v-if="lockState === 'unlocked' && isLegacyLocker && !upgradeSuccess && !upgradeDismissed"
+                    data-testid="upgrade-banner"
                     class="bg-gamboge-300/10 border border-gamboge-300/40 rounded-xl p-4 flex items-start justify-between gap-4"
                 >
                     <div class="text-sm text-gamboge-300">
@@ -622,11 +624,13 @@ const upgradeAuth = async () => {
                         <button
                             @click="upgradeAuth"
                             :disabled="upgrading"
+                            data-testid="upgrade-button"
                             class="border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-xs px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
                         >{{ upgrading ? 'Upgrading…' : 'Upgrade' }}</button>
                         <button
                             @click="upgradeDismissed = true"
                             :disabled="upgrading"
+                            data-testid="upgrade-dismiss-button"
                             class="text-gamboge-300/50 hover:text-gamboge-300 font-mono text-xs px-2 py-1.5 transition-colors disabled:opacity-50"
                             title="Dismiss"
                         >✕</button>

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -651,6 +651,7 @@ const upgradeAuth = async () => {
                         <button
                             v-if="lockState === 'unlocked'"
                             @click="lockLocker"
+                            data-testid="lock-button"
                             class="flex items-center gap-1.5 border border-gray-600 hover:border-gray-400 text-gray-400 hover:text-white font-mono text-xs px-3 py-1.5 rounded-lg transition-colors"
                             title="Lock locker"
                         >

--- a/resources/js/encryption.js
+++ b/resources/js/encryption.js
@@ -5,6 +5,7 @@ import {
     encryptFileToBuffer, decryptFileFromBuffer,
     generateFileKey, wrapFileKey, unwrapFileKey,
     deriveAuthKey, computeVerifier, generateChallenge, deriveUpdateToken,
+    deriveSigningKeypair, signChallenge,
 } from '@pioneer-dynamics/flashview-crypto';
 export { LockerBlobVersionError, LockerDecryptionError } from '@pioneer-dynamics/flashview-crypto';
 
@@ -114,5 +115,13 @@ export class encryption {
 
     async deriveLockerUpdateToken(passphrase, accountId) {
         return deriveUpdateToken(passphrase, accountId);
+    }
+
+    async deriveLockerSigningKeypair(passphrase, accountId) {
+        return deriveSigningKeypair(passphrase, accountId);
+    }
+
+    async signLockerChallenge(privateKey, challengeHex) {
+        return signChallenge(privateKey, challengeHex);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -263,4 +263,6 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
         ->middleware('throttle:6,1')->name('renew.challenge');
     Route::post('/{accountId}/renew', [LockerController::class, 'renewPurchase'])
         ->middleware('throttle:6,1')->name('renew.purchase');
+    Route::post('/{accountId}/upgrade-auth', [LockerController::class, 'upgradeAuth'])
+        ->middleware('throttle:6,1')->name('upgrade-auth');
 });

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -590,4 +590,282 @@ class LockerControllerTest extends TestCase
         $this->assertEquals('freshWrappedKey', $locker->wrapped_file_key);
         $this->assertEquals($newStoragePath, $locker->storage_path);
     }
+
+    // ─── ECDSA Tests ─────────────────────────────────────────────────────────
+
+    /**
+     * Generate a real P-256 keypair for tests. Returns [publicKeyJwkBase64, privateKeyPem].
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function generateEcdsaKeypair(): array
+    {
+        $key = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
+        $details = openssl_pkey_get_details($key);
+        openssl_pkey_export($key, $privateKeyPem);
+
+        $ecPoint = $details['ec'];
+        $toBase64url = fn ($b) => rtrim(strtr(base64_encode($b), '+/', '-_'), '=');
+        $jwk = ['kty' => 'EC', 'crv' => 'P-256', 'x' => $toBase64url($ecPoint['x']), 'y' => $toBase64url($ecPoint['y'])];
+
+        return [base64_encode(json_encode($jwk)), $privateKeyPem];
+    }
+
+    /**
+     * Sign a challenge hex string with an OpenSSL EC private key.
+     * Returns base64-encoded IEEE P1363 signature (r||s, 32+32 bytes).
+     */
+    private function ecdsaSign(string $challengeHex, string $privateKeyPem): string
+    {
+        openssl_sign(hex2bin($challengeHex), $derSig, $privateKeyPem, OPENSSL_ALGO_SHA256);
+
+        // Parse DER → r, s
+        $offset = 2; // skip SEQUENCE tag+length
+        $offset++; // skip INTEGER tag for r
+        $rLen = ord($derSig[$offset++]);
+        $r = substr($derSig, $offset, $rLen);
+        $offset += $rLen;
+        $offset++; // skip INTEGER tag for s
+        $sLen = ord($derSig[$offset++]);
+        $s = substr($derSig, $offset, $sLen);
+
+        $r = str_pad(ltrim($r, "\x00"), 32, "\x00", STR_PAD_LEFT);
+        $s = str_pad(ltrim($s, "\x00"), 32, "\x00", STR_PAD_LEFT);
+
+        return base64_encode($r.$s);
+    }
+
+    public function test_challenge_returns_challenge_id_for_ecdsa_locker(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000001', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $response = $this->getJson(route('lockers.challenge', '1000000001'));
+
+        $response->assertStatus(200)->assertJsonStructure(['challenge', 'challenge_id']);
+    }
+
+    public function test_challenge_does_not_return_challenge_id_for_legacy_locker(): void
+    {
+        Locker::factory()->create(['account_id' => '1000000002']);
+
+        $response = $this->getJson(route('lockers.challenge', '1000000002'));
+
+        $response->assertStatus(200)->assertJsonMissing(['challenge_id']);
+    }
+
+    public function test_store_creates_ecdsa_locker_with_public_key(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        $credit = LockerCredit::factory()->create(['token' => 'ecdsatok1', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '1000000003',
+            'credit_token' => 'ecdsatok1',
+            'payload' => str_repeat('a', 100),
+            'public_key' => $publicKey,
+            'tier' => 'text',
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['expires_at', 'account_id']);
+        $this->assertDatabaseHas('lockers', ['account_id' => '1000000003', 'auth_challenge' => null]);
+    }
+
+    public function test_unlock_succeeds_with_valid_ecdsa_signature(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000004', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        // Fetch challenge
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000004'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        $response = $this->postJson(route('lockers.unlock', '1000000004'), [
+            'challenge_id' => $challengeData['challenge_id'],
+            'signature' => $signature,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['payload']);
+    }
+
+    public function test_unlock_fails_with_invalid_ecdsa_signature(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000005', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000005'))->json();
+
+        $response = $this->postJson(route('lockers.unlock', '1000000005'), [
+            'challenge_id' => $challengeData['challenge_id'],
+            'signature' => base64_encode(str_repeat("\x00", 64)),
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_challenge_replay_is_rejected(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000006', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000006'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        // First unlock succeeds
+        $this->postJson(route('lockers.unlock', '1000000006'), [
+            'challenge_id' => $challengeData['challenge_id'],
+            'signature' => $signature,
+        ])->assertStatus(200);
+
+        // Replaying the same challenge_id must fail
+        $this->postJson(route('lockers.unlock', '1000000006'), [
+            'challenge_id' => $challengeData['challenge_id'],
+            'signature' => $signature,
+        ])->assertStatus(401);
+    }
+
+    public function test_ecdsa_update_succeeds_with_valid_signing_headers(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000007', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000007'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        $response = $this->putJson(
+            route('lockers.update', '1000000007'),
+            ['payload' => str_repeat('b', 100)],
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        );
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+    }
+
+    public function test_ecdsa_update_rejects_replayed_challenge(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000008', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000008'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        // First update consumes the challenge
+        $this->putJson(
+            route('lockers.update', '1000000008'),
+            ['payload' => str_repeat('b', 100)],
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        )->assertStatus(200);
+
+        // Replaying must fail
+        $this->putJson(
+            route('lockers.update', '1000000008'),
+            ['payload' => str_repeat('c', 100)],
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        )->assertStatus(403);
+    }
+
+    public function test_ecdsa_delete_succeeds(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000009', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000009'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        $response = $this->deleteJson(
+            route('lockers.destroy', '1000000009'),
+            [],
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        );
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+        $this->assertDatabaseMissing('lockers', ['account_id' => '1000000009']);
+    }
+
+    public function test_ecdsa_renew_challenge_returns_challenge_id(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000010', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        $response = $this->getJson(route('lockers.renew.challenge', '1000000010'));
+
+        $response->assertStatus(200)->assertJsonStructure(['challenge', 'challenge_id']);
+    }
+
+    public function test_legacy_locker_backward_compat_unlock(): void
+    {
+        $verifier = str_repeat('a', 64);
+        Locker::factory()->create([
+            'account_id' => '1000000011',
+            'auth_verifier' => $verifier,
+        ]);
+
+        // Get legacy challenge (no challenge_id)
+        $challengeData = $this->getJson(route('lockers.challenge', '1000000011'))->json();
+        $this->assertArrayNotHasKey('challenge_id', $challengeData);
+
+        $response = $this->postJson(route('lockers.unlock', '1000000011'), [
+            'verifier' => $verifier,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['payload']);
+    }
+
+    public function test_upgrade_auth_stores_public_key_and_nulls_legacy_columns(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        $verifier = str_repeat('a', 64);
+        Locker::factory()->create([
+            'account_id' => '1000000012',
+            'auth_challenge' => str_repeat('c', 64),
+            'auth_verifier' => $verifier,
+            'update_token_hash' => hash('sha256', 'token'),
+        ]);
+
+        $response = $this->postJson(route('lockers.upgrade-auth', '1000000012'), [
+            'verifier' => $verifier,
+            'public_key' => $publicKey,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+
+        $locker = Locker::where('account_id', '1000000012')->first();
+        $this->assertNotNull($locker->public_key);
+        $this->assertNull($locker->auth_challenge);
+        $this->assertNull($locker->auth_verifier);
+        $this->assertNull($locker->update_token_hash);
+    }
+
+    public function test_upgrade_auth_returns_403_for_wrong_verifier(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        $verifier = str_repeat('a', 64);
+        Locker::factory()->create([
+            'account_id' => '1000000013',
+            'auth_verifier' => $verifier,
+        ]);
+
+        $response = $this->postJson(route('lockers.upgrade-auth', '1000000013'), [
+            'verifier' => str_repeat('b', 64),
+            'public_key' => $publicKey,
+        ]);
+
+        $response->assertStatus(403);
+        $locker = Locker::where('account_id', '1000000013')->first();
+        $this->assertNull($locker->public_key, 'Locker must remain unchanged after failed upgrade');
+    }
+
+    public function test_upgrade_auth_is_idempotent_for_already_upgraded_locker(): void
+    {
+        [$publicKey] = $this->generateEcdsaKeypair();
+        Locker::factory()->create(['account_id' => '1000000014', 'public_key' => $publicKey, 'auth_challenge' => null, 'auth_verifier' => null, 'update_token_hash' => null]);
+
+        // Should return 200 without re-verifying
+        $response = $this->postJson(route('lockers.upgrade-auth', '1000000014'), [
+            'verifier' => str_repeat('x', 64), // wrong verifier — won't be checked for ECDSA lockers
+            'public_key' => $publicKey,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+    }
 }

--- a/tests/Unit/Locker/LockerEcdsaServiceTest.php
+++ b/tests/Unit/Locker/LockerEcdsaServiceTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Locker;
+
+use App\Services\LockerEcdsaService;
+use PHPUnit\Framework\TestCase;
+
+class LockerEcdsaServiceTest extends TestCase
+{
+    private LockerEcdsaService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new LockerEcdsaService;
+    }
+
+    public function test_public_key_to_pem_produces_valid_pem(): void
+    {
+        [$jwkBase64, $privateKeyPem] = $this->generateP256TestKeypair();
+        $pem = $this->service->publicKeyToPem($jwkBase64);
+
+        $this->assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $pem);
+        $this->assertStringEndsWith("-----END PUBLIC KEY-----\n", $pem);
+
+        $key = openssl_pkey_get_public($pem);
+        $this->assertNotFalse($key, 'OpenSSL could not load the generated PEM');
+    }
+
+    public function test_p1363_to_der_converts_known_r_s(): void
+    {
+        // Craft a P1363 signature with known r and s values (all 0x01 and 0x02)
+        $r = str_repeat("\x01", 32);
+        $s = str_repeat("\x02", 32);
+        $p1363 = $r.$s;
+
+        $der = $this->service->p1363ToDer($p1363);
+
+        // DER sequence tag
+        $this->assertEquals("\x30", $der[0]);
+        // Must contain two INTEGER elements
+        $this->assertGreaterThan(68, strlen($der));
+        // r integer tag
+        $this->assertEquals("\x02", $der[2]);
+    }
+
+    public function test_p1363_to_der_prepends_zero_for_high_bit_r(): void
+    {
+        // r with high bit set requires 0x00 prepend in DER
+        $r = "\x80".str_repeat("\x01", 31);
+        $s = str_repeat("\x02", 32);
+        $p1363 = $r.$s;
+
+        $der = $this->service->p1363ToDer($p1363);
+
+        // r should be 34 bytes (0x00 + 0x80 + 31 bytes)
+        $rLen = ord($der[3]);
+        $this->assertEquals(33, $rLen, 'r with high bit should be padded with 0x00');
+        $this->assertEquals("\x00", $der[4], 'First byte of padded r should be 0x00');
+    }
+
+    public function test_verify_returns_true_for_valid_signature(): void
+    {
+        [$publicKeyJwkBase64, $privateKeyPem] = $this->generateP256TestKeypair();
+
+        $challengeHex = bin2hex(random_bytes(32));
+        $message = hex2bin($challengeHex);
+
+        // Sign using OpenSSL (DER format)
+        openssl_sign($message, $derSignature, $privateKeyPem, OPENSSL_ALGO_SHA256);
+
+        // Convert DER to P1363 for testing
+        $signatureBase64 = base64_encode($this->derToP1363($derSignature));
+
+        $result = $this->service->verify($publicKeyJwkBase64, $challengeHex, $signatureBase64);
+        $this->assertTrue($result);
+    }
+
+    public function test_verify_returns_false_for_tampered_signature(): void
+    {
+        [$publicKeyJwkBase64] = $this->generateP256TestKeypair();
+
+        $challengeHex = bin2hex(random_bytes(32));
+        $fakeSignature = base64_encode(str_repeat("\x00", 64));
+
+        $result = $this->service->verify($publicKeyJwkBase64, $challengeHex, $fakeSignature);
+        $this->assertFalse($result);
+    }
+
+    public function test_verify_returns_false_for_invalid_public_key(): void
+    {
+        $invalidJwkBase64 = base64_encode('not-valid-json');
+        $challengeHex = bin2hex(random_bytes(32));
+        $fakeSignature = base64_encode(str_repeat("\x00", 64));
+
+        $result = $this->service->verify($invalidJwkBase64, $challengeHex, $fakeSignature);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Generate a real P-256 keypair using OpenSSL. Returns [publicKeyJwkBase64, privateKeyPem].
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function generateP256TestKeypair(): array
+    {
+        $key = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
+        $details = openssl_pkey_get_details($key);
+        openssl_pkey_export($key, $privateKeyPem);
+
+        $ecPoint = $details['ec'];
+        $x = base64_encode($ecPoint['x']);
+        $y = base64_encode($ecPoint['y']);
+
+        // Convert to base64url
+        $toBase64url = fn ($b64) => rtrim(strtr($b64, '+/', '-_'), '=');
+
+        $jwk = ['kty' => 'EC', 'crv' => 'P-256', 'x' => $toBase64url($x), 'y' => $toBase64url($y)];
+        $publicKeyJwkBase64 = base64_encode(json_encode($jwk));
+
+        return [$publicKeyJwkBase64, $privateKeyPem];
+    }
+
+    /**
+     * Convert a DER-encoded P-256 ECDSA signature to IEEE P1363 (r||s, 32+32 bytes).
+     */
+    private function derToP1363(string $der): string
+    {
+        // Skip SEQUENCE tag and length (bytes 0-1)
+        $offset = 2;
+        // r INTEGER
+        $offset++; // skip 0x02 tag
+        $rLen = ord($der[$offset++]);
+        $r = substr($der, $offset, $rLen);
+        $offset += $rLen;
+        // s INTEGER
+        $offset++; // skip 0x02 tag
+        $sLen = ord($der[$offset++]);
+        $s = substr($der, $offset, $sLen);
+
+        // Strip leading zero if present, then pad to 32 bytes
+        $r = ltrim($r, "\x00");
+        $s = ltrim($s, "\x00");
+        $r = str_pad($r, 32, "\x00", STR_PAD_LEFT);
+        $s = str_pad($s, 32, "\x00", STR_PAD_LEFT);
+
+        return $r.$s;
+    }
+}

--- a/tests/e2e/helpers/locker.ts
+++ b/tests/e2e/helpers/locker.ts
@@ -18,7 +18,33 @@ export function createLockerCredit(
 }
 
 /**
- * Create a text locker via the browser UI. Returns passphrase and accountId.
+ * Create a legacy (HMAC) locker directly in the database via tinker, bypassing the UI.
+ * Used for testing the upgrade flow — the UI now always creates ECDSA lockers.
+ */
+export function createLegacyLockerViaDB(
+    accountId: string,
+    passphrase: string,
+    content: string
+): void {
+    const script = [
+        `$l = App\\\\Models\\\\Locker::create([`,
+        `'account_id' => '${accountId}',`,
+        `'payload' => '01546'.'${content}'.str_repeat('0',40),`,
+        `'auth_challenge' => str_repeat('c',64),`,
+        `'auth_verifier' => str_repeat('a',64),`,
+        `'update_token_hash' => hash('sha256','legacytoken'),`,
+        `'expires_at' => now()->addYear(),`,
+        `]);`,
+    ].join(' ');
+    execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="${script}"`,
+        { stdio: 'pipe' }
+    );
+}
+
+/**
+ * Create a text locker via the browser UI (ECDSA path). Returns passphrase and accountId.
+ * New lockers use ECDSA signing — no update token is stored or shown.
  */
 export async function createLockerViaUI(
     page: Page,
@@ -26,7 +52,7 @@ export async function createLockerViaUI(
     passphrase: string,
     content: string,
     creditToken: string
-): Promise<{ accountId: string; passphrase: string; updateToken: string }> {
+): Promise<{ accountId: string; passphrase: string }> {
     await page.goto(`/lockers/create?token=${encodeURIComponent(creditToken)}`);
     await page.waitForLoadState('networkidle');
 
@@ -35,14 +61,10 @@ export async function createLockerViaUI(
     await page.getByPlaceholder('Enter the content to store…').fill(content);
     await page.getByRole('button', { name: /Encrypt & Create/i }).click();
 
-    // Wait for credentials panel
-    await page.waitForSelector('text=Save all three credentials now', { timeout: 15000 });
+    // Wait for credentials panel (ECDSA: only Account ID + Passphrase shown)
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
 
-    // Extract update token from the credentials panel
-    const credRows = page.locator('code.font-mono');
-    const updateToken = await credRows.nth(2).innerText();
-
-    return { accountId, passphrase, updateToken: updateToken.trim() };
+    return { accountId, passphrase };
 }
 
 /**

--- a/tests/e2e/locker-create.spec.ts
+++ b/tests/e2e/locker-create.spec.ts
@@ -69,7 +69,7 @@ test('generate button fills passphrase field', async ({ page }) => {
     expect(value.length).toBeGreaterThan(10);
 });
 
-test('text content encrypts and credentials panel appears after creation', async ({ page }) => {
+test('ECDSA locker creation shows credentials panel with account ID and passphrase', async ({ page }) => {
     createLockerCredit('createtoken01', 'text', 1);
 
     await page.goto('/lockers/create?token=createtoken01');
@@ -80,9 +80,9 @@ test('text content encrypts and credentials panel appears after creation', async
     await page.getByPlaceholder('Enter the content to store…').fill('Secret text content');
     await page.getByRole('button', { name: /Encrypt & Create/i }).click();
 
-    await expect(page.getByText('Save all three credentials now')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('Account ID', { exact: true })).toBeVisible();
-    await expect(page.getByText('Update Token', { exact: true })).toBeVisible();
+    await expect(page.getByText('Passphrase', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: /Download as text file/i })).toBeVisible();
 });
 
@@ -97,7 +97,7 @@ test('duplicate account ID shows validation error', async ({ page }) => {
     await page.getByPlaceholder('Enter or generate a passphrase').fill('my-strong-test-passphrase-here');
     await page.getByPlaceholder('Enter the content to store…').fill('First locker content');
     await page.getByRole('button', { name: /Encrypt & Create/i }).click();
-    await page.waitForSelector('text=Save all three credentials now', { timeout: 15000 });
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
 
     // Attempt to create second locker with the same ID
     await page.goto('/lockers/create?token=createtoken03');
@@ -158,13 +158,13 @@ test('credentials panel has download button and confirmation checkbox', async ({
     await page.getByPlaceholder('Enter the content to store…').fill('Content for credentials test');
     await page.getByRole('button', { name: /Encrypt & Create/i }).click();
 
-    await page.waitForSelector('text=Save all three credentials now', { timeout: 15000 });
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
 
     // Open locker button should be disabled until checkbox checked
     const openButton = page.getByRole('button', { name: /Open my locker/i });
     await expect(openButton).toBeDisabled();
 
     // Check the confirmation checkbox
-    await page.getByLabel(/I have saved all three credentials/i).check();
+    await page.getByLabel(/I have saved both credentials/i).check();
     await expect(openButton).toBeEnabled();
 });

--- a/tests/e2e/locker-renew.spec.ts
+++ b/tests/e2e/locker-renew.spec.ts
@@ -54,3 +54,45 @@ test('wrong passphrase on renew shows error', async ({ page }) => {
 
     await expect(page.getByText(/Invalid passphrase|Authentication failed/i)).toBeVisible({ timeout: 10000 });
 });
+
+// ─── ECDSA renewal (PIO-103) ──────────────────────────────────────────────────
+
+test('ECDSA locker renewal with correct passphrase redirects to Stripe checkout', async ({ page }) => {
+    createLockerCredit('ecdsarenew01', 'text', 1);
+    const { passphrase } = await createLockerViaUI(page, '6060606060', 'ecdsa-renew-passphrase-long', 'Renewal test content', 'ecdsarenew01');
+
+    // Mock Stripe checkout creation — Stripe is not available in test environment
+    await page.route('**/6060606060/renew', async (route, request) => {
+        if (request.method() === 'POST') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ checkout_url: 'https://checkout.stripe.com/test-session' }),
+            });
+        } else {
+            await route.continue();
+        }
+    });
+
+    await page.goto('/lockers/6060606060/renew');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder(/passphrase/i).fill(passphrase);
+    await page.getByRole('button', { name: /Renew for/i }).click();
+
+    // Should redirect to Stripe checkout URL
+    await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 15000 });
+});
+
+test('ECDSA locker renewal with wrong passphrase shows error', async ({ page }) => {
+    createLockerCredit('ecdsarenew02', 'text', 1);
+    await createLockerViaUI(page, '7070707070', 'ecdsa-renew-correct-pass', 'Renewal wrong pass test', 'ecdsarenew02');
+
+    await page.goto('/lockers/7070707070/renew');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder(/passphrase/i).fill('totally-wrong-passphrase!');
+    await page.getByRole('button', { name: /Renew for/i }).click();
+
+    await expect(page.getByText(/Invalid passphrase/i)).toBeVisible({ timeout: 10000 });
+});

--- a/tests/e2e/locker-show.spec.ts
+++ b/tests/e2e/locker-show.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { resetDatabase, clearCache } from './helpers/db';
-import { createLockerCredit, createLockerViaUI, createFileLockerViaUI } from './helpers/locker';
+import { createLockerCredit, createLockerViaUI, createFileLockerViaUI, createLegacyLockerViaDB } from './helpers/locker';
 
 test.beforeEach(() => {
     resetDatabase();
@@ -194,4 +194,172 @@ test('passphrase change on DEK-based file locker does not re-download the file',
 
     // Core assertion: no S3 file was downloaded during passphrase change
     expect(s3Downloads).toHaveLength(0);
+});
+
+// ─── ECDSA flows (PIO-103) ────────────────────────────────────────────────────
+
+test('ECDSA locker unlock decrypts and displays content', async ({ page }) => {
+    createLockerCredit('ecdsashow01', 'text', 1);
+    const { passphrase } = await createLockerViaUI(page, '5100000001', 'ecdsa-unlock-passphrase', 'ECDSA secret text', 'ecdsashow01');
+
+    await page.goto('/lockers/5100000001');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('ECDSA secret text')).toBeVisible();
+});
+
+test('ECDSA locker update content shows success message', async ({ page }) => {
+    createLockerCredit('ecdsashow02', 'text', 1);
+    const { passphrase } = await createLockerViaUI(page, '5100000002', 'ecdsa-update-passphrase', 'Original content', 'ecdsashow02');
+
+    await page.goto('/lockers/5100000002');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    await page.getByPlaceholder('New content…').fill('Updated secret content');
+    await page.getByTestId('update-button').click();
+
+    await expect(page.getByText('Content updated.')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Updated secret content')).toBeVisible();
+});
+
+test('ECDSA locker delete redirects to home', async ({ page }) => {
+    createLockerCredit('ecdsashow03', 'text', 1);
+    const { passphrase } = await createLockerViaUI(page, '5100000003', 'ecdsa-delete-passphrase', 'Content to delete', 'ecdsashow03');
+
+    await page.goto('/lockers/5100000003');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: /Delete this locker permanently/i }).click();
+    await page.getByTestId('confirm-delete-button').click();
+
+    await expect(page).toHaveURL('/', { timeout: 15000 });
+});
+
+test('ECDSA locker passphrase change — new passphrase unlocks, old one fails', async ({ page }) => {
+    createLockerCredit('ecdsashow04', 'text', 1);
+    const oldPassphrase = 'ecdsa-old-passphrase-secure';
+    const newPassphrase = 'ecdsa-new-passphrase-secure';
+    const { accountId } = await createLockerViaUI(page, '5100000004', oldPassphrase, 'Passphrase change content', 'ecdsashow04');
+
+    // Unlock with old passphrase and change it
+    await page.goto(`/lockers/${accountId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(oldPassphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    await page.getByPlaceholder('Enter or generate a passphrase').last().fill(newPassphrase);
+    await page.getByRole('button', { name: /Change Passphrase/i }).click();
+    await expect(page.getByText(/Passphrase changed/i)).toBeVisible({ timeout: 15000 });
+
+    // Lock and try old passphrase — should fail
+    await page.getByRole('button', { name: /^Lock$/i }).click();
+    await page.getByTestId('passphrase-input').fill(oldPassphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypt-error')).toBeVisible({ timeout: 10000 });
+
+    // Try new passphrase — should succeed
+    await page.getByTestId('passphrase-input').fill(newPassphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+});
+
+test('upgrade banner appears after legacy unlock and upgrade migrates to ECDSA', async ({ page }) => {
+    // Create a legacy locker via DB (UI now always creates ECDSA)
+    createLegacyLockerViaDB('5100000005', 'legacy-passphrase', 'payload');
+
+    // Intercept the challenge endpoint to return a legacy response (no challenge_id)
+    // This simulates a locker that has not been upgraded
+    await page.goto('/lockers/5100000005');
+    await page.waitForLoadState('networkidle');
+
+    // Legacy unlock: verifier path
+    // We need to compute the HMAC verifier — but since we set a known auth_verifier directly,
+    // we can mock the unlock endpoint to succeed and return auth_challenge
+    await page.route('**/5100000005/challenge', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ challenge: 'c'.repeat(64) }),
+        });
+    });
+
+    await page.route('**/5100000005/unlock', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                payload: '0154' + '0'.repeat(60),
+                is_file_locker: false,
+                expires_at: new Date(Date.now() + 365 * 86400 * 1000).toISOString(),
+                auth_challenge: 'c'.repeat(64),
+            }),
+        });
+    });
+
+    await page.getByTestId('passphrase-input').fill('any-passphrase');
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Security upgrade available')).toBeVisible();
+
+    // Intercept upgrade-auth to simulate success
+    await page.route('**/5100000005/upgrade-auth', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ ok: true }),
+        });
+    });
+
+    await page.getByTestId('upgrade-button').click();
+
+    await expect(page.getByTestId('upgrade-success')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('upgrade-banner')).not.toBeVisible();
+});
+
+test('upgrade banner can be dismissed without upgrading', async ({ page }) => {
+    await page.goto('/lockers/5100000006');
+    await page.waitForLoadState('networkidle');
+
+    await page.route('**/5100000006/challenge', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ challenge: 'c'.repeat(64) }),
+        });
+    });
+
+    await page.route('**/5100000006/unlock', async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                payload: '0154' + '0'.repeat(60),
+                is_file_locker: false,
+                expires_at: new Date(Date.now() + 365 * 86400 * 1000).toISOString(),
+                auth_challenge: 'c'.repeat(64),
+            }),
+        });
+    });
+
+    await page.getByTestId('passphrase-input').fill('any-passphrase');
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('upgrade-dismiss-button').click();
+    await expect(page.getByTestId('upgrade-banner')).not.toBeVisible();
 });

--- a/tests/e2e/locker-show.spec.ts
+++ b/tests/e2e/locker-show.spec.ts
@@ -266,10 +266,14 @@ test('ECDSA locker passphrase change — new passphrase unlocks, old one fails',
     await expect(page.getByText(/Passphrase changed/i)).toBeVisible({ timeout: 15000 });
 
     // Lock and try old passphrase — should fail
-    await page.getByRole('button', { name: /^Lock$/i }).click();
+    await page.getByTestId('lock-button').click();
     await page.getByTestId('passphrase-input').fill(oldPassphrase);
     await page.getByTestId('unlock-button').click();
     await expect(page.getByTestId('decrypt-error')).toBeVisible({ timeout: 10000 });
+
+    // Clear rate limiters (the failed attempt hit the cooldown) and wait for shake to end
+    clearCache();
+    await expect(page.getByTestId('unlock-button')).toBeEnabled({ timeout: 3000 });
 
     // Try new passphrase — should succeed
     await page.getByTestId('passphrase-input').fill(newPassphrase);
@@ -278,52 +282,72 @@ test('ECDSA locker passphrase change — new passphrase unlocks, old one fails',
 });
 
 test('upgrade banner appears after legacy unlock and upgrade migrates to ECDSA', async ({ page }) => {
-    // Create a legacy locker via DB (UI now always creates ECDSA)
-    createLegacyLockerViaDB('5100000005', 'legacy-passphrase', 'payload');
+    createLockerCredit('ecdsashow05', 'text', 1);
+    const upgradePassphrase = 'upgrade-banner-passphrase';
+    const upgradeAccountId = '5100000005';
 
-    // Intercept the challenge endpoint to return a legacy response (no challenge_id)
-    // This simulates a locker that has not been upgraded
-    await page.goto('/lockers/5100000005');
-    await page.waitForLoadState('networkidle');
+    // Capture the encrypted payload from the creation request body before it hits the server
+    let capturedPayload: string | null = null;
+    await page.route('**/lockers', async (route, request) => {
+        if (request.method() === 'POST' && !request.url().includes('file')) {
+            const body = JSON.parse(request.postData() || '{}');
+            if (body.account_id === upgradeAccountId) {
+                capturedPayload = body.payload;
+            }
+        }
+        await route.continue();
+    });
 
-    // Legacy unlock: verifier path
-    // We need to compute the HMAC verifier — but since we set a known auth_verifier directly,
-    // we can mock the unlock endpoint to succeed and return auth_challenge
-    await page.route('**/5100000005/challenge', async route => {
+    await createLockerViaUI(page, upgradeAccountId, upgradePassphrase, 'Banner test content', 'ecdsashow05');
+
+    // Use context-level routes (persist across navigations, evaluated before page routes)
+    const challengePattern = new RegExp(`/lockers/${upgradeAccountId}/challenge`);
+    const unlockPattern = new RegExp(`/lockers/${upgradeAccountId}/unlock`);
+    const upgradePattern = new RegExp(`/lockers/${upgradeAccountId}/upgrade-auth`);
+
+    const futureExpiry = new Date(Date.now() + 365 * 86400 * 1000).toISOString();
+
+    // Mock challenge as legacy (no challenge_id) to trigger the upgrade banner
+    await page.context().route(challengePattern, async route => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify({ challenge: 'c'.repeat(64) }),
+            body: JSON.stringify({ challenge: 'a'.repeat(64) }),
         });
     });
 
-    await page.route('**/5100000005/unlock', async route => {
+    // Mock unlock to return the real encrypted payload (so decryption succeeds)
+    await page.context().route(unlockPattern, async route => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
-                payload: '0154' + '0'.repeat(60),
+                payload: capturedPayload,
                 is_file_locker: false,
-                expires_at: new Date(Date.now() + 365 * 86400 * 1000).toISOString(),
-                auth_challenge: 'c'.repeat(64),
+                expires_at: futureExpiry,
+                auth_challenge: 'a'.repeat(64),
             }),
         });
     });
 
-    await page.getByTestId('passphrase-input').fill('any-passphrase');
-    await page.getByTestId('unlock-button').click();
-
-    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('Security upgrade available')).toBeVisible();
-
-    // Intercept upgrade-auth to simulate success
-    await page.route('**/5100000005/upgrade-auth', async route => {
+    await page.context().route(upgradePattern, async route => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({ ok: true }),
         });
     });
+
+    // Navigate to show page with mocks already active
+    await page.goto(`/lockers/${upgradeAccountId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(upgradePassphrase);
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Security upgrade available')).toBeVisible();
 
     await page.getByTestId('upgrade-button').click();
 
@@ -332,33 +356,55 @@ test('upgrade banner appears after legacy unlock and upgrade migrates to ECDSA',
 });
 
 test('upgrade banner can be dismissed without upgrading', async ({ page }) => {
-    await page.goto('/lockers/5100000006');
-    await page.waitForLoadState('networkidle');
+    createLockerCredit('ecdsashow06', 'text', 1);
+    const dismissPassphrase = 'dismiss-banner-passphrase';
+    const dismissAccountId = '5100000006';
 
-    await page.route('**/5100000006/challenge', async route => {
+    let capturedPayload2: string | null = null;
+    await page.route('**/lockers', async (route, request) => {
+        if (request.method() === 'POST' && !request.url().includes('file')) {
+            const body = JSON.parse(request.postData() || '{}');
+            if (body.account_id === dismissAccountId) {
+                capturedPayload2 = body.payload;
+            }
+        }
+        await route.continue();
+    });
+
+    await createLockerViaUI(page, dismissAccountId, dismissPassphrase, 'Dismiss test content', 'ecdsashow06');
+
+    const challengePattern2 = new RegExp(`/lockers/${dismissAccountId}/challenge`);
+    const unlockPattern2 = new RegExp(`/lockers/${dismissAccountId}/unlock`);
+    const futureExpiry2 = new Date(Date.now() + 365 * 86400 * 1000).toISOString();
+
+    await page.context().route(challengePattern2, async route => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify({ challenge: 'c'.repeat(64) }),
+            body: JSON.stringify({ challenge: 'b'.repeat(64) }),
         });
     });
 
-    await page.route('**/5100000006/unlock', async route => {
+    await page.context().route(unlockPattern2, async route => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
-                payload: '0154' + '0'.repeat(60),
+                payload: capturedPayload2,
                 is_file_locker: false,
-                expires_at: new Date(Date.now() + 365 * 86400 * 1000).toISOString(),
-                auth_challenge: 'c'.repeat(64),
+                expires_at: futureExpiry2,
+                auth_challenge: 'b'.repeat(64),
             }),
         });
     });
 
-    await page.getByTestId('passphrase-input').fill('any-passphrase');
+    await page.goto(`/lockers/${dismissAccountId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(dismissPassphrase);
     await page.getByTestId('unlock-button').click();
-    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('upgrade-banner')).toBeVisible({ timeout: 5000 });
 
     await page.getByTestId('upgrade-dismiss-button').click();
     await expect(page.getByTestId('upgrade-banner')).not.toBeVisible();

--- a/tools/flashview-cli/src/crypto.js
+++ b/tools/flashview-cli/src/crypto.js
@@ -17,4 +17,6 @@ export {
     unwrapFileKey,
     encryptFileToBuffer,
     decryptFileFromBuffer,
+    deriveSigningKeypair,
+    signChallenge,
 } from '@pioneer-dynamics/flashview-crypto';

--- a/tools/flashview-crypto/package-lock.json
+++ b/tools/flashview-crypto/package-lock.json
@@ -8,10 +8,38 @@
             "name": "@pioneer-dynamics/flashview-crypto",
             "version": "2.0.0",
             "dependencies": {
+                "@noble/curves": "^1.9.7",
                 "random-words": "^2.0.0"
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/random-words": {

--- a/tools/flashview-crypto/package.json
+++ b/tools/flashview-crypto/package.json
@@ -25,6 +25,7 @@
         "test": "node --test tests/*.test.js"
     },
     "dependencies": {
+        "@noble/curves": "^1.9.7",
         "random-words": "^2.0.0"
     }
 }

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -1,4 +1,5 @@
 import { generate } from 'random-words';
+import { p256 } from '@noble/curves/p256';
 
 const PBKDF2_ITERATIONS = 64000;
 const KEY_LENGTH_BITS = 256;
@@ -744,6 +745,91 @@ export async function computeVerifier(authKey, challenge) {
         new TextEncoder().encode(challenge)
     );
     return bufferToHex(new Uint8Array(sig));
+}
+
+/**
+ * Derive a deterministic P-256 ECDSA signing keypair from passphrase + accountId.
+ *
+ * Derivation: PBKDF2(passphrase, accountId+':signing-v1', 100k, SHA-512, 64 bytes)
+ *             → HKDF(ikm=pbkdf2, salt='locker-signing-v1', info='ecdsa-private-key', length=32)
+ *             → private scalar (normalised mod n to [1, n-1])
+ *             → p256.getPublicKey(scalar) → uncompressed point
+ *             → JWK imported as CryptoKey
+ *
+ * @param {string} passphrase
+ * @param {string} accountId
+ * @returns {Promise<{ privateKey: CryptoKey, publicKeyJwkBase64: string }>}
+ */
+export async function deriveSigningKeypair(passphrase, accountId) {
+    const passphraseKey = await globalThis.crypto.subtle.importKey(
+        'raw', new TextEncoder().encode(passphrase), 'PBKDF2', false, ['deriveBits']
+    );
+    const pbkdf2Bits = await globalThis.crypto.subtle.deriveBits(
+        {
+            name: 'PBKDF2',
+            salt: new TextEncoder().encode(accountId + ':signing-v1'),
+            iterations: LOCKER_PBKDF2_ITERATIONS,
+            hash: 'SHA-512',
+        },
+        passphraseKey,
+        512
+    );
+    const hkdfKey = await globalThis.crypto.subtle.importKey('raw', pbkdf2Bits, 'HKDF', false, ['deriveBits']);
+    const scalar32 = await globalThis.crypto.subtle.deriveBits(
+        {
+            name: 'HKDF',
+            hash: 'SHA-256',
+            salt: new TextEncoder().encode('locker-signing-v1'),
+            info: new TextEncoder().encode('ecdsa-private-key'),
+        },
+        hkdfKey,
+        256
+    );
+    let privateScalar = new Uint8Array(scalar32);
+
+    // Normalise scalar to [1, n-1] via BigInt mod — required because @noble/curves
+    // getPublicKey() throws for scalar >= n, and ~1-in-4.3B HKDF outputs exceed n.
+    const n = p256.CURVE.n;
+    let scalarBig = BigInt('0x' + bufferToHex(privateScalar));
+    scalarBig = scalarBig % n;
+    if (scalarBig === 0n) { scalarBig = 1n; }
+    privateScalar = hexToBuffer(scalarBig.toString(16).padStart(64, '0'));
+
+    const publicUncompressed = p256.getPublicKey(privateScalar, false); // 65 bytes: 04 || x || y
+    const x = publicUncompressed.slice(1, 33);
+    const y = publicUncompressed.slice(33, 65);
+
+    const toBase64Url = (bytes) =>
+        btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+    const jwk = { kty: 'EC', crv: 'P-256', x: toBase64Url(x), y: toBase64Url(y), d: toBase64Url(privateScalar) };
+
+    const privateKey = await globalThis.crypto.subtle.importKey(
+        'jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign']
+    );
+
+    const publicJwk = { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y };
+    const publicKeyJwkBase64 = btoa(JSON.stringify(publicJwk));
+
+    return { privateKey, publicKeyJwkBase64 };
+}
+
+/**
+ * Sign a hex-encoded challenge with an ECDSA P-256 private key.
+ * Returns a base64-encoded IEEE P1363 signature (64 bytes: r || s).
+ *
+ * @param {CryptoKey} privateKey
+ * @param {string} challengeHex
+ * @returns {Promise<string>} base64 signature
+ */
+export async function signChallenge(privateKey, challengeHex) {
+    const challengeBytes = hexToBuffer(challengeHex);
+    const sigBuffer = await globalThis.crypto.subtle.sign(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        privateKey,
+        challengeBytes
+    );
+    return uint8ArrayToBase64(new Uint8Array(sigBuffer));
 }
 
 // ─── Message Decryption (legacy PBKDF2 / OpenCrypto) ─────────────────────────

--- a/tools/flashview-crypto/tests/crypto.test.js
+++ b/tools/flashview-crypto/tests/crypto.test.js
@@ -5,6 +5,7 @@ import {
     encryptBuffer, decryptBuffer,
     encryptFileToBuffer, decryptFileFromBuffer,
     generateFileKey, wrapFileKey, unwrapFileKey,
+    deriveSigningKeypair, signChallenge,
 } from '../src/index.js';
 
 // Known vectors generated from the pre-migration CLI implementation (tools/flashview-cli/src/crypto.js)
@@ -436,5 +437,98 @@ describe('encryptFileToBuffer + decryptFileFromBuffer backward compat', () => {
 
         const decrypted = await decryptFileFromBuffer(encrypted, { dek: finalDek });
         assert.deepEqual(decrypted, original, 'File must decrypt correctly after DEK re-wrap');
+    });
+});
+
+// ─── ECDSA signing (PIO-103) ──────────────────────────────────────────────────
+
+describe('deriveSigningKeypair', () => {
+    it('returns a CryptoKey and base64 JWK public key', async () => {
+        const { privateKey, publicKeyJwkBase64 } = await deriveSigningKeypair('test-passphrase', 'account-123');
+        assert.ok(privateKey instanceof CryptoKey, 'privateKey should be a CryptoKey');
+        assert.equal(privateKey.type, 'private', 'privateKey should be private type');
+        assert.ok(typeof publicKeyJwkBase64 === 'string', 'publicKeyJwkBase64 should be a string');
+
+        const jwk = JSON.parse(atob(publicKeyJwkBase64));
+        assert.equal(jwk.kty, 'EC', 'JWK kty should be EC');
+        assert.equal(jwk.crv, 'P-256', 'JWK crv should be P-256');
+        assert.ok(jwk.x, 'JWK should have x coordinate');
+        assert.ok(jwk.y, 'JWK should have y coordinate');
+        assert.equal(jwk.d, undefined, 'Public JWK should not contain d (private scalar)');
+    });
+
+    it('is deterministic — same passphrase+accountId produces the same public key', async () => {
+        const { publicKeyJwkBase64: pub1 } = await deriveSigningKeypair('deterministic-pass', 'acct-42');
+        const { publicKeyJwkBase64: pub2 } = await deriveSigningKeypair('deterministic-pass', 'acct-42');
+        assert.equal(pub1, pub2, 'Same inputs must produce the same public key');
+    });
+
+    it('different passphrases produce different keypairs', async () => {
+        const { publicKeyJwkBase64: pub1 } = await deriveSigningKeypair('passphrase-A', 'acct-1');
+        const { publicKeyJwkBase64: pub2 } = await deriveSigningKeypair('passphrase-B', 'acct-1');
+        assert.notEqual(pub1, pub2, 'Different passphrases must produce different keypairs');
+    });
+
+    it('different accountIds produce different keypairs', async () => {
+        const { publicKeyJwkBase64: pub1 } = await deriveSigningKeypair('shared-pass', 'acct-1');
+        const { publicKeyJwkBase64: pub2 } = await deriveSigningKeypair('shared-pass', 'acct-2');
+        assert.notEqual(pub1, pub2, 'Different accountIds must produce different keypairs');
+    });
+});
+
+describe('signChallenge', () => {
+    it('returns a base64-encoded 64-byte P1363 signature', async () => {
+        const { privateKey } = await deriveSigningKeypair('sign-test-pass', 'sign-acct');
+        const challengeHex = '0'.repeat(64); // 32 zero bytes
+        const signatureBase64 = await signChallenge(privateKey, challengeHex);
+
+        assert.ok(typeof signatureBase64 === 'string', 'Signature should be a string');
+        const sigBytes = Uint8Array.from(atob(signatureBase64), c => c.charCodeAt(0));
+        assert.equal(sigBytes.length, 64, 'P1363 signature should be exactly 64 bytes (r||s)');
+    });
+
+    it('signature verifies with the corresponding public key via Web Crypto', async () => {
+        const { privateKey, publicKeyJwkBase64 } = await deriveSigningKeypair('verify-test-pass', 'verify-acct');
+        const challengeHex = 'ab'.repeat(32); // 32 bytes
+        const signatureBase64 = await signChallenge(privateKey, challengeHex);
+
+        const sigBytes = Uint8Array.from(atob(signatureBase64), c => c.charCodeAt(0));
+        const challengeBytes = new Uint8Array(challengeHex.match(/.{2}/g).map(b => parseInt(b, 16)));
+
+        const pubJwk = JSON.parse(atob(publicKeyJwkBase64));
+        const pubKey = await crypto.subtle.importKey(
+            'jwk', pubJwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']
+        );
+
+        const isValid = await crypto.subtle.verify(
+            { name: 'ECDSA', hash: 'SHA-256' },
+            pubKey,
+            sigBytes,
+            challengeBytes
+        );
+        assert.ok(isValid, 'Signature should verify correctly with the corresponding public key');
+    });
+
+    it('signature does not verify with a different keypair', async () => {
+        const { privateKey: key1 } = await deriveSigningKeypair('key-1-pass', 'acct-x');
+        const { publicKeyJwkBase64: pub2 } = await deriveSigningKeypair('key-2-pass', 'acct-x');
+        const challengeHex = 'ff'.repeat(32);
+        const signatureBase64 = await signChallenge(key1, challengeHex);
+
+        const sigBytes = Uint8Array.from(atob(signatureBase64), c => c.charCodeAt(0));
+        const challengeBytes = new Uint8Array(challengeHex.match(/.{2}/g).map(b => parseInt(b, 16)));
+
+        const pubJwk = JSON.parse(atob(pub2));
+        const pubKey = await crypto.subtle.importKey(
+            'jwk', pubJwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']
+        );
+
+        const isValid = await crypto.subtle.verify(
+            { name: 'ECDSA', hash: 'SHA-256' },
+            pubKey,
+            sigBytes,
+            challengeBytes
+        );
+        assert.ok(! isValid, 'Signature from key1 must not verify with key2 public key');
     });
 });


### PR DESCRIPTION
## Summary

- **Replace static HMAC/update-token auth** with asymmetric ECDSA P-256 challenge-response across all locker endpoints (unlock, update, destroy, renewPurchase, renewChallenge)
- **New `upgrade-auth` endpoint** lets existing legacy lockers migrate in-place with a one-click banner after unlock
- **Full backward compat** — lockers without `public_key` continue to use the HMAC path indefinitely

## Changes

### Crypto
- Add `@noble/curves ^1.9.7` to `flashview-crypto` for EC point multiplication
- Export `deriveSigningKeypair(passphrase, accountId)` and `signChallenge(privateKey, challengeHex)` from shared library; wrapped in `encryption.js` (web) and `crypto.js` (CLI)

### Database
- Migration: adds `public_key` (nullable text) column; makes `auth_challenge`, `auth_verifier`, `update_token_hash` nullable for ECDSA lockers

### Backend
- `LockerEcdsaService` — JWK→PEM, P1363→DER, `openssl_verify()` ECDSA verification with `Cache::pull()` for atomic challenge consumption
- `challenge()` — returns `{challenge_id, challenge}` for ECDSA lockers; static `auth_challenge` for legacy (enumeration-safe)
- `unlock()`, `update()`, `destroy()`, `renewPurchase()`, `renewChallenge()` — dual-path ECDSA/legacy; all three rate limiters preserved
- `upgradeAuth()` (new) — verifies legacy HMAC verifier, stores ECDSA public key; idempotent; protected by `locker-account-lock` rate limiter
- `UnlockLockerRequest`, `UpgradeAuthLockerRequest` (new) — Form Request classes for inline validation replaced per conventions

### Frontend
- `Create.vue` — derive signing keypair at creation, send `public_key`, omit legacy auth fields
- `Show.vue` — `fetchSigningHeaders()` helper for all mutations; upgrade banner with plain-language copy, dismiss, 4s auto-dismiss success state
- `Renew.vue` — detect ECDSA from `challenge_id` presence in challenge response

### Tests
- 6 PHPUnit unit tests (`LockerEcdsaServiceTest`)
- 14 PHPUnit feature tests (ECDSA create/unlock/update/delete/renew/replay/upgrade)
- 7 JS crypto tests (`deriveSigningKeypair` determinism + `signChallenge` round-trip)
- 10 Playwright E2E tests (ECDSA locker lifecycle, upgrade banner flow)

## Regression risks (from regression-detector)
- `LockerRateLimitingTest` exercises legacy path — confirmed still passes
- `payload()` endpoint returns `auth_challenge: null` for ECDSA lockers (field still present in response, was null for upgraded lockers — no consumer impact)
- 403 error message changed from `"Invalid update token."` to `"Invalid credentials."` in update/destroy

## Test plan
- See `.claude.d/PIO-103.test.md` for full manual test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)