### PR TITLE
PIO-105: eLocker multi-factor authentication (passphrase, key file, combined)

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -131,6 +131,8 @@ class LockerController extends Controller
             'storage_path' => $request->input('storage_path'),
             'wrapped_file_key' => $request->input('wrapped_file_key'),
             'expires_at' => now()->addYears($credit->years),
+            'auth_mode' => $request->input('auth_mode', 'passphrase'),
+            'key_file_count' => $request->input('key_file_count'),
         ];
 
         if ($request->filled('public_key')) {
@@ -177,6 +179,20 @@ class LockerController extends Controller
             'upload_url' => $uploadUrl,
             'upload_headers' => $uploadHeaders,
             'storage_path' => $storagePath,
+        ]);
+    }
+
+    public function authInfo(Request $request, string $accountId): JsonResponse
+    {
+        $locker = Locker::where('account_id', $accountId)->first();
+
+        if (! $locker) {
+            return response()->json(['auth_mode' => 'passphrase', 'key_file_count' => null]);
+        }
+
+        return response()->json([
+            'auth_mode' => $locker->auth_mode,
+            'key_file_count' => $locker->key_file_count,
         ]);
     }
 

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -445,6 +445,11 @@ class LockerController extends Controller
             $updates['wrapped_file_key'] = $request->input('new_wrapped_file_key');
         }
 
+        if ($request->filled('new_auth_mode')) {
+            $updates['auth_mode'] = $request->input('new_auth_mode');
+            $updates['key_file_count'] = $request->input('new_key_file_count');
+        }
+
         $locker->update($updates);
 
         return response()->json(['ok' => true]);

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -133,6 +133,7 @@ class LockerController extends Controller
             'expires_at' => now()->addYears($credit->years),
             'auth_mode' => $request->input('auth_mode', 'passphrase'),
             'key_file_count' => $request->input('key_file_count'),
+            'show_clues' => $request->boolean('show_clues', true),
         ];
 
         if ($request->filled('public_key')) {
@@ -186,13 +187,16 @@ class LockerController extends Controller
     {
         $locker = Locker::where('account_id', $accountId)->first();
 
-        if (! $locker) {
-            return response()->json(['auth_mode' => 'passphrase', 'key_file_count' => null]);
+        // Non-existent lockers and lockers with show_clues=false return an opaque
+        // passphrase-default response, preventing enumeration of locker existence and auth mode.
+        if (! $locker || ! $locker->show_clues) {
+            return response()->json(['auth_mode' => 'passphrase', 'key_file_count' => null, 'show_clues' => false]);
         }
 
         return response()->json([
             'auth_mode' => $locker->auth_mode,
             'key_file_count' => $locker->key_file_count,
+            'show_clues' => true,
         ]);
     }
 

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -200,6 +200,48 @@ class LockerController extends Controller
         ]);
     }
 
+    public function updateSettings(Request $request, string $accountId): JsonResponse
+    {
+        $request->validate(['show_clues' => ['required', 'boolean']]);
+
+        $locker = Locker::where('account_id', $accountId)->first();
+
+        if (! $locker) {
+            abort(404);
+        }
+
+        if ($locker->isExpired()) {
+            abort(410);
+        }
+
+        $verified = false;
+
+        if ($locker->public_key !== null) {
+            $challengeId = $request->header('X-Signing-Challenge-Id');
+            $signature = $request->header('X-Signature');
+
+            if ($challengeId && $signature) {
+                $challengeHex = $this->ecdsaService->consumeChallenge($challengeId, $accountId);
+                if ($challengeHex !== null) {
+                    $verified = $this->ecdsaService->verify($locker->public_key, $challengeHex, $signature);
+                }
+            }
+        } else {
+            $updateToken = $request->header('X-Update-Token');
+            if ($updateToken) {
+                $verified = $locker->verifyUpdateToken($updateToken);
+            }
+        }
+
+        if (! $verified) {
+            return response()->json(['error' => 'Invalid credentials.'], 403);
+        }
+
+        $locker->update(['show_clues' => $request->boolean('show_clues')]);
+
+        return response()->json(['ok' => true]);
+    }
+
     public function show(Request $request, string $accountId): Response
     {
         return Inertia::render('Locker/Show', [

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -182,7 +182,7 @@ class LockerController extends Controller
         ]);
     }
 
-    public function authInfo(Request $request, string $accountId): JsonResponse
+    public function authInfo(string $accountId): JsonResponse
     {
         $locker = Locker::where('account_id', $accountId)->first();
 

--- a/app/Http/Requests/Locker/StoreLockerRequest.php
+++ b/app/Http/Requests/Locker/StoreLockerRequest.php
@@ -32,6 +32,14 @@ class StoreLockerRequest extends FormRequest
             'tier' => ['required', 'in:text,file'],
             'storage_path' => ['required_if:tier,file', 'nullable', 'string'],
             'wrapped_file_key' => ['nullable', 'string', 'max:512'],
+            'auth_mode' => ['sometimes', 'in:passphrase,key_file,combined'],
+            'key_file_count' => [
+                'nullable',
+                'prohibited_if:auth_mode,passphrase',
+                'required_if:auth_mode,key_file',
+                'required_if:auth_mode,combined',
+                'integer', 'min:1', 'max:20',
+            ],
         ];
     }
 

--- a/app/Http/Requests/Locker/StoreLockerRequest.php
+++ b/app/Http/Requests/Locker/StoreLockerRequest.php
@@ -40,6 +40,7 @@ class StoreLockerRequest extends FormRequest
                 'required_if:auth_mode,combined',
                 'integer', 'min:1', 'max:20',
             ],
+            'show_clues' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/app/Http/Requests/Locker/UpdateLockerRequest.php
+++ b/app/Http/Requests/Locker/UpdateLockerRequest.php
@@ -26,6 +26,14 @@ class UpdateLockerRequest extends FormRequest
             'new_update_token' => ['nullable', 'string', 'size:64'],
             'new_wrapped_file_key' => ['nullable', 'string', 'max:512'],
             'new_public_key' => ['nullable', 'string'],
+            'new_auth_mode' => ['sometimes', 'in:passphrase,key_file,combined'],
+            'new_key_file_count' => [
+                'nullable',
+                'prohibited_if:new_auth_mode,passphrase',
+                'required_if:new_auth_mode,key_file',
+                'required_if:new_auth_mode,combined',
+                'integer', 'min:1', 'max:20',
+            ],
         ];
     }
 }

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -24,6 +24,7 @@ class Locker extends Model
         'expires_at',
         'auth_mode',
         'key_file_count',
+        'show_clues',
     ];
 
     protected function casts(): array
@@ -32,6 +33,7 @@ class Locker extends Model
             'expires_at' => 'datetime',
             'wrapped_file_key' => 'encrypted',
             'key_file_count' => 'integer',
+            'show_clues' => 'boolean',
         ];
     }
 

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -22,6 +22,8 @@ class Locker extends Model
         'update_token_hash',
         'public_key',
         'expires_at',
+        'auth_mode',
+        'key_file_count',
     ];
 
     protected function casts(): array
@@ -29,6 +31,7 @@ class Locker extends Model
         return [
             'expires_at' => 'datetime',
             'wrapped_file_key' => 'encrypted',
+            'key_file_count' => 'integer',
         ];
     }
 

--- a/database/migrations/2026_06_04_115513_add_auth_mode_to_lockers_table.php
+++ b/database/migrations/2026_06_04_115513_add_auth_mode_to_lockers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->string('auth_mode', 20)->default('passphrase')->after('expires_at');
+            $table->unsignedSmallInteger('key_file_count')->nullable()->after('auth_mode');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->dropColumn(['auth_mode', 'key_file_count']);
+        });
+    }
+};

--- a/database/migrations/2026_06_05_031224_add_show_clues_to_lockers_table.php
+++ b/database/migrations/2026_06_05_031224_add_show_clues_to_lockers_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->boolean('show_clues')->default(true)->after('key_file_count');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lockers', function (Blueprint $table) {
+            $table->dropColumn('show_clues');
+        });
+    }
+};

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -463,9 +463,9 @@ const submit = async () => {
                                 </div>
                             </div>
 
-                            <label class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 rounded-lg px-3 py-2.5 transition-colors text-gray-400 text-sm">
+                            <label class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2.5 transition-colors text-gray-400 text-sm">
                                 <span class="font-mono text-xs">+ Add key file</span>
-                                <input type="file" class="sr-only" @change="onKeyFileAdded" />
+                                <input type="file" class="sr-only" @change="onKeyFileAdded" data-testid="key-file-input" />
                             </label>
                             <p v-if="errors.key_files" class="text-red-400 text-xs mt-1">{{ errors.key_files }}</p>
                             <p v-else class="text-gray-500 text-xs mt-1">{{ keyFiles.length }} key file(s) added. Files are processed locally — no content is uploaded.</p>

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -330,8 +330,9 @@ const submit = async () => {
                     </button>
 
                     <label class="flex items-center gap-2 text-gray-300 text-sm mb-4 cursor-pointer">
-                        <input type="checkbox" v-model="savedConfirmed" class="rounded border-gray-600 bg-gray-700 text-gamboge-300" />
-                        I have saved my credentials
+                        <input type="checkbox" v-model="savedConfirmed" class="rounded border-gray-600 bg-gray-700 text-gamboge-300" data-testid="saved-confirmed-checkbox" />
+                        <span v-if="credentials.authMode === 'passphrase'">I have saved both credentials</span>
+                        <span v-else>I have saved my credentials</span>
                     </label>
 
                     <button

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -29,9 +29,10 @@ const content      = ref('');
 const selectedFile = ref(null);
 
 // Auth mode
-const authMode             = ref('passphrase'); // 'passphrase' | 'key_file' | 'combined'
-const keyFiles             = ref([]); // [{ file: File, hash: string, fingerprint: string }]
+const authMode                = ref('passphrase'); // 'passphrase' | 'key_file' | 'combined'
+const keyFiles                = ref([]); // [{ file: File }]
 const keyFileRiskAcknowledged = ref(false);
+const showClues               = ref(true); // when false, unlock page reveals no credential-type hints
 
 // State
 const step          = ref('form'); // 'form' | 'encrypting' | 'uploading' | 'credentials'
@@ -62,15 +63,11 @@ const generatePassphrase = () => { passphrase.value = enc.generatePasssphrase();
 const onFileChange = (e) => { selectedFile.value = e.target.files[0] ?? null; };
 const copyToClipboard = async (text) => { await navigator.clipboard.writeText(text); };
 
-const onKeyFileAdded = async (e) => {
+const onKeyFileAdded = (e) => {
     const file = e.target.files[0];
     if (!file) return;
     e.target.value = '';
-
-    const buffer = await file.arrayBuffer();
-    const hash = await enc.deriveLockerKeyFromFile(buffer);
-    const fingerprint = hash.slice(0, 8);
-    keyFiles.value.push({ file, hash, fingerprint });
+    keyFiles.value.push({ file });
 };
 
 const removeKeyFile = (index) => {
@@ -81,6 +78,7 @@ const setAuthMode = (mode) => {
     authMode.value = mode;
     keyFiles.value = [];
     keyFileRiskAcknowledged.value = false;
+    if (mode === 'passphrase') showClues.value = true;
 };
 
 const computeEffectivePassphrase = async () => {
@@ -113,13 +111,16 @@ const downloadCredentials = () => {
 
     if (authMode.value !== 'passphrase') {
         lines.push('');
-        lines.push('Key File Fingerprints (load in this exact order when unlocking):');
-        credentials.value.keyFileFingerprints.forEach((fp, i) => {
-            lines.push(`  ${i + 1}. ${fp}`);
+        lines.push('Key Files (load in this exact order when unlocking):');
+        credentials.value.keyFileNames.forEach((name, i) => {
+            lines.push(`  ${i + 1}. ${name}`);
         });
         lines.push('');
-        lines.push('IMPORTANT: Key files must be loaded in this exact order. Refer to this file');
-        lines.push('for the required fingerprint sequence. There is no recovery if you lose your key files.');
+        lines.push('IMPORTANT: Key files must be loaded in this exact order. There is no recovery if you lose your key files.');
+        if (!showClues.value) {
+            lines.push('NOTE: The unlock page is configured to show no hints about required credentials.');
+            lines.push('Share access instructions with authorised users through a separate secure channel.');
+        }
     }
 
     lines.push('', `Expires: ${new Date(credentials.value.expires_at).toLocaleDateString()}`);
@@ -245,6 +246,7 @@ const submit = async () => {
                 wrapped_file_key: wrappedFileKey,
                 auth_mode:        authMode.value,
                 key_file_count:   authMode.value !== 'passphrase' ? keyFiles.value.length : null,
+                show_clues:       showClues.value,
             }),
         });
 
@@ -264,11 +266,11 @@ const submit = async () => {
 
         localStorage.removeItem('locker_pending_token');
         credentials.value = {
-            account_id:  data.account_id,
-            passphrase:  passphrase.value,
-            expires_at:  data.expires_at,
-            keyFileFingerprints: keyFiles.value.map(kf => kf.fingerprint),
-            authMode: authMode.value,
+            account_id:   data.account_id,
+            passphrase:   passphrase.value,
+            expires_at:   data.expires_at,
+            keyFileNames: keyFiles.value.map(kf => kf.file.name),
+            authMode:     authMode.value,
         };
         step.value = 'credentials';
 
@@ -311,11 +313,11 @@ const submit = async () => {
                         </div>
 
                         <div v-if="credentials.authMode !== 'passphrase'" class="bg-gray-900 rounded-lg p-3">
-                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Key File Fingerprints (load in this order)</div>
+                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Key Files (load in this order)</div>
                             <div class="space-y-1 mt-2">
-                                <div v-for="(fp, i) in credentials.keyFileFingerprints" :key="i" class="flex items-center gap-2">
-                                    <span class="text-gamboge-300/60 font-mono text-xs w-4">{{ i + 1 }}.</span>
-                                    <code class="text-white text-sm font-mono">{{ fp }}</code>
+                                <div v-for="(name, i) in credentials.keyFileNames" :key="i" class="flex items-center gap-2">
+                                    <span class="text-gamboge-300/60 text-xs w-4 shrink-0">{{ i + 1 }}.</span>
+                                    <span class="text-white text-sm truncate">{{ name }}</span>
                                 </div>
                             </div>
                             <p class="text-gray-500 text-xs mt-2">Key files must be loaded in this exact order when unlocking.</p>
@@ -452,8 +454,7 @@ const submit = async () => {
                                     class="flex items-center gap-3 bg-gray-900 rounded-lg px-3 py-2"
                                 >
                                     <span class="text-gamboge-300/60 font-mono text-xs w-4 shrink-0">{{ i + 1 }}.</span>
-                                    <code class="text-gamboge-300 font-mono text-sm flex-1">{{ kf.fingerprint }}</code>
-                                    <span class="text-gray-500 text-xs truncate max-w-32">{{ kf.file.name }}</span>
+                                    <span class="text-white text-sm flex-1 truncate">{{ kf.file.name }}</span>
                                     <button
                                         type="button"
                                         @click="removeKeyFile(i)"
@@ -469,6 +470,22 @@ const submit = async () => {
                             </label>
                             <p v-if="errors.key_files" class="text-red-400 text-xs mt-1">{{ errors.key_files }}</p>
                             <p v-else class="text-gray-500 text-xs mt-1">{{ keyFiles.length }} key file(s) added. Files are processed locally — no content is uploaded.</p>
+
+                            <!-- Show clues toggle -->
+                            <label class="flex items-start gap-2 text-sm cursor-pointer mt-3">
+                                <input
+                                    type="checkbox"
+                                    v-model="showClues"
+                                    class="mt-0.5 rounded border-gray-600 bg-gray-700 text-gamboge-300 shrink-0"
+                                    data-testid="show-clues-checkbox"
+                                />
+                                <span class="text-gray-400 text-xs">
+                                    Show unlock hints (displays required credential type and count on the unlock page)
+                                </span>
+                            </label>
+                            <p v-if="!showClues" class="text-gray-500 text-xs mt-1 ml-5">
+                                The unlock page will show a generic interface with no hints about what credentials are needed.
+                            </p>
 
                             <!-- Recovery acknowledgement (required) -->
                             <label class="flex items-start gap-2 text-sm cursor-pointer mt-3 p-3 bg-red-900/10 border border-red-500/30 rounded-lg">

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -28,6 +28,11 @@ const passphrase   = ref('');
 const content      = ref('');
 const selectedFile = ref(null);
 
+// Auth mode
+const authMode             = ref('passphrase'); // 'passphrase' | 'key_file' | 'combined'
+const keyFiles             = ref([]); // [{ file: File, hash: string, fingerprint: string }]
+const keyFileRiskAcknowledged = ref(false);
+
 // State
 const step          = ref('form'); // 'form' | 'encrypting' | 'uploading' | 'credentials'
 const uploadProgress = ref(0);
@@ -57,17 +62,73 @@ const generatePassphrase = () => { passphrase.value = enc.generatePasssphrase();
 const onFileChange = (e) => { selectedFile.value = e.target.files[0] ?? null; };
 const copyToClipboard = async (text) => { await navigator.clipboard.writeText(text); };
 
+const onKeyFileAdded = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    e.target.value = '';
+
+    const buffer = await file.arrayBuffer();
+    const hash = await enc.deriveLockerKeyFromFile(buffer);
+    const fingerprint = hash.slice(0, 8);
+    keyFiles.value.push({ file, hash, fingerprint });
+};
+
+const removeKeyFile = (index) => {
+    keyFiles.value.splice(index, 1);
+};
+
+const setAuthMode = (mode) => {
+    authMode.value = mode;
+    keyFiles.value = [];
+    keyFileRiskAcknowledged.value = false;
+};
+
+const computeEffectivePassphrase = async () => {
+    if (authMode.value === 'passphrase') {
+        return passphrase.value;
+    }
+    // Re-read buffers from File references at submit time — avoids holding large ArrayBuffers in memory
+    const fileHashes = await Promise.all(
+        keyFiles.value.map(async (kf) => {
+            const buf = await kf.file.arrayBuffer();
+            return enc.deriveLockerKeyFromFile(buf);
+        })
+    );
+    if (authMode.value === 'key_file') {
+        return enc.combineLockerKeyMaterials(fileHashes);
+    }
+    return enc.combineLockerKeyMaterials([passphrase.value, ...fileHashes]);
+};
+
 const downloadCredentials = () => {
-    const text = [
+    const lines = [
         'eLocker Credentials — Save these securely. They cannot be recovered.',
         '',
         `Account ID: ${credentials.value.account_id}`,
-        `Passphrase: ${credentials.value.passphrase}`,
-        '',
-        `Expires: ${new Date(credentials.value.expires_at).toLocaleDateString()}`,
-        '',
-        'Note: Your passphrase is the only key to decrypt and modify your locker.',
-    ].join('\n');
+    ];
+
+    if (authMode.value !== 'key_file') {
+        lines.push(`Passphrase: ${credentials.value.passphrase}`);
+    }
+
+    if (authMode.value !== 'passphrase') {
+        lines.push('');
+        lines.push('Key File Fingerprints (load in this exact order when unlocking):');
+        credentials.value.keyFileFingerprints.forEach((fp, i) => {
+            lines.push(`  ${i + 1}. ${fp}`);
+        });
+        lines.push('');
+        lines.push('IMPORTANT: Key files must be loaded in this exact order. Refer to this file');
+        lines.push('for the required fingerprint sequence. There is no recovery if you lose your key files.');
+    }
+
+    lines.push('', `Expires: ${new Date(credentials.value.expires_at).toLocaleDateString()}`);
+
+    if (authMode.value === 'passphrase') {
+        lines.push('', 'Note: Your passphrase is the only key to decrypt and modify your locker.');
+    }
+
+    const text = lines.join('\n');
     const blob = new Blob([text], { type: 'text/plain' });
     const url  = URL.createObjectURL(blob);
     const a    = document.createElement('a');
@@ -86,8 +147,16 @@ const submit = async () => {
         errors.value.account_id = 'Account ID must be exactly 10 digits.';
         return;
     }
-    if (!passphrase.value || passphrase.value.length < 8) {
+    if (authMode.value !== 'key_file' && (!passphrase.value || passphrase.value.length < 8)) {
         errors.value.passphrase = 'Passphrase must be at least 8 characters.';
+        return;
+    }
+    if (authMode.value !== 'passphrase' && keyFiles.value.length === 0) {
+        errors.value.key_files = 'Please add at least one key file.';
+        return;
+    }
+    if (authMode.value !== 'passphrase' && !keyFileRiskAcknowledged.value) {
+        errors.value.key_file_risk = 'You must acknowledge the key file risk before continuing.';
         return;
     }
     if (!isFileTier.value && !content.value.trim()) {
@@ -103,29 +172,27 @@ const submit = async () => {
     uploadProgress.value = 0;
 
     try {
-        const { privateKey: _unusedKey, publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(passphrase.value, accountId.value);
+        const effectivePassphrase = await computeEffectivePassphrase();
+
+        const { privateKey: _unusedKey, publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(effectivePassphrase, accountId.value);
 
         let payload;
         let storagePath = null;
-
         let wrappedFileKey = null;
 
         if (isFileTier.value) {
-            // Encrypt file metadata into the payload field
             const meta = JSON.stringify({
                 name: selectedFile.value.name,
                 type: selectedFile.value.type,
                 size: selectedFile.value.size,
             });
-            payload = await enc.encryptLockerContent(meta, passphrase.value);
+            payload = await enc.encryptLockerContent(meta, effectivePassphrase);
 
-            // Generate DEK, wrap it with passphrase, encrypt file with DEK
             const dek = enc.generateLockerFileKey();
-            wrappedFileKey = await enc.wrapLockerFileKey(dek, passphrase.value, accountId.value);
+            wrappedFileKey = await enc.wrapLockerFileKey(dek, effectivePassphrase, accountId.value);
             const fileBuffer = await selectedFile.value.arrayBuffer();
             const encryptedBytes = await enc.encryptLockerFileToBuffer(fileBuffer, { dek });
 
-            // Get presigned upload URL
             const prepRes = await fetch(route('lockers.file.prepare'), {
                 method: 'POST',
                 headers: {
@@ -141,7 +208,6 @@ const submit = async () => {
             const { upload_url, upload_headers, storage_path } = await prepRes.json();
             storagePath = storage_path;
 
-            // Upload encrypted binary via XHR for progress tracking (encryptedBytes is already Uint8Array)
             step.value = 'uploading';
             await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
@@ -159,7 +225,7 @@ const submit = async () => {
                 xhr.send(new Blob([encryptedBytes], { type: 'application/octet-stream' }));
             });
         } else {
-            payload = await enc.encryptLockerContent(content.value, passphrase.value);
+            payload = await enc.encryptLockerContent(content.value, effectivePassphrase);
         }
 
         const res = await fetch(route('lockers.store'), {
@@ -177,6 +243,8 @@ const submit = async () => {
                 tier:             props.tier,
                 storage_path:     storagePath,
                 wrapped_file_key: wrappedFileKey,
+                auth_mode:        authMode.value,
+                key_file_count:   authMode.value !== 'passphrase' ? keyFiles.value.length : null,
             }),
         });
 
@@ -199,6 +267,8 @@ const submit = async () => {
             account_id:  data.account_id,
             passphrase:  passphrase.value,
             expires_at:  data.expires_at,
+            keyFileFingerprints: keyFiles.value.map(kf => kf.fingerprint),
+            authMode: authMode.value,
         };
         step.value = 'credentials';
 
@@ -219,22 +289,36 @@ const submit = async () => {
                     <h1 class="text-2xl font-bold text-white mb-2">Locker created!</h1>
                     <div class="bg-red-900/20 border border-red-500/40 rounded-lg p-4 mb-6 text-red-300 text-sm">
                         <p class="font-semibold text-red-200 mb-1">Save these credentials now — they cannot be recovered.</p>
-                        Your passphrase is the only key to decrypt, update, or delete this locker. The server has never seen it.
+                        <span v-if="credentials.authMode === 'passphrase'">Your passphrase is the only key to decrypt, update, or delete this locker. The server has never seen it.</span>
+                        <span v-else>Your key file(s) and passphrase are the only way to access this locker. The server has never seen them.</span>
                     </div>
 
                     <div class="space-y-4 mb-6 ph-no-capture">
-                        <div v-for="field in [
-                            { label: 'Account ID', value: credentials.account_id },
-                            { label: 'Passphrase', value: credentials.passphrase },
-                        ]" :key="field.label" class="bg-gray-900 rounded-lg p-3">
-                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">{{ field.label }}</div>
+                        <div class="bg-gray-900 rounded-lg p-3">
+                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Account ID</div>
                             <div class="flex items-center gap-2">
-                                <code class="text-white text-sm flex-1 break-all font-mono">{{ field.value }}</code>
-                                <button
-                                    @click="copyToClipboard(field.value)"
-                                    class="shrink-0 text-gray-400 hover:text-gamboge-300 transition-colors text-xs border border-gray-700 hover:border-gamboge-300 rounded px-2 py-1"
-                                >Copy</button>
+                                <code class="text-white text-sm flex-1 break-all font-mono">{{ credentials.account_id }}</code>
+                                <button @click="copyToClipboard(credentials.account_id)" class="shrink-0 text-gray-400 hover:text-gamboge-300 transition-colors text-xs border border-gray-700 hover:border-gamboge-300 rounded px-2 py-1">Copy</button>
                             </div>
+                        </div>
+
+                        <div v-if="credentials.authMode !== 'key_file'" class="bg-gray-900 rounded-lg p-3">
+                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Passphrase</div>
+                            <div class="flex items-center gap-2">
+                                <code class="text-white text-sm flex-1 break-all font-mono">{{ credentials.passphrase }}</code>
+                                <button @click="copyToClipboard(credentials.passphrase)" class="shrink-0 text-gray-400 hover:text-gamboge-300 transition-colors text-xs border border-gray-700 hover:border-gamboge-300 rounded px-2 py-1">Copy</button>
+                            </div>
+                        </div>
+
+                        <div v-if="credentials.authMode !== 'passphrase'" class="bg-gray-900 rounded-lg p-3">
+                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Key File Fingerprints (load in this order)</div>
+                            <div class="space-y-1 mt-2">
+                                <div v-for="(fp, i) in credentials.keyFileFingerprints" :key="i" class="flex items-center gap-2">
+                                    <span class="text-gamboge-300/60 font-mono text-xs w-4">{{ i + 1 }}.</span>
+                                    <code class="text-white text-sm font-mono">{{ fp }}</code>
+                                </div>
+                            </div>
+                            <p class="text-gray-500 text-xs mt-2">Key files must be loaded in this exact order when unlocking.</p>
                         </div>
                     </div>
 
@@ -247,7 +331,7 @@ const submit = async () => {
 
                     <label class="flex items-center gap-2 text-gray-300 text-sm mb-4 cursor-pointer">
                         <input type="checkbox" v-model="savedConfirmed" class="rounded border-gray-600 bg-gray-700 text-gamboge-300" />
-                        I have saved both credentials
+                        I have saved my credentials
                     </label>
 
                     <button
@@ -295,8 +379,39 @@ const submit = async () => {
                             <p v-else class="text-gray-500 text-xs mt-1">Your memorable number — like a bank account ID.</p>
                         </div>
 
-                        <!-- Passphrase -->
+                        <!-- Authentication Mode -->
                         <div>
+                            <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Authentication Mode</label>
+                            <div class="flex gap-2">
+                                <button
+                                    v-for="mode in [
+                                        { value: 'passphrase', label: 'Passphrase' },
+                                        { value: 'key_file',  label: 'Key File(s)' },
+                                        { value: 'combined',  label: 'Both' },
+                                    ]"
+                                    :key="mode.value"
+                                    type="button"
+                                    @click="setAuthMode(mode.value)"
+                                    class="flex-1 py-2 rounded-lg font-mono text-xs transition-colors border"
+                                    :class="authMode === mode.value
+                                        ? 'bg-gamboge-300/20 border-gamboge-300 text-gamboge-300 shadow-neon-cyan-sm'
+                                        : 'border-gray-600 text-gray-400 hover:border-gray-400'"
+                                >
+                                    {{ mode.label }}
+                                </button>
+                            </div>
+                            <p class="text-gray-500 text-xs mt-1">
+                                <span v-if="authMode === 'passphrase'">Passphrase only — current behaviour.</span>
+                                <span v-else-if="authMode === 'key_file'">One or more key files required to unlock.</span>
+                                <span v-else>Both passphrase and all key files required.</span>
+                            </p>
+                            <div v-if="authMode !== 'passphrase'" class="mt-2 bg-amber-900/20 border border-amber-500/40 rounded-lg p-3 text-amber-400 text-xs">
+                                &#x26A0; Key file credential rotation is not yet supported. To change your key files in the future, you will need to recreate the locker.
+                            </div>
+                        </div>
+
+                        <!-- Passphrase — hidden for key_file mode -->
+                        <div v-if="authMode !== 'key_file'">
                             <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Passphrase</label>
                             <div class="flex gap-2">
                                 <input
@@ -319,6 +434,54 @@ const submit = async () => {
                             </div>
                             <p v-if="errors.passphrase" class="text-red-400 text-xs mt-1">{{ errors.passphrase }}</p>
                             <p v-else class="text-gray-500 text-xs mt-1">This also controls who can update or delete the locker — keep it safe.</p>
+                        </div>
+
+                        <!-- Key File section — shown for key_file and combined modes -->
+                        <div v-if="authMode !== 'passphrase'">
+                            <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Key Files</label>
+                            <p class="text-gray-500 text-xs mb-3">
+                                Use a unique file only you possess — a personal photo, private document, or generated key file.
+                                Avoid widely-shared files (stock images, public downloads). The file must never change — even a single byte difference will lock you out.
+                            </p>
+
+                            <div v-if="keyFiles.length > 0" class="mb-3 space-y-2">
+                                <div
+                                    v-for="(kf, i) in keyFiles"
+                                    :key="i"
+                                    class="flex items-center gap-3 bg-gray-900 rounded-lg px-3 py-2"
+                                >
+                                    <span class="text-gamboge-300/60 font-mono text-xs w-4 shrink-0">{{ i + 1 }}.</span>
+                                    <code class="text-gamboge-300 font-mono text-sm flex-1">{{ kf.fingerprint }}</code>
+                                    <span class="text-gray-500 text-xs truncate max-w-32">{{ kf.file.name }}</span>
+                                    <button
+                                        type="button"
+                                        @click="removeKeyFile(i)"
+                                        class="shrink-0 text-gray-500 hover:text-red-400 font-mono text-xs transition-colors"
+                                        title="Remove"
+                                    >✕</button>
+                                </div>
+                            </div>
+
+                            <label class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 rounded-lg px-3 py-2.5 transition-colors text-gray-400 text-sm">
+                                <span class="font-mono text-xs">+ Add key file</span>
+                                <input type="file" class="sr-only" @change="onKeyFileAdded" />
+                            </label>
+                            <p v-if="errors.key_files" class="text-red-400 text-xs mt-1">{{ errors.key_files }}</p>
+                            <p v-else class="text-gray-500 text-xs mt-1">{{ keyFiles.length }} key file(s) added. Files are processed locally — no content is uploaded.</p>
+
+                            <!-- Recovery acknowledgement (required) -->
+                            <label class="flex items-start gap-2 text-sm cursor-pointer mt-3 p-3 bg-red-900/10 border border-red-500/30 rounded-lg">
+                                <input
+                                    type="checkbox"
+                                    v-model="keyFileRiskAcknowledged"
+                                    class="mt-0.5 rounded border-gray-600 bg-gray-700 text-gamboge-300 shrink-0"
+                                    data-testid="key-file-risk-checkbox"
+                                />
+                                <span class="text-red-300 text-xs">
+                                    I understand that if I lose my key file(s), my locker cannot be unlocked by anyone, including FlashView support. There is no recovery option.
+                                </span>
+                            </label>
+                            <p v-if="errors.key_file_risk" class="text-red-400 text-xs mt-1">{{ errors.key_file_risk }}</p>
                         </div>
 
                         <!-- Content -->
@@ -348,6 +511,7 @@ const submit = async () => {
                             @click="submit"
                             :disabled="step !== 'form'"
                             class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-60 disabled:cursor-not-allowed text-gray-900 font-semibold py-3 px-4 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
+                            data-testid="create-submit-button"
                         >
                             <span v-if="step === 'encrypting'">Encrypting…</span>
                             <span v-else-if="step === 'uploading'">Uploading…</span>

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -72,6 +72,7 @@ const passphraseChangeState    = ref(null); // null | 'encrypting' | 'uploading'
 const passphraseChangeProgress = ref(0);
 
 // Credential rotation state (key_file and combined modes)
+const rotAuthMode           = ref('passphrase'); // chosen new auth mode during rotation
 const newKeyFiles           = ref([]); // [{ file: File }]
 const newPassphraseRot      = ref('');
 const credRotateError       = ref('');
@@ -188,6 +189,7 @@ const lockLocker = () => {
     passphraseChangeError.value   = '';
     passphraseChangeSuccess.value = false;
     newPassphrase.value           = '';
+    rotAuthMode.value             = 'passphrase';
     newKeyFiles.value             = [];
     newPassphraseRot.value        = '';
     credRotateError.value         = '';
@@ -314,6 +316,15 @@ const unlock = async () => {
 
         failCount.value = 0;
         lockState.value = 'unlocked';
+
+        // Initialise rotation mode to the current auth mode (or infer from credentials in no-clues mode)
+        if (!showClues.value) {
+            const usedPassphrase = passphrase.value.length > 0;
+            const usedFiles = keyFiles.value.length > 0;
+            rotAuthMode.value = (usedPassphrase && usedFiles) ? 'combined' : (usedFiles ? 'key_file' : 'passphrase');
+        } else {
+            rotAuthMode.value = authMode.value;
+        }
 
     } catch (err) {
         const elapsed = Date.now() - animationStart;
@@ -649,20 +660,16 @@ const removeNewKeyFile = (index) => {
 };
 
 const computeNewEffectivePassphrase = async () => {
+    if (rotAuthMode.value === 'passphrase') {
+        return newPassphraseRot.value;
+    }
     const fileHashes = await Promise.all(
         newKeyFiles.value.map(async (kf) => {
             const buf = await kf.file.arrayBuffer();
             return enc.deriveLockerKeyFromFile(buf);
         })
     );
-    // In no-clues mode the real authMode is unknown; derive from what was provided
-    if (!showClues.value) {
-        const hasPassphrase = newPassphraseRot.value.length > 0;
-        if (!fileHashes.length) return newPassphraseRot.value;
-        if (!hasPassphrase) return enc.combineLockerKeyMaterials(fileHashes);
-        return enc.combineLockerKeyMaterials([newPassphraseRot.value, ...fileHashes]);
-    }
-    if (authMode.value === 'key_file') {
+    if (rotAuthMode.value === 'key_file') {
         return enc.combineLockerKeyMaterials(fileHashes);
     }
     // combined
@@ -674,19 +681,12 @@ const rotateCredentials = async () => {
     credRotateSuccess.value = false;
 
     // Validation
-    const needsPassphrase = showClues.value ? authMode.value !== 'key_file' : newPassphraseRot.value.length > 0;
-    const needsFiles      = showClues.value ? authMode.value !== 'passphrase' : true;
-
-    if (needsPassphrase && newPassphraseRot.value.length < 8) {
+    if (rotAuthMode.value !== 'key_file' && newPassphraseRot.value.length < 8) {
         credRotateError.value = 'New passphrase must be at least 8 characters.';
         return;
     }
-    if (needsFiles && newKeyFiles.value.length === 0) {
+    if (rotAuthMode.value !== 'passphrase' && newKeyFiles.value.length === 0) {
         credRotateError.value = 'Please add at least one key file.';
-        return;
-    }
-    if (showClues.value && keyFileCount.value && newKeyFiles.value.length !== keyFileCount.value) {
-        credRotateError.value = `Please add exactly ${keyFileCount.value} key file(s) — the same number as at creation.`;
         return;
     }
 
@@ -699,7 +699,12 @@ const rotateCredentials = async () => {
         const newEp = await computeNewEffectivePassphrase();
 
         const { publicKeyJwkBase64: newPublicKey } = await enc.deriveLockerSigningKeypair(newEp, props.account_id);
-        const putBody = { new_public_key: newPublicKey };
+        const newKeyFileCount = rotAuthMode.value !== 'passphrase' ? newKeyFiles.value.length : null;
+        const putBody = {
+            new_public_key:    newPublicKey,
+            new_auth_mode:     rotAuthMode.value,
+            new_key_file_count: newKeyFileCount,
+        };
 
         if (isFileLocker.value && wrappedFileKey.value) {
             // v2 file locker: re-wrap DEK with new credentials — no file re-download needed
@@ -795,6 +800,9 @@ const rotateCredentials = async () => {
         newKeyFiles.value       = [];
         newPassphraseRot.value  = '';
         credRotateSuccess.value = true;
+        // Reflect new auth structure in the current session
+        authMode.value      = rotAuthMode.value;
+        keyFileCount.value  = newKeyFileCount;
 
     } catch (err) {
         credRotateError.value = err.message || 'Rotation failed. Please try again.';
@@ -1137,8 +1145,8 @@ const upgradeAuth = async () => {
                     <p class="text-gray-500 text-xs">Unlock your locker to update or delete it.</p>
                 </div>
 
-                <!-- Change Passphrase panel — only when unlocked and in passphrase mode -->
-                <div v-if="lockState === 'unlocked' && authMode === 'passphrase'" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
+                <!-- Change Passphrase panel — only for legacy (HMAC) lockers -->
+                <div v-if="lockState === 'unlocked' && isLegacyLocker" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
                     <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Change Passphrase</h2>
                     <p class="text-gray-400 text-xs">Your content will be re-encrypted with the new passphrase. This cannot be undone.</p>
 
@@ -1174,15 +1182,37 @@ const upgradeAuth = async () => {
                     >Change Passphrase</button>
                 </div>
 
-                <!-- Credential Rotation — key_file and combined modes, or no-clues mode (may have files) -->
-                <div v-if="lockState === 'unlocked' && (authMode !== 'passphrase' || !showClues)" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
+                <!-- Credential Rotation — all ECDSA lockers (legacy lockers use Change Passphrase above) -->
+                <div v-if="lockState === 'unlocked' && !isLegacyLocker" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
                     <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Change Credentials</h2>
-                    <p class="text-gray-400 text-xs">
-                        Your locker content will be re-encrypted with your new credentials. The key file count cannot change — provide the same number as when you created this locker.
-                    </p>
+                    <p class="text-gray-400 text-xs">Content is re-encrypted with your new credentials. You can switch authentication mode or change your key files.</p>
 
-                    <!-- New passphrase (combined mode or no-clues with passphrase) -->
-                    <div v-if="showClues ? authMode === 'combined' : true">
+                    <!-- Auth mode selector -->
+                    <div>
+                        <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">New Authentication Mode</label>
+                        <div class="flex gap-2">
+                            <button
+                                v-for="mode in [
+                                    { value: 'passphrase', label: 'Passphrase' },
+                                    { value: 'key_file',  label: 'Key File(s)' },
+                                    { value: 'combined',  label: 'Both' },
+                                ]"
+                                :key="mode.value"
+                                type="button"
+                                @click="rotAuthMode = mode.value; newKeyFiles = []; newPassphraseRot = ''"
+                                class="flex-1 py-2 rounded-lg font-mono text-xs transition-colors border"
+                                :class="rotAuthMode === mode.value
+                                    ? 'bg-gamboge-300/20 border-gamboge-300 text-gamboge-300 shadow-neon-cyan-sm'
+                                    : 'border-gray-600 text-gray-400 hover:border-gray-400'"
+                                data-testid="rot-mode-button"
+                            >
+                                {{ mode.label }}
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- New passphrase (passphrase and combined modes) -->
+                    <div v-if="rotAuthMode !== 'key_file'">
                         <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">New Passphrase</label>
                         <div class="flex gap-2">
                             <input
@@ -1190,6 +1220,7 @@ const upgradeAuth = async () => {
                                 type="text"
                                 placeholder="Enter or generate a new passphrase"
                                 class="flex-1 bg-gray-900 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none"
+                                data-testid="new-passphrase-rot-input"
                             />
                             <button
                                 @click="newPassphraseRot = enc.generatePasssphrase()"
@@ -1198,12 +1229,10 @@ const upgradeAuth = async () => {
                         </div>
                     </div>
 
-                    <!-- New key files -->
-                    <div v-if="showClues ? authMode !== 'passphrase' : true" class="space-y-2">
+                    <!-- New key files (key_file and combined modes) -->
+                    <div v-if="rotAuthMode !== 'passphrase'" class="space-y-2">
                         <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">New Key Files</label>
-                        <p v-if="showClues && keyFileCount" class="text-gray-500 text-xs">
-                            Add {{ keyFileCount }} new key file(s) in the same order you want for future unlocks.
-                        </p>
+                        <p class="text-gray-500 text-xs">Add your new key files in the order you want to use for future unlocks.</p>
 
                         <div v-if="newKeyFiles.length > 0" class="space-y-1">
                             <div
@@ -1222,22 +1251,16 @@ const upgradeAuth = async () => {
                             </div>
                         </div>
 
-                        <label
-                            v-if="showClues ? newKeyFiles.length < (keyFileCount ?? 999) : true"
-                            class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
-                        >
-                            <span class="font-mono text-xs">+ Add new key file</span>
+                        <label class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm">
+                            <span class="font-mono text-xs">+ Add key file</span>
                             <input type="file" class="sr-only" @change="onNewKeyFileAdded" data-testid="new-key-file-input" />
                         </label>
-
-                        <p v-if="showClues && keyFileCount" class="text-xs text-gray-500 font-mono">
-                            {{ newKeyFiles.length }} / {{ keyFileCount }} added
-                        </p>
+                        <p class="text-gray-500 text-xs">{{ newKeyFiles.length }} key file(s) added.</p>
                     </div>
 
                     <FileProgressBar v-if="credRotateState" :state="credRotateState" :progress="credRotateProgress" />
                     <p v-if="credRotateError" class="text-red-400 text-xs">{{ credRotateError }}</p>
-                    <p v-if="credRotateSuccess" class="text-gamboge-300 text-xs">Credentials changed successfully. Use your new credentials next time you unlock.</p>
+                    <p v-if="credRotateSuccess" class="text-gamboge-300 text-xs">Credentials changed. Use your new credentials next time you unlock.</p>
 
                     <button
                         v-if="!credRotateState"

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -624,6 +624,39 @@ const changePassphrase = async () => {
     }
 };
 
+// Settings state
+const showCluesUpdating = ref(false);
+const showCluesError    = ref('');
+
+const toggleShowClues = async () => {
+    showCluesError.value = '';
+    showCluesUpdating.value = true;
+    try {
+        const authHeaders = await fetchSigningHeaders();
+        const newValue = !showClues.value;
+
+        const res = await fetch(route('lockers.settings', props.account_id), {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-XSRF-TOKEN': getXsrf(),
+                ...authHeaders,
+            },
+            body: JSON.stringify({ show_clues: newValue }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) { showCluesError.value = data.error ?? 'Failed to update setting.'; return; }
+
+        showClues.value = newValue;
+    } catch (err) {
+        showCluesError.value = err.message || 'Failed to update setting.';
+    } finally {
+        showCluesUpdating.value = false;
+    }
+};
+
 const confirmDelete = async () => {
     deleteError.value = '';
     deleting.value    = true;
@@ -967,6 +1000,36 @@ const upgradeAuth = async () => {
                     <p class="text-gray-400 text-xs">
                         Key file credential rotation is not yet supported. To change your key files, create a new locker and migrate your content.
                     </p>
+                </div>
+
+                <!-- Locker Settings — unlock hints toggle, shown for all modes when unlocked -->
+                <div v-if="lockState === 'unlocked'" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-3">
+                    <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Locker Settings</h2>
+
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="flex-1">
+                            <div class="text-white text-sm mb-0.5">Show unlock hints</div>
+                            <p class="text-gray-500 text-xs">
+                                When enabled, the unlock page shows what credential type is required (passphrase, key file, or both) and how many files are needed.
+                                Disable for maximum security — visitors will see a generic interface with no hints.
+                            </p>
+                        </div>
+                        <button
+                            @click="toggleShowClues"
+                            :disabled="showCluesUpdating"
+                            class="shrink-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none disabled:opacity-50"
+                            :class="showClues ? 'bg-gamboge-300 shadow-neon-cyan-sm' : 'bg-gray-600'"
+                            data-testid="show-clues-toggle"
+                            :title="showClues ? 'Unlock hints visible — click to hide' : 'Unlock hints hidden — click to show'"
+                        >
+                            <span
+                                class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform"
+                                :class="showClues ? 'translate-x-6' : 'translate-x-1'"
+                            />
+                        </button>
+                    </div>
+
+                    <p v-if="showCluesError" class="text-red-400 text-xs">{{ showCluesError }}</p>
                 </div>
 
                 <!-- Delete panel — only when unlocked -->

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -64,12 +64,21 @@ const deleteError       = ref('');
 const deleting          = ref(false);
 const showDeleteConfirm = ref(false);
 
-// Passphrase change state
+// Passphrase change state (passphrase-only mode)
 const newPassphrase            = ref('');
 const passphraseChangeError    = ref('');
 const passphraseChangeSuccess  = ref(false);
 const passphraseChangeState    = ref(null); // null | 'encrypting' | 'uploading'
 const passphraseChangeProgress = ref(0);
+
+// Credential rotation state (key_file and combined modes)
+const newKeyFiles           = ref([]); // [{ file: File }]
+const newPassphraseRot      = ref('');
+const credRotateError       = ref('');
+const credRotateSuccess     = ref(false);
+const credRotating          = ref(false);
+const credRotateState       = ref(null); // null | 'encrypting' | 'uploading'
+const credRotateProgress    = ref(0);
 
 const newPassphraseStrength = computed(() => {
     const p = newPassphrase.value;
@@ -179,6 +188,10 @@ const lockLocker = () => {
     passphraseChangeError.value   = '';
     passphraseChangeSuccess.value = false;
     newPassphrase.value           = '';
+    newKeyFiles.value             = [];
+    newPassphraseRot.value        = '';
+    credRotateError.value         = '';
+    credRotateSuccess.value       = false;
     deleteError.value             = '';
     showDeleteConfirm.value       = false;
     isLegacyLocker.value          = false;
@@ -624,6 +637,173 @@ const changePassphrase = async () => {
     }
 };
 
+const onNewKeyFileAdded = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    e.target.value = '';
+    newKeyFiles.value.push({ file });
+};
+
+const removeNewKeyFile = (index) => {
+    newKeyFiles.value.splice(index, 1);
+};
+
+const computeNewEffectivePassphrase = async () => {
+    const fileHashes = await Promise.all(
+        newKeyFiles.value.map(async (kf) => {
+            const buf = await kf.file.arrayBuffer();
+            return enc.deriveLockerKeyFromFile(buf);
+        })
+    );
+    // In no-clues mode the real authMode is unknown; derive from what was provided
+    if (!showClues.value) {
+        const hasPassphrase = newPassphraseRot.value.length > 0;
+        if (!fileHashes.length) return newPassphraseRot.value;
+        if (!hasPassphrase) return enc.combineLockerKeyMaterials(fileHashes);
+        return enc.combineLockerKeyMaterials([newPassphraseRot.value, ...fileHashes]);
+    }
+    if (authMode.value === 'key_file') {
+        return enc.combineLockerKeyMaterials(fileHashes);
+    }
+    // combined
+    return enc.combineLockerKeyMaterials([newPassphraseRot.value, ...fileHashes]);
+};
+
+const rotateCredentials = async () => {
+    credRotateError.value   = '';
+    credRotateSuccess.value = false;
+
+    // Validation
+    const needsPassphrase = showClues.value ? authMode.value !== 'key_file' : newPassphraseRot.value.length > 0;
+    const needsFiles      = showClues.value ? authMode.value !== 'passphrase' : true;
+
+    if (needsPassphrase && newPassphraseRot.value.length < 8) {
+        credRotateError.value = 'New passphrase must be at least 8 characters.';
+        return;
+    }
+    if (needsFiles && newKeyFiles.value.length === 0) {
+        credRotateError.value = 'Please add at least one key file.';
+        return;
+    }
+    if (showClues.value && keyFileCount.value && newKeyFiles.value.length !== keyFileCount.value) {
+        credRotateError.value = `Please add exactly ${keyFileCount.value} key file(s) — the same number as at creation.`;
+        return;
+    }
+
+    credRotating.value      = true;
+    credRotateState.value   = 'encrypting';
+    credRotateProgress.value = 0;
+
+    try {
+        const authHeaders = await fetchSigningHeaders();
+        const newEp = await computeNewEffectivePassphrase();
+
+        const { publicKeyJwkBase64: newPublicKey } = await enc.deriveLockerSigningKeypair(newEp, props.account_id);
+        const putBody = { new_public_key: newPublicKey };
+
+        if (isFileLocker.value && wrappedFileKey.value) {
+            // v2 file locker: re-wrap DEK with new credentials — no file re-download needed
+            const meta = JSON.stringify(decryptedFileMeta.value);
+            const newPayload = await enc.encryptLockerContent(meta, newEp);
+            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, effectivePassphrase.value, props.account_id);
+            const newWrappedKey = await enc.wrapLockerFileKey(dek, newEp, props.account_id);
+            putBody.new_wrapped_file_key = newWrappedKey;
+            putBody.payload = newPayload;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
+                body: JSON.stringify(putBody),
+            });
+            const data = await res.json();
+            if (!res.ok) { credRotateError.value = data.error ?? 'Rotation failed.'; return; }
+
+            effectivePassphrase.value = newEp;
+            wrappedFileKey.value      = newWrappedKey;
+
+        } else if (isFileLocker.value) {
+            // v1 legacy file locker: download, decrypt, re-encrypt, upload
+            const meta = JSON.stringify(decryptedFileMeta.value);
+            const newPayload = await enc.encryptLockerContent(meta, newEp);
+
+            const encryptedBytes = await new Promise((resolve, reject) => {
+                const xhr = new XMLHttpRequest();
+                xhr.open('GET', downloadUrl.value);
+                xhr.responseType = 'arraybuffer';
+                xhr.onprogress = (e) => {
+                    if (e.lengthComputable) credRotateProgress.value = Math.round((e.loaded / e.total) * 50);
+                };
+                xhr.onload  = () => (xhr.status >= 200 && xhr.status < 300) ? resolve(new Uint8Array(xhr.response)) : reject(new Error('Download failed.'));
+                xhr.onerror = () => reject(new Error('Download failed.'));
+                xhr.send();
+            });
+
+            const fileData = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: effectivePassphrase.value });
+            const reEncryptedBytes = await enc.encryptLockerFileToBuffer(fileData, { passphrase: newEp });
+
+            const prepRes = await fetch(route('lockers.file.prepare'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf() },
+                body: JSON.stringify({}),
+            });
+            if (!prepRes.ok) throw new Error('Could not prepare file upload.');
+            const { upload_url, upload_headers, storage_path: newStoragePath } = await prepRes.json();
+
+            credRotateState.value = 'uploading';
+            await new Promise((resolve, reject) => {
+                const xhr = new XMLHttpRequest();
+                xhr.open('PUT', upload_url);
+                for (const [k, v] of Object.entries(upload_headers ?? {})) xhr.setRequestHeader(k, v);
+                xhr.upload.onprogress = (e) => {
+                    if (e.lengthComputable) credRotateProgress.value = 50 + Math.round((e.loaded / e.total) * 50);
+                };
+                xhr.onload  = () => (xhr.status >= 200 && xhr.status < 300) ? resolve() : reject(new Error('Upload failed.'));
+                xhr.onerror = () => reject(new Error('Upload failed.'));
+                xhr.send(new Blob([reEncryptedBytes], { type: 'application/octet-stream' }));
+            });
+
+            putBody.payload      = newPayload;
+            putBody.storage_path = newStoragePath;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
+                body: JSON.stringify(putBody),
+            });
+            const data = await res.json();
+            if (!res.ok) { credRotateError.value = data.error ?? 'Rotation failed.'; return; }
+
+            effectivePassphrase.value = newEp;
+            downloadUrl.value         = '';
+
+        } else {
+            // Text locker
+            const newPayload = await enc.encryptLockerContent(decryptedText.value, newEp);
+            putBody.payload  = newPayload;
+
+            const res = await fetch(route('lockers.update', props.account_id), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf(), ...authHeaders },
+                body: JSON.stringify(putBody),
+            });
+            const data = await res.json();
+            if (!res.ok) { credRotateError.value = data.error ?? 'Rotation failed.'; return; }
+
+            effectivePassphrase.value = newEp;
+        }
+
+        newKeyFiles.value       = [];
+        newPassphraseRot.value  = '';
+        credRotateSuccess.value = true;
+
+    } catch (err) {
+        credRotateError.value = err.message || 'Rotation failed. Please try again.';
+    } finally {
+        credRotating.value    = false;
+        credRotateState.value = null;
+    }
+};
+
 // Settings state
 const showCluesUpdating = ref(false);
 const showCluesError    = ref('');
@@ -994,12 +1174,78 @@ const upgradeAuth = async () => {
                     >Change Passphrase</button>
                 </div>
 
-                <!-- Key file credential rotation notice — shown for key_file and combined modes when unlocked -->
-                <div v-if="lockState === 'unlocked' && authMode !== 'passphrase'" class="bg-gray-800 border border-gray-700 rounded-xl p-6">
-                    <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Credential Management</h2>
+                <!-- Credential Rotation — key_file and combined modes, or no-clues mode (may have files) -->
+                <div v-if="lockState === 'unlocked' && (authMode !== 'passphrase' || !showClues)" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
+                    <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Change Credentials</h2>
                     <p class="text-gray-400 text-xs">
-                        Key file credential rotation is not yet supported. To change your key files, create a new locker and migrate your content.
+                        Your locker content will be re-encrypted with your new credentials. The key file count cannot change — provide the same number as when you created this locker.
                     </p>
+
+                    <!-- New passphrase (combined mode or no-clues with passphrase) -->
+                    <div v-if="showClues ? authMode === 'combined' : true">
+                        <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">New Passphrase</label>
+                        <div class="flex gap-2">
+                            <input
+                                v-model="newPassphraseRot"
+                                type="text"
+                                placeholder="Enter or generate a new passphrase"
+                                class="flex-1 bg-gray-900 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none"
+                            />
+                            <button
+                                @click="newPassphraseRot = enc.generatePasssphrase()"
+                                class="shrink-0 border border-gamboge-300/50 text-gamboge-300 hover:border-gamboge-300 text-xs font-mono px-3 rounded-lg transition-colors"
+                            >Generate</button>
+                        </div>
+                    </div>
+
+                    <!-- New key files -->
+                    <div v-if="showClues ? authMode !== 'passphrase' : true" class="space-y-2">
+                        <label class="block text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">New Key Files</label>
+                        <p v-if="showClues && keyFileCount" class="text-gray-500 text-xs">
+                            Add {{ keyFileCount }} new key file(s) in the same order you want for future unlocks.
+                        </p>
+
+                        <div v-if="newKeyFiles.length > 0" class="space-y-1">
+                            <div
+                                v-for="(kf, i) in newKeyFiles"
+                                :key="i"
+                                class="flex items-center gap-3 bg-gray-900 rounded-lg px-3 py-2"
+                            >
+                                <span class="text-gamboge-300/60 text-xs w-4 shrink-0">{{ i + 1 }}.</span>
+                                <span class="text-white text-sm flex-1 truncate">{{ kf.file.name }}</span>
+                                <button
+                                    type="button"
+                                    @click="removeNewKeyFile(i)"
+                                    class="shrink-0 text-gray-500 hover:text-red-400 font-mono text-xs transition-colors"
+                                    title="Remove"
+                                >✕</button>
+                            </div>
+                        </div>
+
+                        <label
+                            v-if="showClues ? newKeyFiles.length < (keyFileCount ?? 999) : true"
+                            class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
+                        >
+                            <span class="font-mono text-xs">+ Add new key file</span>
+                            <input type="file" class="sr-only" @change="onNewKeyFileAdded" data-testid="new-key-file-input" />
+                        </label>
+
+                        <p v-if="showClues && keyFileCount" class="text-xs text-gray-500 font-mono">
+                            {{ newKeyFiles.length }} / {{ keyFileCount }} added
+                        </p>
+                    </div>
+
+                    <FileProgressBar v-if="credRotateState" :state="credRotateState" :progress="credRotateProgress" />
+                    <p v-if="credRotateError" class="text-red-400 text-xs">{{ credRotateError }}</p>
+                    <p v-if="credRotateSuccess" class="text-gamboge-300 text-xs">Credentials changed successfully. Use your new credentials next time you unlock.</p>
+
+                    <button
+                        v-if="!credRotateState"
+                        @click="rotateCredentials"
+                        :disabled="credRotating"
+                        class="w-full border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-xs py-2 rounded-lg transition-colors disabled:opacity-50"
+                        data-testid="rotate-credentials-button"
+                    >{{ credRotating ? 'Rotating…' : 'Change Credentials' }}</button>
                 </div>
 
                 <!-- Locker Settings — unlock hints toggle, shown for all modes when unlocked -->

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -803,7 +803,7 @@ const upgradeAuth = async () => {
 
                                 <label
                                     v-if="keyFiles.length < (keyFileCount ?? 999)"
-                                    class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
+                                    class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
                                     data-testid="key-file-input-label"
                                 >
                                     <span class="font-mono text-xs">+ Add key file</span>

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -1,7 +1,7 @@
 <script setup>
 import AppLayout from '@/Layouts/AppLayout.vue';
 import FileProgressBar from '@/Components/FileProgressBar.vue';
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { router } from '@inertiajs/vue3';
 import { encryption, LockerDecryptionError } from '@/encryption.js';
 
@@ -25,8 +25,14 @@ const upgradeSuccess   = ref(false);
 const upgradeDismissed = ref(false);
 const upgradeError     = ref('');
 
+// Auth mode — fetched on mount from auth-info endpoint
+const authMode     = ref('passphrase'); // 'passphrase' | 'key_file' | 'combined'
+const keyFileCount = ref(null);
+
 // Unlock state
 const passphrase        = ref('');
+const effectivePassphrase = ref(''); // Derived on unlock; cleared on lock. Never the raw passphrase for key_file/combined modes.
+const keyFiles          = ref([]); // [{ file: File, fingerprint: string }]
 const lockState         = ref('locked'); // 'locked' | 'animating' | 'unlocked' | 'shaking'
 const decryptError      = ref('');
 const failCount         = ref(0);
@@ -78,29 +84,92 @@ const newPassphraseStrengthWidth = computed(() => ['w-0', 'w-1/4', 'w-2/4', 'w-3
 const newPassphraseStrengthBg    = computed(() => ['', 'bg-red-400', 'bg-gamboge-500', 'bg-gamboge-400', 'bg-gamboge-300'][newPassphraseStrength.value] ?? '');
 const generateNewPassphrase = () => { newPassphrase.value = enc.generatePasssphrase(); };
 
+// Computed: whether the unlock button should be enabled
+const canUnlock = computed(() => {
+    if (lockState.value === 'animating' || lockState.value === 'shaking') return false;
+    if (authMode.value === 'key_file') {
+        return keyFiles.value.length >= (keyFileCount.value ?? 1);
+    }
+    if (authMode.value === 'combined') {
+        return passphrase.value.length > 0 && keyFiles.value.length >= (keyFileCount.value ?? 1);
+    }
+    return passphrase.value.length > 0;
+});
+
+onMounted(async () => {
+    try {
+        const infoRes = await fetch(route('lockers.auth-info', props.account_id), {
+            headers: { 'Accept': 'application/json' },
+        });
+        if (infoRes.ok) {
+            const info = await infoRes.json();
+            authMode.value = info.auth_mode ?? 'passphrase';
+            keyFileCount.value = info.key_file_count ?? null;
+        }
+    } catch {
+        // Fall through to passphrase default on network error
+    }
+});
+
+const onKeyFileAdded = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    e.target.value = '';
+
+    const buffer = await file.arrayBuffer();
+    const hash = await enc.deriveLockerKeyFromFile(buffer);
+    const fingerprint = hash.slice(0, 8);
+    keyFiles.value.push({ file, fingerprint });
+};
+
+const removeKeyFile = (index) => {
+    keyFiles.value.splice(index, 1);
+};
+
+const computeEffectivePassphrase = async () => {
+    if (authMode.value === 'passphrase') {
+        return passphrase.value;
+    }
+    // Re-read buffers from File references at call time to avoid holding large ArrayBuffers
+    const fileHashes = await Promise.all(
+        keyFiles.value.map(async (kf) => {
+            const buf = await kf.file.arrayBuffer();
+            return enc.deriveLockerKeyFromFile(buf);
+        })
+    );
+    if (authMode.value === 'key_file') {
+        return enc.combineLockerKeyMaterials(fileHashes);
+    }
+    return enc.combineLockerKeyMaterials([passphrase.value, ...fileHashes]);
+};
+
 const lockLocker = () => {
-    passphrase.value          = '';
-    decryptedText.value       = '';
-    decryptedFileMeta.value   = null;
-    downloadUrl.value         = '';
-    authChallenge.value       = '';
-    wrappedFileKey.value      = '';
-    decryptError.value        = '';
-    updateError.value         = '';
-    updateSuccess.value       = false;
-    newContent.value          = '';
-    replacementFile.value     = null;
+    // Security requirement: clear effectivePassphrase and key files to prevent re-unlock
+    // without re-presenting credentials
+    effectivePassphrase.value     = '';
+    keyFiles.value                = [];
+    passphrase.value              = '';
+    decryptedText.value           = '';
+    decryptedFileMeta.value       = null;
+    downloadUrl.value             = '';
+    authChallenge.value           = '';
+    wrappedFileKey.value          = '';
+    decryptError.value            = '';
+    updateError.value             = '';
+    updateSuccess.value           = false;
+    newContent.value              = '';
+    replacementFile.value         = null;
     passphraseChangeError.value   = '';
     passphraseChangeSuccess.value = false;
-    newPassphrase.value       = '';
-    deleteError.value         = '';
-    showDeleteConfirm.value   = false;
-    isLegacyLocker.value      = false;
-    upgrading.value           = false;
-    upgradeSuccess.value      = false;
-    upgradeDismissed.value    = false;
-    upgradeError.value        = '';
-    lockState.value           = 'locked';
+    newPassphrase.value           = '';
+    deleteError.value             = '';
+    showDeleteConfirm.value       = false;
+    isLegacyLocker.value          = false;
+    upgrading.value               = false;
+    upgradeSuccess.value          = false;
+    upgradeDismissed.value        = false;
+    upgradeError.value            = '';
+    lockState.value               = 'locked';
 };
 
 const daysRemaining = computed(() => {
@@ -127,13 +196,16 @@ const triggerShake = (msg) => {
 const getXsrf = () => decodeURIComponent(document.cookie.match(/XSRF-TOKEN=([^;]+)/)?.[1] ?? '');
 
 const unlock = async () => {
-    if (!passphrase.value || lockState.value === 'animating' || lockState.value === 'shaking') return;
+    if (!canUnlock.value) return;
     decryptError.value = '';
     lockState.value    = 'animating';
 
     const animationStart = Date.now();
 
     try {
+        // Compute effective passphrase from all credentials before any crypto operation
+        const ep = await computeEffectivePassphrase();
+
         // Step 1: Fetch challenge (always returns one — fake for non-existent accounts)
         const challengeRes = await fetch(route('lockers.challenge', props.account_id), {
             headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
@@ -153,13 +225,11 @@ const unlock = async () => {
 
         let unlockBody;
         if (isEcdsa) {
-            // ECDSA path: derive private key, sign the server challenge
-            const { privateKey } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+            const { privateKey } = await enc.deriveLockerSigningKeypair(ep, props.account_id);
             const signature = await enc.signLockerChallenge(privateKey, challengeData.challenge);
             unlockBody = { challenge_id: challengeData.challenge_id, signature };
         } else {
-            // Legacy HMAC path: derive verifier from passphrase
-            const authKey  = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
+            const authKey  = await enc.deriveLockerAuthKey(ep, props.account_id);
             const verifier = await enc.computeLockerVerifier(authKey, challengeData.challenge);
             unlockBody = { verifier };
         }
@@ -181,18 +251,25 @@ const unlock = async () => {
 
         if (!unlockRes.ok) {
             failCount.value++;
-            triggerShake(data.error ?? (unlockRes.status === 429 ? 'Too many attempts. Please try again later.' : 'Credentials do not match.'));
+            const baseMsg = data.error ?? (unlockRes.status === 429 ? 'Too many attempts. Please try again later.' : 'Credentials do not match.');
+            const hintMsg = authMode.value !== 'passphrase'
+                ? `${baseMsg} Check your key file order — files must match the creation sequence.`
+                : baseMsg;
+            triggerShake(hintMsg);
             return;
         }
 
-        // Success — populate state from unlock response (server uses snake_case JSON)
+        // Store effective passphrase for downstream operations — not passphrase.value directly
+        effectivePassphrase.value = ep;
+
+        // Success — populate state from unlock response
         isFileLocker.value   = data.is_file_locker ?? false;
         expiresAt.value      = data.expires_at ?? null;
         authChallenge.value  = data.auth_challenge ?? '';
         wrappedFileKey.value = data.wrapped_file_key ?? '';
         isLegacyLocker.value = !isEcdsa;
 
-        const result = await enc.decryptLockerContent(data.payload, passphrase.value);
+        const result = await enc.decryptLockerContent(data.payload, ep);
 
         if (data.is_file_locker) {
             try {
@@ -212,7 +289,7 @@ const unlock = async () => {
         const elapsed = Date.now() - animationStart;
         if (elapsed < 600) await sleep(600 - elapsed);
         failCount.value++;
-        triggerShake(err instanceof LockerDecryptionError ? 'Incorrect passphrase.' : 'Decryption failed. Please try again.');
+        triggerShake(err instanceof LockerDecryptionError ? 'Incorrect credentials.' : 'Decryption failed. Please try again.');
     }
 };
 
@@ -230,7 +307,6 @@ const downloadFile = async () => {
     fileProgress.value = 0;
 
     try {
-        // Download binary blob with XHR progress
         const encryptedBytes = await new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
             xhr.open('GET', downloadUrl.value);
@@ -243,16 +319,14 @@ const downloadFile = async () => {
             xhr.send();
         });
 
-        // Decrypt — v2 lockers use DEK from wrapped_file_key; v1 legacy use passphrase in blob
         let decryptedBuffer;
         if (wrappedFileKey.value) {
-            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, passphrase.value, props.account_id);
+            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, effectivePassphrase.value, props.account_id);
             decryptedBuffer = await enc.decryptLockerFileFromBuffer(encryptedBytes, { dek });
         } else {
-            decryptedBuffer = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: passphrase.value });
+            decryptedBuffer = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: effectivePassphrase.value });
         }
 
-        // Trigger browser download
         const name = decryptedFileMeta.value?.name ?? 'locker-file';
         const type = decryptedFileMeta.value?.type ?? 'application/octet-stream';
         const blob = new Blob([decryptedBuffer], { type });
@@ -275,14 +349,14 @@ const fetchSigningHeaders = async () => {
     const challengeData = await challengeRes.json();
 
     if (challengeData.challenge_id) {
-        const { privateKey } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+        const { privateKey } = await enc.deriveLockerSigningKeypair(effectivePassphrase.value, props.account_id);
         const signature = await enc.signLockerChallenge(privateKey, challengeData.challenge);
         return {
             'X-Signing-Challenge-Id': challengeData.challenge_id,
             'X-Signature': signature,
         };
     } else {
-        const updateToken = await enc.deriveLockerUpdateToken(passphrase.value, props.account_id);
+        const updateToken = await enc.deriveLockerUpdateToken(effectivePassphrase.value, props.account_id);
         return { 'X-Update-Token': updateToken };
     }
 };
@@ -294,7 +368,7 @@ const submitUpdate = async () => {
 
     updating.value = true;
     try {
-        const payload  = await enc.encryptLockerContent(newContent.value, passphrase.value);
+        const payload  = await enc.encryptLockerContent(newContent.value, effectivePassphrase.value);
         const authHeaders = await fetchSigningHeaders();
 
         const res = await fetch(route('lockers.update', props.account_id), {
@@ -332,19 +406,17 @@ const submitFileUpdate = async () => {
 
     try {
         const meta    = JSON.stringify({ name: replacementFile.value.name, type: replacementFile.value.type, size: replacementFile.value.size });
-        const payload = await enc.encryptLockerContent(meta, passphrase.value);
+        const payload = await enc.encryptLockerContent(meta, effectivePassphrase.value);
 
-        // Generate fresh DEK for the replacement file and encrypt directly to Uint8Array
         const newDek = enc.generateLockerFileKey();
-        const newWrappedFileKey = await enc.wrapLockerFileKey(newDek, passphrase.value, props.account_id);
+        const newWrappedFileKey = await enc.wrapLockerFileKey(newDek, effectivePassphrase.value, props.account_id);
         const fileBuffer = await replacementFile.value.arrayBuffer();
         const bytes = await enc.encryptLockerFileToBuffer(fileBuffer, { dek: newDek });
 
-        // Get presigned upload URL
         const prepRes = await fetch(route('lockers.file.prepare'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-XSRF-TOKEN': getXsrf() },
-            body: JSON.stringify({}), // no credit_token needed for updates
+            body: JSON.stringify({}),
         });
 
         let storagePath = null;
@@ -386,7 +458,7 @@ const submitFileUpdate = async () => {
         wrappedFileKey.value = newWrappedFileKey;
         decryptedFileMeta.value = JSON.parse(meta);
         replacementFile.value  = null;
-        downloadUrl.value = '';  // URL is now stale; re-unlock to get fresh URL
+        downloadUrl.value = '';
     } catch (err) {
         updateError.value = err.message || 'Update failed. Please try again.';
     } finally {
@@ -417,12 +489,10 @@ const changePassphrase = async () => {
         let newPayload;
         const putBody = {};
 
-        // ECDSA lockers: register new public key derived from new passphrase
         if (!isLegacyLocker.value) {
             const { publicKeyJwkBase64: newPublicKey } = await enc.deriveLockerSigningKeypair(newPassphrase.value, props.account_id);
             putBody.new_public_key = newPublicKey;
         } else {
-            // Legacy lockers: update verifier + update token
             const newAuthKey     = await enc.deriveLockerAuthKey(newPassphrase.value, props.account_id);
             const newVerifier    = await enc.computeLockerVerifier(newAuthKey, authChallenge.value);
             const newUpdateToken = await enc.deriveLockerUpdateToken(newPassphrase.value, props.account_id);
@@ -431,10 +501,9 @@ const changePassphrase = async () => {
         }
 
         if (isFileLocker.value && wrappedFileKey.value) {
-            // New locker (v2): re-wrap DEK with new passphrase — no file download required
             const meta = JSON.stringify(decryptedFileMeta.value);
             newPayload = await enc.encryptLockerContent(meta, newPassphrase.value);
-            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, passphrase.value, props.account_id);
+            const dek = await enc.unwrapLockerFileKey(wrappedFileKey.value, effectivePassphrase.value, props.account_id);
             const newWrappedKey = await enc.wrapLockerFileKey(dek, newPassphrase.value, props.account_id);
             putBody.new_wrapped_file_key = newWrappedKey;
             putBody.payload = newPayload;
@@ -448,13 +517,13 @@ const changePassphrase = async () => {
             const data = await res.json();
             if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
 
-            passphrase.value     = newPassphrase.value;
-            wrappedFileKey.value = newWrappedKey;
+            effectivePassphrase.value    = newPassphrase.value;
+            passphrase.value             = newPassphrase.value;
+            wrappedFileKey.value         = newWrappedKey;
             newPassphrase.value           = '';
             passphraseChangeSuccess.value = true;
 
         } else if (isFileLocker.value) {
-            // Legacy locker (v1): download, decrypt, re-encrypt with new passphrase
             const meta = JSON.stringify(decryptedFileMeta.value);
             newPayload = await enc.encryptLockerContent(meta, newPassphrase.value);
 
@@ -470,7 +539,7 @@ const changePassphrase = async () => {
                 xhr.send();
             });
 
-            const fileData = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: passphrase.value });
+            const fileData = await enc.decryptLockerFileFromBuffer(encryptedBytes, { passphrase: effectivePassphrase.value });
             const reEncryptedBytes = await enc.encryptLockerFileToBuffer(fileData, { passphrase: newPassphrase.value });
 
             const prepRes = await fetch(route('lockers.file.prepare'), {
@@ -506,8 +575,9 @@ const changePassphrase = async () => {
             const data = await res.json();
             if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
 
-            passphrase.value = newPassphrase.value;
-            downloadUrl.value = '';
+            effectivePassphrase.value = newPassphrase.value;
+            passphrase.value          = newPassphrase.value;
+            downloadUrl.value         = '';
             newPassphrase.value           = '';
             passphraseChangeSuccess.value = true;
 
@@ -524,7 +594,8 @@ const changePassphrase = async () => {
             const data = await res.json();
             if (!res.ok) { passphraseChangeError.value = data.error ?? 'Failed to change passphrase.'; return; }
 
-            passphrase.value = newPassphrase.value;
+            effectivePassphrase.value    = newPassphrase.value;
+            passphrase.value             = newPassphrase.value;
             newPassphrase.value           = '';
             passphraseChangeSuccess.value = true;
         }
@@ -566,9 +637,9 @@ const upgradeAuth = async () => {
     upgrading.value     = true;
     upgradeError.value  = '';
     try {
-        const authKey  = await enc.deriveLockerAuthKey(passphrase.value, props.account_id);
+        const authKey  = await enc.deriveLockerAuthKey(effectivePassphrase.value, props.account_id);
         const verifier = await enc.computeLockerVerifier(authKey, authChallenge.value);
-        const { publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(passphrase.value, props.account_id);
+        const { publicKeyJwkBase64 } = await enc.deriveLockerSigningKeypair(effectivePassphrase.value, props.account_id);
 
         const res = await fetch(route('lockers.upgrade-auth', props.account_id), {
             method: 'POST',
@@ -688,22 +759,68 @@ const upgradeAuth = async () => {
                         </div>
 
                         <div class="w-full space-y-3">
-                            <input
-                                v-model="passphrase"
-                                type="password"
-                                placeholder="Enter passphrase to unlock"
-                                @keydown.enter="unlock"
-                                class="w-full bg-gray-900 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:ring-gamboge-300 focus:outline-none"
-                                data-testid="passphrase-input"
-                            />
+                            <!-- Passphrase input — shown for passphrase and combined modes -->
+                            <div v-if="authMode !== 'key_file'">
+                                <input
+                                    v-model="passphrase"
+                                    type="password"
+                                    placeholder="Enter passphrase to unlock"
+                                    @keydown.enter="canUnlock && unlock()"
+                                    class="w-full bg-gray-900 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:ring-gamboge-300 focus:outline-none"
+                                    data-testid="passphrase-input"
+                                />
+                            </div>
+
+                            <!-- Key file section — shown for key_file and combined modes -->
+                            <div v-if="authMode !== 'passphrase'" class="space-y-2">
+                                <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Key Files</div>
+                                <p class="text-gray-500 text-xs">
+                                    Load your key files in the same order as when you created this locker.
+                                    Refer to your saved credential file for the required fingerprint sequence.
+                                </p>
+
+                                <div v-if="keyFiles.length > 0" class="space-y-1">
+                                    <div
+                                        v-for="(kf, i) in keyFiles"
+                                        :key="i"
+                                        class="flex items-center gap-3 bg-gray-900 rounded-lg px-3 py-2"
+                                    >
+                                        <span class="text-gamboge-300/60 font-mono text-xs w-4 shrink-0">{{ i + 1 }}.</span>
+                                        <code class="text-gamboge-300 font-mono text-sm flex-1">{{ kf.fingerprint }}</code>
+                                        <span class="text-gray-500 text-xs truncate max-w-32">{{ kf.file.name }}</span>
+                                        <button
+                                            type="button"
+                                            @click="removeKeyFile(i)"
+                                            class="shrink-0 text-gray-500 hover:text-red-400 font-mono text-xs transition-colors"
+                                            title="Remove"
+                                        >✕</button>
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center justify-between text-xs text-gray-500 font-mono">
+                                    <span>{{ keyFiles.length }} / {{ keyFileCount ?? '?' }} loaded</span>
+                                </div>
+
+                                <label
+                                    v-if="keyFiles.length < (keyFileCount ?? 999)"
+                                    class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
+                                    data-testid="key-file-input-label"
+                                >
+                                    <span class="font-mono text-xs">+ Add key file</span>
+                                    <input type="file" class="sr-only" @change="onKeyFileAdded" data-testid="key-file-input" />
+                                </label>
+
+                                <p v-if="authMode === 'combined'" class="text-gamboge-300/70 text-xs">Both your passphrase and all {{ keyFileCount }} key file(s) are required to unlock.</p>
+                            </div>
+
                             <p v-if="decryptError" class="text-red-400 text-sm text-center" data-testid="decrypt-error">{{ decryptError }}</p>
                             <p v-if="failCount >= 2 && decryptError" class="text-gray-500 text-xs text-center">
-                                Repeatedly seeing this error? If your passphrase is lost, the content of this locker cannot be recovered.
-                                Passphrase reset is not possible by design.
+                                Repeatedly seeing this error? If your credentials are lost, the content of this locker cannot be recovered.
+                                Credential reset is not possible by design.
                             </p>
                             <button
                                 @click="unlock"
-                                :disabled="lockState === 'animating' || lockState === 'shaking'"
+                                :disabled="!canUnlock"
                                 class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-60 text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
                                 data-testid="unlock-button"
                             >
@@ -788,11 +905,11 @@ const upgradeAuth = async () => {
 
                 <!-- Update hint when locked -->
                 <div v-if="lockState !== 'unlocked'" class="bg-gray-800 border border-gray-700 rounded-xl p-4 text-center">
-                    <p class="text-gray-500 text-xs">Unlock your locker with your passphrase to update or delete it.</p>
+                    <p class="text-gray-500 text-xs">Unlock your locker to update or delete it.</p>
                 </div>
 
-                <!-- Change Passphrase panel — only when unlocked -->
-                <div v-if="lockState === 'unlocked'" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
+                <!-- Change Passphrase panel — only when unlocked and in passphrase mode -->
+                <div v-if="lockState === 'unlocked' && authMode === 'passphrase'" class="bg-gray-800 border border-gray-700 rounded-xl p-6 space-y-4">
                     <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Change Passphrase</h2>
                     <p class="text-gray-400 text-xs">Your content will be re-encrypted with the new passphrase. This cannot be undone.</p>
 
@@ -826,6 +943,14 @@ const upgradeAuth = async () => {
                         @click="changePassphrase"
                         class="w-full border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-xs py-2 rounded-lg transition-colors"
                     >Change Passphrase</button>
+                </div>
+
+                <!-- Key file credential rotation notice — shown for key_file and combined modes when unlocked -->
+                <div v-if="lockState === 'unlocked' && authMode !== 'passphrase'" class="bg-gray-800 border border-gray-700 rounded-xl p-6">
+                    <h2 class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Credential Management</h2>
+                    <p class="text-gray-400 text-xs">
+                        Key file credential rotation is not yet supported. To change your key files, create a new locker and migrate your content.
+                    </p>
                 </div>
 
                 <!-- Delete panel — only when unlocked -->

--- a/resources/js/Pages/Locker/Show.vue
+++ b/resources/js/Pages/Locker/Show.vue
@@ -26,13 +26,16 @@ const upgradeDismissed = ref(false);
 const upgradeError     = ref('');
 
 // Auth mode — fetched on mount from auth-info endpoint
+// When show_clues=false the server returns opaque passphrase defaults, so authMode stays 'passphrase'
+// client-side. The real mode is unknown; computeEffectivePassphrase derives from what the user provides.
 const authMode     = ref('passphrase'); // 'passphrase' | 'key_file' | 'combined'
 const keyFileCount = ref(null);
+const showClues    = ref(true);  // false = server returned opaque response; show generic UI
 
 // Unlock state
-const passphrase        = ref('');
-const effectivePassphrase = ref(''); // Derived on unlock; cleared on lock. Never the raw passphrase for key_file/combined modes.
-const keyFiles          = ref([]); // [{ file: File, fingerprint: string }]
+const passphrase          = ref('');
+const effectivePassphrase = ref(''); // Derived on unlock; cleared on lock.
+const keyFiles            = ref([]); // [{ file: File }]
 const lockState         = ref('locked'); // 'locked' | 'animating' | 'unlocked' | 'shaking'
 const decryptError      = ref('');
 const failCount         = ref(0);
@@ -87,6 +90,10 @@ const generateNewPassphrase = () => { newPassphrase.value = enc.generatePasssphr
 // Computed: whether the unlock button should be enabled
 const canUnlock = computed(() => {
     if (lockState.value === 'animating' || lockState.value === 'shaking') return false;
+    if (!showClues.value) {
+        // No-clues mode: allow attempt if at least one credential has been provided
+        return passphrase.value.length > 0 || keyFiles.value.length > 0;
+    }
     if (authMode.value === 'key_file') {
         return keyFiles.value.length >= (keyFileCount.value ?? 1);
     }
@@ -103,6 +110,7 @@ onMounted(async () => {
         });
         if (infoRes.ok) {
             const info = await infoRes.json();
+            showClues.value = info.show_clues ?? true;
             authMode.value = info.auth_mode ?? 'passphrase';
             keyFileCount.value = info.key_file_count ?? null;
         }
@@ -111,15 +119,11 @@ onMounted(async () => {
     }
 });
 
-const onKeyFileAdded = async (e) => {
+const onKeyFileAdded = (e) => {
     const file = e.target.files[0];
     if (!file) return;
     e.target.value = '';
-
-    const buffer = await file.arrayBuffer();
-    const hash = await enc.deriveLockerKeyFromFile(buffer);
-    const fingerprint = hash.slice(0, 8);
-    keyFiles.value.push({ file, fingerprint });
+    keyFiles.value.push({ file });
 };
 
 const removeKeyFile = (index) => {
@@ -127,16 +131,29 @@ const removeKeyFile = (index) => {
 };
 
 const computeEffectivePassphrase = async () => {
-    if (authMode.value === 'passphrase') {
-        return passphrase.value;
-    }
+    const hasPassphrase = passphrase.value.length > 0;
+    const hasFiles = keyFiles.value.length > 0;
+
     // Re-read buffers from File references at call time to avoid holding large ArrayBuffers
-    const fileHashes = await Promise.all(
+    const getFileHashes = async () => Promise.all(
         keyFiles.value.map(async (kf) => {
             const buf = await kf.file.arrayBuffer();
             return enc.deriveLockerKeyFromFile(buf);
         })
     );
+
+    if (!showClues.value) {
+        // No-clues mode: derive from whatever the user provided
+        if (!hasFiles) return passphrase.value;
+        const fileHashes = await getFileHashes();
+        if (!hasPassphrase) return enc.combineLockerKeyMaterials(fileHashes);
+        return enc.combineLockerKeyMaterials([passphrase.value, ...fileHashes]);
+    }
+
+    if (authMode.value === 'passphrase') {
+        return passphrase.value;
+    }
+    const fileHashes = await getFileHashes();
     if (authMode.value === 'key_file') {
         return enc.combineLockerKeyMaterials(fileHashes);
     }
@@ -759,8 +776,8 @@ const upgradeAuth = async () => {
                         </div>
 
                         <div class="w-full space-y-3">
-                            <!-- Passphrase input — shown for passphrase and combined modes -->
-                            <div v-if="authMode !== 'key_file'">
+                            <!-- Passphrase input — shown when mode needs a passphrase, or when no-clues (generic) -->
+                            <div v-if="showClues ? authMode !== 'key_file' : true">
                                 <input
                                     v-model="passphrase"
                                     type="password"
@@ -771,12 +788,12 @@ const upgradeAuth = async () => {
                                 />
                             </div>
 
-                            <!-- Key file section — shown for key_file and combined modes -->
-                            <div v-if="authMode !== 'passphrase'" class="space-y-2">
-                                <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Key Files</div>
-                                <p class="text-gray-500 text-xs">
+                            <!-- Key file section — shown when mode needs key files, or when no-clues (generic) -->
+                            <div v-if="showClues ? authMode !== 'passphrase' : true" class="space-y-2">
+                                <div v-if="showClues" class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Key Files</div>
+                                <p v-if="showClues" class="text-gray-500 text-xs">
                                     Load your key files in the same order as when you created this locker.
-                                    Refer to your saved credential file for the required fingerprint sequence.
+                                    Refer to your saved credential file for the required order.
                                 </p>
 
                                 <div v-if="keyFiles.length > 0" class="space-y-1">
@@ -785,9 +802,8 @@ const upgradeAuth = async () => {
                                         :key="i"
                                         class="flex items-center gap-3 bg-gray-900 rounded-lg px-3 py-2"
                                     >
-                                        <span class="text-gamboge-300/60 font-mono text-xs w-4 shrink-0">{{ i + 1 }}.</span>
-                                        <code class="text-gamboge-300 font-mono text-sm flex-1">{{ kf.fingerprint }}</code>
-                                        <span class="text-gray-500 text-xs truncate max-w-32">{{ kf.file.name }}</span>
+                                        <span class="text-gamboge-300/60 text-xs w-4 shrink-0">{{ i + 1 }}.</span>
+                                        <span class="text-white text-sm flex-1 truncate">{{ kf.file.name }}</span>
                                         <button
                                             type="button"
                                             @click="removeKeyFile(i)"
@@ -797,12 +813,12 @@ const upgradeAuth = async () => {
                                     </div>
                                 </div>
 
-                                <div class="flex items-center justify-between text-xs text-gray-500 font-mono">
-                                    <span>{{ keyFiles.length }} / {{ keyFileCount ?? '?' }} loaded</span>
+                                <div v-if="showClues && keyFileCount" class="text-xs text-gray-500 font-mono">
+                                    {{ keyFiles.length }} / {{ keyFileCount }} loaded
                                 </div>
 
                                 <label
-                                    v-if="keyFiles.length < (keyFileCount ?? 999)"
+                                    v-if="showClues ? keyFiles.length < (keyFileCount ?? 999) : true"
                                     class="flex items-center gap-2 cursor-pointer border border-dashed border-gray-600 hover:border-gamboge-300/50 hover:shadow-neon-cyan-sm rounded-lg px-3 py-2 transition-colors text-gray-400 text-sm"
                                     data-testid="key-file-input-label"
                                 >
@@ -810,7 +826,7 @@ const upgradeAuth = async () => {
                                     <input type="file" class="sr-only" @change="onKeyFileAdded" data-testid="key-file-input" />
                                 </label>
 
-                                <p v-if="authMode === 'combined'" class="text-gamboge-300/70 text-xs">Both your passphrase and all {{ keyFileCount }} key file(s) are required to unlock.</p>
+                                <p v-if="showClues && authMode === 'combined'" class="text-gamboge-300/70 text-xs">Both your passphrase and all {{ keyFileCount }} key file(s) are required to unlock.</p>
                             </div>
 
                             <p v-if="decryptError" class="text-red-400 text-sm text-center" data-testid="decrypt-error">{{ decryptError }}</p>

--- a/resources/js/encryption.js
+++ b/resources/js/encryption.js
@@ -6,6 +6,7 @@ import {
     generateFileKey, wrapFileKey, unwrapFileKey,
     deriveAuthKey, computeVerifier, generateChallenge, deriveUpdateToken,
     deriveSigningKeypair, signChallenge,
+    deriveKeyFromFile, combineLockerKeyMaterials,
 } from '@pioneer-dynamics/flashview-crypto';
 export { LockerBlobVersionError, LockerDecryptionError } from '@pioneer-dynamics/flashview-crypto';
 
@@ -123,5 +124,13 @@ export class encryption {
 
     async signLockerChallenge(privateKey, challengeHex) {
         return signChallenge(privateKey, challengeHex);
+    }
+
+    async deriveLockerKeyFromFile(fileBuffer) {
+        return deriveKeyFromFile(fileBuffer);
+    }
+
+    async combineLockerKeyMaterials(materials) {
+        return combineLockerKeyMaterials(materials);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -247,7 +247,9 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
     Route::post('/', [LockerController::class, 'store'])
         ->middleware('throttle:6,1')->name('store');
 
-    // Wildcard routes
+    // Wildcard routes — static sub-paths must precede /{accountId} wildcard
+    Route::get('/{accountId}/auth-info', [LockerController::class, 'authInfo'])
+        ->middleware('throttle:30,1')->name('auth-info');
     Route::get('/{accountId}', [LockerController::class, 'show'])->name('show');
     Route::get('/{accountId}/challenge', [LockerController::class, 'challenge'])
         ->middleware('throttle:30,1')->name('challenge');

--- a/routes/web.php
+++ b/routes/web.php
@@ -250,6 +250,8 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
     // Wildcard routes — static sub-paths must precede /{accountId} wildcard
     Route::get('/{accountId}/auth-info', [LockerController::class, 'authInfo'])
         ->middleware('throttle:30,1')->name('auth-info');
+    Route::patch('/{accountId}/settings', [LockerController::class, 'updateSettings'])
+        ->middleware('throttle:10,1')->name('settings');
     Route::get('/{accountId}', [LockerController::class, 'show'])->name('show');
     Route::get('/{accountId}/challenge', [LockerController::class, 'challenge'])
         ->middleware('throttle:30,1')->name('challenge');

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -868,4 +868,162 @@ class LockerControllerTest extends TestCase
 
         $response->assertStatus(200)->assertJson(['ok' => true]);
     }
+
+    public function test_can_create_locker_with_key_file_auth_mode(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'kftok1', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '2000000001',
+            'credit_token' => 'kftok1',
+            'payload' => str_repeat('a', 100),
+            'public_key' => base64_encode(json_encode(['kty' => 'EC', 'crv' => 'P-256', 'x' => str_repeat('A', 43), 'y' => str_repeat('B', 43)])),
+            'tier' => 'text',
+            'storage_path' => null,
+            'auth_mode' => 'key_file',
+            'key_file_count' => 2,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['expires_at', 'account_id']);
+
+        $this->assertDatabaseHas('lockers', [
+            'account_id' => '2000000001',
+            'auth_mode' => 'key_file',
+            'key_file_count' => 2,
+        ]);
+    }
+
+    public function test_can_create_locker_with_combined_auth_mode(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'cmbtok1', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '2000000002',
+            'credit_token' => 'cmbtok1',
+            'payload' => str_repeat('a', 100),
+            'public_key' => base64_encode(json_encode(['kty' => 'EC', 'crv' => 'P-256', 'x' => str_repeat('A', 43), 'y' => str_repeat('B', 43)])),
+            'tier' => 'text',
+            'storage_path' => null,
+            'auth_mode' => 'combined',
+            'key_file_count' => 1,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['expires_at', 'account_id']);
+
+        $this->assertDatabaseHas('lockers', [
+            'account_id' => '2000000002',
+            'auth_mode' => 'combined',
+            'key_file_count' => 1,
+        ]);
+    }
+
+    public function test_store_validates_key_file_count_required_for_key_file_mode(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'kftok2', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '2000000003',
+            'credit_token' => 'kftok2',
+            'payload' => str_repeat('a', 100),
+            'public_key' => base64_encode('{}'),
+            'tier' => 'text',
+            'auth_mode' => 'key_file',
+            // key_file_count intentionally omitted
+        ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['key_file_count']);
+    }
+
+    public function test_store_validates_key_file_count_required_for_combined_mode(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'cmbtok2', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '2000000004',
+            'credit_token' => 'cmbtok2',
+            'payload' => str_repeat('a', 100),
+            'public_key' => base64_encode('{}'),
+            'tier' => 'text',
+            'auth_mode' => 'combined',
+            // key_file_count intentionally omitted
+        ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['key_file_count']);
+    }
+
+    public function test_store_rejects_key_file_count_when_passphrase_mode(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'pptok1', 'tier' => 'text', 'years' => 1]);
+
+        $response = $this->postJson(route('lockers.store'), [
+            'account_id' => '2000000005',
+            'credit_token' => 'pptok1',
+            'payload' => str_repeat('a', 100),
+            'auth_challenge' => str_repeat('c', 64),
+            'auth_verifier' => str_repeat('a', 64),
+            'update_token' => str_repeat('b', 64),
+            'tier' => 'text',
+            'auth_mode' => 'passphrase',
+            'key_file_count' => 2,
+        ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['key_file_count']);
+    }
+
+    public function test_auth_info_endpoint_returns_mode_and_count(): void
+    {
+        Locker::factory()->create([
+            'account_id' => '2000000006',
+            'auth_mode' => 'key_file',
+            'key_file_count' => 3,
+        ]);
+
+        $response = $this->getJson(route('lockers.auth-info', '2000000006'));
+
+        $response->assertStatus(200)->assertJson([
+            'auth_mode' => 'key_file',
+            'key_file_count' => 3,
+        ]);
+    }
+
+    public function test_auth_info_returns_passphrase_defaults_for_nonexistent_account(): void
+    {
+        $response = $this->getJson(route('lockers.auth-info', '9999999999'));
+
+        $response->assertStatus(200)->assertJson([
+            'auth_mode' => 'passphrase',
+            'key_file_count' => null,
+        ]);
+    }
+
+    public function test_existing_passphrase_locker_auth_info_returns_passphrase_mode(): void
+    {
+        Locker::factory()->create([
+            'account_id' => '2000000007',
+            // auth_mode defaults to 'passphrase' via migration
+        ]);
+
+        $response = $this->getJson(route('lockers.auth-info', '2000000007'));
+
+        $response->assertStatus(200)->assertJson([
+            'auth_mode' => 'passphrase',
+            'key_file_count' => null,
+        ]);
+    }
+
+    public function test_existing_locker_unlock_still_works_regression(): void
+    {
+        $verifier = str_repeat('a', 64);
+        Locker::factory()->create([
+            'account_id' => '2000000008',
+            'auth_verifier' => $verifier,
+            // auth_mode defaults to 'passphrase' — regression check
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '2000000008'), [
+            'verifier' => $verifier,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['payload', 'expires_at', 'is_file_locker']);
+    }
 }

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -1106,4 +1106,48 @@ class LockerControllerTest extends TestCase
             'show_clues' => true,
         ]);
     }
+
+    public function test_update_settings_requires_authentication(): void
+    {
+        Locker::factory()->create(['account_id' => '4000000001']);
+
+        $response = $this->patchJson(route('lockers.settings', '4000000001'), [
+            'show_clues' => false,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_update_settings_updates_show_clues_with_valid_token(): void
+    {
+        $locker = Locker::factory()->create([
+            'account_id' => '4000000002',
+            'auth_verifier' => str_repeat('a', 64),
+            'update_token_hash' => hash('sha256', 'validtoken'),
+            'show_clues' => true,
+        ]);
+
+        $response = $this->patchJson(route('lockers.settings', '4000000002'), [
+            'show_clues' => false,
+        ], ['X-Update-Token' => 'validtoken']);
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+
+        $locker->refresh();
+        $this->assertFalse((bool) $locker->show_clues);
+    }
+
+    public function test_update_settings_rejects_invalid_token(): void
+    {
+        Locker::factory()->create([
+            'account_id' => '4000000003',
+            'update_token_hash' => hash('sha256', 'correcttoken'),
+        ]);
+
+        $response = $this->patchJson(route('lockers.settings', '4000000003'), [
+            'show_clues' => false,
+        ], ['X-Update-Token' => 'wrongtoken']);
+
+        $response->assertStatus(403);
+    }
 }

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -1026,4 +1026,84 @@ class LockerControllerTest extends TestCase
 
         $response->assertStatus(200)->assertJsonStructure(['payload', 'expires_at', 'is_file_locker']);
     }
+
+    public function test_auth_info_returns_show_clues_true_for_normal_locker(): void
+    {
+        Locker::factory()->create([
+            'account_id' => '3000000001',
+            'show_clues' => true,
+            'auth_mode' => 'key_file',
+            'key_file_count' => 2,
+        ]);
+
+        $response = $this->getJson(route('lockers.auth-info', '3000000001'));
+
+        $response->assertStatus(200)->assertJson([
+            'auth_mode' => 'key_file',
+            'key_file_count' => 2,
+            'show_clues' => true,
+        ]);
+    }
+
+    public function test_auth_info_returns_opaque_response_when_show_clues_false(): void
+    {
+        Locker::factory()->create([
+            'account_id' => '3000000002',
+            'show_clues' => false,
+            'auth_mode' => 'key_file',
+            'key_file_count' => 3,
+        ]);
+
+        $response = $this->getJson(route('lockers.auth-info', '3000000002'));
+
+        // Should return fake passphrase defaults, hiding real auth mode
+        $response->assertStatus(200)->assertJson([
+            'auth_mode' => 'passphrase',
+            'key_file_count' => null,
+            'show_clues' => false,
+        ]);
+
+        $response->assertJsonMissing(['key_file']);
+    }
+
+    public function test_store_saves_show_clues_false(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'sctok01', 'tier' => 'text', 'years' => 1]);
+
+        $this->postJson(route('lockers.store'), [
+            'account_id' => '3000000003',
+            'credit_token' => 'sctok01',
+            'payload' => str_repeat('a', 100),
+            'public_key' => base64_encode(json_encode(['kty' => 'EC'])),
+            'tier' => 'text',
+            'auth_mode' => 'key_file',
+            'key_file_count' => 1,
+            'show_clues' => false,
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('lockers', [
+            'account_id' => '3000000003',
+            'show_clues' => false,
+        ]);
+    }
+
+    public function test_store_defaults_show_clues_to_true(): void
+    {
+        $credit = LockerCredit::factory()->create(['token' => 'sctok02', 'tier' => 'text', 'years' => 1]);
+
+        $this->postJson(route('lockers.store'), [
+            'account_id' => '3000000004',
+            'credit_token' => 'sctok02',
+            'payload' => str_repeat('a', 100),
+            'auth_challenge' => str_repeat('c', 64),
+            'auth_verifier' => str_repeat('a', 64),
+            'update_token' => str_repeat('b', 64),
+            'tier' => 'text',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('lockers', [
+            'account_id' => '3000000004',
+            'show_clues' => true,
+        ]);
+    }
 }

--- a/tests/e2e/helpers/locker.ts
+++ b/tests/e2e/helpers/locker.ts
@@ -67,6 +67,88 @@ export async function createLockerViaUI(
     return { accountId, passphrase };
 }
 
+/** Deterministic test key file fixtures. Use these for all key-file E2E tests. */
+export const KEY_FILE_ALPHA = {
+    name: 'key-file-alpha.bin',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from('e2e-key-file-alpha-content-unique-v1'),
+};
+
+export const KEY_FILE_BETA = {
+    name: 'key-file-beta.bin',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from('e2e-key-file-beta-content-unique-v1'),
+};
+
+export const KEY_FILE_WRONG = {
+    name: 'key-file-wrong.bin',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from('e2e-key-file-wrong-content-should-fail'),
+};
+
+/**
+ * Create a key-file-only locker via the browser UI.
+ * Accepts one or more key file fixtures (from KEY_FILE_ALPHA, etc.).
+ */
+export async function createKeyFileLockerViaUI(
+    page: Page,
+    accountId: string,
+    content: string,
+    creditToken: string,
+    keyFiles: { name: string; mimeType: string; buffer: Buffer }[]
+): Promise<{ accountId: string; keyFiles: typeof keyFiles }> {
+    await page.goto(`/lockers/create?token=${encodeURIComponent(creditToken)}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill(accountId);
+    await page.getByRole('button', { name: 'Key File(s)' }).click();
+
+    for (const kf of keyFiles) {
+        await page.getByTestId('key-file-input').setInputFiles(kf);
+        await page.waitForTimeout(300); // allow fingerprint computation
+    }
+
+    await page.getByTestId('key-file-risk-checkbox').check();
+    await page.getByPlaceholder('Enter the content to store…').fill(content);
+    await page.getByTestId('create-submit-button').click();
+
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
+
+    return { accountId, keyFiles };
+}
+
+/**
+ * Create a combined (passphrase + key file) locker via the browser UI.
+ */
+export async function createCombinedLockerViaUI(
+    page: Page,
+    accountId: string,
+    passphrase: string,
+    content: string,
+    creditToken: string,
+    keyFiles: { name: string; mimeType: string; buffer: Buffer }[]
+): Promise<{ accountId: string; passphrase: string; keyFiles: typeof keyFiles }> {
+    await page.goto(`/lockers/create?token=${encodeURIComponent(creditToken)}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Choose a 10-digit number').fill(accountId);
+    await page.getByRole('button', { name: 'Both' }).click();
+    await page.getByPlaceholder('Enter or generate a passphrase').fill(passphrase);
+
+    for (const kf of keyFiles) {
+        await page.getByTestId('key-file-input').setInputFiles(kf);
+        await page.waitForTimeout(300);
+    }
+
+    await page.getByTestId('key-file-risk-checkbox').check();
+    await page.getByPlaceholder('Enter the content to store…').fill(content);
+    await page.getByTestId('create-submit-button').click();
+
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
+
+    return { accountId, passphrase, keyFiles };
+}
+
 /**
  * Create a file locker via the browser UI with mocked S3 endpoints.
  * S3 is not available in the test environment — routes are intercepted.

--- a/tests/e2e/helpers/locker.ts
+++ b/tests/e2e/helpers/locker.ts
@@ -105,7 +105,6 @@ export async function createKeyFileLockerViaUI(
 
     for (const kf of keyFiles) {
         await page.getByTestId('key-file-input').setInputFiles(kf);
-        await page.waitForTimeout(300); // allow fingerprint computation
     }
 
     await page.getByTestId('key-file-risk-checkbox').check();

--- a/tests/e2e/locker-auth-modes.spec.ts
+++ b/tests/e2e/locker-auth-modes.spec.ts
@@ -303,7 +303,7 @@ test('show page for key file locker does not show passphrase input', async ({ pa
     await expect(page.getByText(/same order as when you created/i)).toBeVisible();
 });
 
-test('change passphrase panel hidden for key file mode after unlock', async ({ page }) => {
+test('change passphrase panel hidden for key file mode; change credentials panel shown instead', async ({ page }) => {
     createLockerCredit('kfcp01', 'text', 1);
     await createKeyFileLockerViaUI(page, '8000000051', 'Key file no passchange', 'kfcp01', [KEY_FILE_ALPHA]);
 
@@ -314,7 +314,9 @@ test('change passphrase panel hidden for key file mode after unlock', async ({ p
     await page.getByTestId('unlock-button').click();
     await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
 
-    // Change Passphrase heading must NOT be visible; Credential Management notice must be
+    // Passphrase change panel must NOT be visible for key file lockers
     await expect(page.getByRole('heading', { name: /Change Passphrase/i })).not.toBeVisible();
-    await expect(page.getByText(/credential rotation is not yet supported/i)).toBeVisible();
+    // Change Credentials panel must be visible instead
+    await expect(page.getByRole('heading', { name: /Change Credentials/i })).toBeVisible();
+    await expect(page.getByTestId('rotate-credentials-button')).toBeVisible();
 });

--- a/tests/e2e/locker-auth-modes.spec.ts
+++ b/tests/e2e/locker-auth-modes.spec.ts
@@ -40,7 +40,7 @@ test('key file mode creation shows fingerprint and credential panel without pass
 
     // Select key file mode
     await page.getByRole('button', { name: 'Key File(s)' }).click();
-    await expect(page.getByText(/Key File Rotation/i)).toBeVisible();
+    await expect(page.getByText(/rotation is not yet supported/i)).toBeVisible();
 
     // Passphrase field should be hidden
     await expect(page.getByPlaceholder('Enter or generate a passphrase')).not.toBeVisible();
@@ -274,7 +274,7 @@ test('credential download button visible and credential panel shows fingerprints
 
     // Fingerprint section must be present in the credentials panel
     await expect(page.getByText('Key File Fingerprints')).toBeVisible();
-    await expect(page.getByText('load in this exact order')).toBeVisible();
+    await expect(page.getByText('loaded in this exact order')).toBeVisible();
 
     // Download button present
     await expect(page.getByRole('button', { name: /Download as text file/i })).toBeVisible();

--- a/tests/e2e/locker-auth-modes.spec.ts
+++ b/tests/e2e/locker-auth-modes.spec.ts
@@ -1,0 +1,330 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from './helpers/db';
+import {
+    createLockerCredit,
+    createLockerViaUI,
+    createKeyFileLockerViaUI,
+    createCombinedLockerViaUI,
+    KEY_FILE_ALPHA,
+    KEY_FILE_BETA,
+    KEY_FILE_WRONG,
+} from './helpers/locker';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+// ─── Scenario 1: Passphrase-only mode (regression) ────────────────────────────
+
+test('passphrase-only creation and unlock still works (regression)', async ({ page }) => {
+    createLockerCredit('regtoken01', 'text', 1);
+    const { passphrase } = await createLockerViaUI(page, '8000000001', 'regression-passphrase-ok', 'Regression content', 'regtoken01');
+
+    await page.goto('/lockers/8000000001');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Regression content')).toBeVisible();
+});
+
+// ─── Scenario 2: Key file creation ────────────────────────────────────────────
+
+test('key file mode creation shows fingerprint and credential panel without passphrase', async ({ page }) => {
+    createLockerCredit('kfcreate01', 'text', 1);
+
+    await page.goto('/lockers/create?token=kfcreate01');
+    await page.waitForLoadState('networkidle');
+
+    // Select key file mode
+    await page.getByRole('button', { name: 'Key File(s)' }).click();
+    await expect(page.getByText(/Key File Rotation/i)).toBeVisible();
+
+    // Passphrase field should be hidden
+    await expect(page.getByPlaceholder('Enter or generate a passphrase')).not.toBeVisible();
+
+    // Add a key file — fingerprint should appear
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    // Fingerprint is 8 hex chars shown in a code element
+    await expect(page.locator('code').filter({ hasText: /^[0-9a-f]{8}$/ })).toBeVisible();
+
+    // Risk acknowledgement checkbox must be checked before submit
+    await page.getByTestId('key-file-risk-checkbox').check();
+    await page.getByPlaceholder('Enter the content to store…').fill('Key file protected content');
+    await page.getByPlaceholder('Choose a 10-digit number').fill('8000000002');
+    await page.getByTestId('create-submit-button').click();
+
+    await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 15000 });
+    // Passphrase field not shown in credentials panel (key_file mode)
+    await expect(page.getByText('Passphrase', { exact: true })).not.toBeVisible();
+    // Key file fingerprints shown in credentials panel
+    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+});
+
+test('key file mode creation blocked if risk checkbox is not checked', async ({ page }) => {
+    createLockerCredit('kfcreate02', 'text', 1);
+
+    await page.goto('/lockers/create?token=kfcreate02');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Key File(s)' }).click();
+    await page.getByPlaceholder('Choose a 10-digit number').fill('8000000003');
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    await page.getByPlaceholder('Enter the content to store…').fill('Content');
+    // Do NOT check the risk checkbox
+    await page.getByTestId('create-submit-button').click();
+
+    await expect(page.getByText('acknowledge the key file risk')).toBeVisible();
+    await expect(page.getByText('Locker created!')).not.toBeVisible();
+});
+
+// ─── Scenario 3: Key file unlock success ─────────────────────────────────────
+
+test('key file mode unlock succeeds with correct key file', async ({ page }) => {
+    createLockerCredit('kfunlock01', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000010', 'Unlockable key file content', 'kfunlock01', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000010');
+    await page.waitForLoadState('networkidle');
+
+    // Passphrase input not shown for key_file mode
+    await expect(page.getByTestId('passphrase-input')).not.toBeVisible();
+
+    // Key file picker guidance visible
+    await expect(page.getByText(/same order as when you created/i)).toBeVisible();
+
+    // Load the correct key file
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Unlockable key file content')).toBeVisible();
+});
+
+// ─── Scenario 4: Key file unlock fails with wrong file ────────────────────────
+
+test('key file mode unlock fails with wrong key file', async ({ page }) => {
+    createLockerCredit('kfunlock02', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000011', 'Content protected by correct file', 'kfunlock02', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000011');
+    await page.waitForLoadState('networkidle');
+
+    // Load the WRONG key file
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_WRONG);
+    await page.waitForTimeout(400);
+
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypt-error')).toBeVisible({ timeout: 12000 });
+    await expect(page.getByText(/Credentials do not match|Incorrect credentials|key file order/i)).toBeVisible();
+    // Content must NOT be revealed
+    await expect(page.getByTestId('decrypted-content')).not.toBeVisible();
+});
+
+// ─── Scenario 5: Combined mode creation ──────────────────────────────────────
+
+test('combined mode creation shows both passphrase and key file section', async ({ page }) => {
+    createLockerCredit('cmb01', 'text', 1);
+
+    await page.goto('/lockers/create?token=cmb01');
+    await page.waitForLoadState('networkidle');
+
+    // Select combined mode
+    await page.getByRole('button', { name: 'Both' }).click();
+
+    // Both passphrase and key file section should be visible
+    await expect(page.getByPlaceholder('Enter or generate a passphrase')).toBeVisible();
+    await expect(page.getByTestId('key-file-input')).toBeAttached();
+    await expect(page.getByText(/both passphrase and all/i)).toBeVisible();
+});
+
+test('combined mode locker creation completes successfully', async ({ page }) => {
+    createLockerCredit('cmb02', 'text', 1);
+    await createCombinedLockerViaUI(page, '8000000020', 'combined-pass-long', 'Combined mode content', 'cmb02', [KEY_FILE_ALPHA]);
+
+    await expect(page.getByText('Locker created!')).toBeVisible();
+    // Both passphrase and fingerprints shown in credentials
+    await expect(page.getByText('Passphrase', { exact: true })).toBeVisible();
+    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+});
+
+// ─── Scenario 6: Combined mode unlock success ────────────────────────────────
+
+test('combined mode unlock succeeds with both passphrase and correct key file', async ({ page }) => {
+    createLockerCredit('cmb03', 'text', 1);
+    await createCombinedLockerViaUI(page, '8000000021', 'combined-unlock-pass', 'Combined unlock content', 'cmb03', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000021');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('passphrase-input').fill('combined-unlock-pass');
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Combined unlock content')).toBeVisible();
+});
+
+// ─── Scenario 7: Combined mode fails with passphrase only ────────────────────
+
+test('combined mode unlock fails when passphrase provided but no key file', async ({ page }) => {
+    createLockerCredit('cmb04', 'text', 1);
+    await createCombinedLockerViaUI(page, '8000000022', 'combined-passonly-pass', 'Content', 'cmb04', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000022');
+    await page.waitForLoadState('networkidle');
+
+    // Provide passphrase but NO key file — unlock button must remain disabled
+    await page.getByTestId('passphrase-input').fill('combined-passonly-pass');
+
+    await expect(page.getByTestId('unlock-button')).toBeDisabled();
+});
+
+// ─── Scenario 8: Combined mode fails with file only ──────────────────────────
+
+test('combined mode unlock fails when key file provided but no passphrase', async ({ page }) => {
+    createLockerCredit('cmb05', 'text', 1);
+    await createCombinedLockerViaUI(page, '8000000023', 'combined-fileonly-pass', 'Content', 'cmb05', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000023');
+    await page.waitForLoadState('networkidle');
+
+    // Load key file but NO passphrase — unlock button must remain disabled
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+
+    // Passphrase is empty → canUnlock should be false
+    await expect(page.getByTestId('unlock-button')).toBeDisabled();
+});
+
+// ─── Scenario 9: Multiple key files ──────────────────────────────────────────
+
+test('multiple key files: creation and successful unlock with all files', async ({ page }) => {
+    createLockerCredit('mkf01', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000030', 'Two key file content', 'mkf01', [KEY_FILE_ALPHA, KEY_FILE_BETA]);
+
+    await page.goto('/lockers/8000000030');
+    await page.waitForLoadState('networkidle');
+
+    // Unlock button disabled until both files loaded
+    await expect(page.getByTestId('unlock-button')).toBeDisabled();
+
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    // Still disabled — only 1 of 2 loaded
+    await expect(page.getByTestId('unlock-button')).toBeDisabled();
+
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_BETA);
+    await page.waitForTimeout(400);
+    // Now enabled
+    await expect(page.getByTestId('unlock-button')).toBeEnabled();
+
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Two key file content')).toBeVisible();
+});
+
+// ─── Scenario 10: Multiple key files — only 1 of 2 provided ─────────────────
+
+test('multiple key files: unlock button disabled when only 1 of 2 files loaded', async ({ page }) => {
+    createLockerCredit('mkf02', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000031', 'Two key file content', 'mkf02', [KEY_FILE_ALPHA, KEY_FILE_BETA]);
+
+    await page.goto('/lockers/8000000031');
+    await page.waitForLoadState('networkidle');
+
+    // Load only 1 of 2 key files
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+
+    // Progress indicator shows 1 / 2
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    // Unlock button still disabled
+    await expect(page.getByTestId('unlock-button')).toBeDisabled();
+});
+
+// ─── Scenario 11: Credential download includes key file fingerprints ──────────
+
+test('credential download button visible and credential panel shows fingerprints for key file mode', async ({ page }) => {
+    createLockerCredit('credkf01', 'text', 1);
+
+    await page.goto('/lockers/create?token=credkf01');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Key File(s)' }).click();
+    await page.getByPlaceholder('Choose a 10-digit number').fill('8000000040');
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    await page.getByTestId('key-file-risk-checkbox').check();
+    await page.getByPlaceholder('Enter the content to store…').fill('Credentials test content');
+    await page.getByTestId('create-submit-button').click();
+
+    await page.waitForSelector('text=Locker created!', { timeout: 15000 });
+
+    // Fingerprint section must be present in the credentials panel
+    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+    await expect(page.getByText('load in this exact order')).toBeVisible();
+
+    // Download button present
+    await expect(page.getByRole('button', { name: /Download as text file/i })).toBeVisible();
+});
+
+// ─── Additional: auth mode UI interaction ────────────────────────────────────
+
+test('switching back to passphrase mode hides key file section and clears added files', async ({ page }) => {
+    createLockerCredit('modeswitch01', 'text', 1);
+
+    await page.goto('/lockers/create?token=modeswitch01');
+    await page.waitForLoadState('networkidle');
+
+    // Go to key_file mode and add a file
+    await page.getByRole('button', { name: 'Key File(s)' }).click();
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    await expect(page.locator('code').filter({ hasText: /^[0-9a-f]{8}$/ })).toBeVisible();
+
+    // Switch back to passphrase — key file list and section should be gone
+    await page.getByRole('button', { name: 'Passphrase' }).click();
+    await expect(page.getByPlaceholder('Enter or generate a passphrase')).toBeVisible();
+    await expect(page.getByTestId('key-file-input')).not.toBeVisible();
+});
+
+test('show page for key file locker does not show passphrase input', async ({ page }) => {
+    createLockerCredit('kfshow01', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000050', 'Key file show test', 'kfshow01', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000050');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('passphrase-input')).not.toBeVisible();
+    await expect(page.getByTestId('key-file-input')).toBeAttached();
+    await expect(page.getByText(/same order as when you created/i)).toBeVisible();
+});
+
+test('change passphrase panel hidden for key file mode after unlock', async ({ page }) => {
+    createLockerCredit('kfcp01', 'text', 1);
+    await createKeyFileLockerViaUI(page, '8000000051', 'Key file no passchange', 'kfcp01', [KEY_FILE_ALPHA]);
+
+    await page.goto('/lockers/8000000051');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
+    await page.waitForTimeout(400);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    // Change Passphrase heading must NOT be visible; Credential Management notice must be
+    await expect(page.getByRole('heading', { name: /Change Passphrase/i })).not.toBeVisible();
+    await expect(page.getByText(/credential rotation is not yet supported/i)).toBeVisible();
+});

--- a/tests/e2e/locker-auth-modes.spec.ts
+++ b/tests/e2e/locker-auth-modes.spec.ts
@@ -32,7 +32,7 @@ test('passphrase-only creation and unlock still works (regression)', async ({ pa
 
 // ─── Scenario 2: Key file creation ────────────────────────────────────────────
 
-test('key file mode creation shows fingerprint and credential panel without passphrase', async ({ page }) => {
+test('key file mode creation shows filename and credential panel without passphrase', async ({ page }) => {
     createLockerCredit('kfcreate01', 'text', 1);
 
     await page.goto('/lockers/create?token=kfcreate01');
@@ -45,11 +45,9 @@ test('key file mode creation shows fingerprint and credential panel without pass
     // Passphrase field should be hidden
     await expect(page.getByPlaceholder('Enter or generate a passphrase')).not.toBeVisible();
 
-    // Add a key file — fingerprint should appear
+    // Add a key file — filename should appear (no fingerprint)
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
-    // Fingerprint is 8 hex chars shown in a code element
-    await expect(page.locator('code').filter({ hasText: /^[0-9a-f]{8}$/ })).toBeVisible();
+    await expect(page.getByText(KEY_FILE_ALPHA.name)).toBeVisible();
 
     // Risk acknowledgement checkbox must be checked before submit
     await page.getByTestId('key-file-risk-checkbox').check();
@@ -60,8 +58,9 @@ test('key file mode creation shows fingerprint and credential panel without pass
     await expect(page.getByText('Locker created!')).toBeVisible({ timeout: 15000 });
     // Passphrase field not shown in credentials panel (key_file mode)
     await expect(page.getByText('Passphrase', { exact: true })).not.toBeVisible();
-    // Key file fingerprints shown in credentials panel
-    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+    // Key file names shown in credentials panel (no fingerprints)
+    await expect(page.getByText('Key Files (load in this order)')).toBeVisible();
+    await expect(page.getByText(KEY_FILE_ALPHA.name)).toBeVisible();
 });
 
 test('key file mode creation blocked if risk checkbox is not checked', async ({ page }) => {
@@ -73,7 +72,6 @@ test('key file mode creation blocked if risk checkbox is not checked', async ({ 
     await page.getByRole('button', { name: 'Key File(s)' }).click();
     await page.getByPlaceholder('Choose a 10-digit number').fill('8000000003');
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
     await page.getByPlaceholder('Enter the content to store…').fill('Content');
     // Do NOT check the risk checkbox
     await page.getByTestId('create-submit-button').click();
@@ -99,7 +97,6 @@ test('key file mode unlock succeeds with correct key file', async ({ page }) => 
 
     // Load the correct key file
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
 
     await page.getByTestId('unlock-button').click();
 
@@ -118,7 +115,6 @@ test('key file mode unlock fails with wrong key file', async ({ page }) => {
 
     // Load the WRONG key file
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_WRONG);
-    await page.waitForTimeout(400);
 
     await page.getByTestId('unlock-button').click();
 
@@ -150,9 +146,10 @@ test('combined mode locker creation completes successfully', async ({ page }) =>
     await createCombinedLockerViaUI(page, '8000000020', 'combined-pass-long', 'Combined mode content', 'cmb02', [KEY_FILE_ALPHA]);
 
     await expect(page.getByText('Locker created!')).toBeVisible();
-    // Both passphrase and fingerprints shown in credentials
+    // Both passphrase and key file names shown in credentials
     await expect(page.getByText('Passphrase', { exact: true })).toBeVisible();
-    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+    await expect(page.getByText('Key Files (load in this order)')).toBeVisible();
+    await expect(page.getByText(KEY_FILE_ALPHA.name)).toBeVisible();
 });
 
 // ─── Scenario 6: Combined mode unlock success ────────────────────────────────
@@ -166,7 +163,6 @@ test('combined mode unlock succeeds with both passphrase and correct key file', 
 
     await page.getByTestId('passphrase-input').fill('combined-unlock-pass');
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
 
     await page.getByTestId('unlock-button').click();
 
@@ -200,7 +196,6 @@ test('combined mode unlock fails when key file provided but no passphrase', asyn
 
     // Load key file but NO passphrase — unlock button must remain disabled
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
 
     // Passphrase is empty → canUnlock should be false
     await expect(page.getByTestId('unlock-button')).toBeDisabled();
@@ -219,12 +214,10 @@ test('multiple key files: creation and successful unlock with all files', async 
     await expect(page.getByTestId('unlock-button')).toBeDisabled();
 
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
     // Still disabled — only 1 of 2 loaded
     await expect(page.getByTestId('unlock-button')).toBeDisabled();
 
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_BETA);
-    await page.waitForTimeout(400);
     // Now enabled
     await expect(page.getByTestId('unlock-button')).toBeEnabled();
 
@@ -245,7 +238,6 @@ test('multiple key files: unlock button disabled when only 1 of 2 files loaded',
 
     // Load only 1 of 2 key files
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
 
     // Progress indicator shows 1 / 2
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
@@ -254,9 +246,9 @@ test('multiple key files: unlock button disabled when only 1 of 2 files loaded',
     await expect(page.getByTestId('unlock-button')).toBeDisabled();
 });
 
-// ─── Scenario 11: Credential download includes key file fingerprints ──────────
+// ─── Scenario 11: Credential download includes key file names ────────────────
 
-test('credential download button visible and credential panel shows fingerprints for key file mode', async ({ page }) => {
+test('credential panel shows key file names (not fingerprints) and download button is visible', async ({ page }) => {
     createLockerCredit('credkf01', 'text', 1);
 
     await page.goto('/lockers/create?token=credkf01');
@@ -265,15 +257,15 @@ test('credential download button visible and credential panel shows fingerprints
     await page.getByRole('button', { name: 'Key File(s)' }).click();
     await page.getByPlaceholder('Choose a 10-digit number').fill('8000000040');
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
     await page.getByTestId('key-file-risk-checkbox').check();
     await page.getByPlaceholder('Enter the content to store…').fill('Credentials test content');
     await page.getByTestId('create-submit-button').click();
 
     await page.waitForSelector('text=Locker created!', { timeout: 15000 });
 
-    // Fingerprint section must be present in the credentials panel
-    await expect(page.getByText('Key File Fingerprints')).toBeVisible();
+    // Key file names shown (no fingerprints)
+    await expect(page.getByText('Key Files (load in this order)')).toBeVisible();
+    await expect(page.getByText(KEY_FILE_ALPHA.name)).toBeVisible();
     await expect(page.getByText('loaded in this exact order')).toBeVisible();
 
     // Download button present
@@ -291,8 +283,7 @@ test('switching back to passphrase mode hides key file section and clears added 
     // Go to key_file mode and add a file
     await page.getByRole('button', { name: 'Key File(s)' }).click();
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
-    await expect(page.locator('code').filter({ hasText: /^[0-9a-f]{8}$/ })).toBeVisible();
+    await expect(page.getByText(KEY_FILE_ALPHA.name)).toBeVisible();
 
     // Switch back to passphrase — key file list and section should be gone
     await page.getByRole('button', { name: 'Passphrase' }).click();
@@ -320,7 +311,6 @@ test('change passphrase panel hidden for key file mode after unlock', async ({ p
     await page.waitForLoadState('networkidle');
 
     await page.getByTestId('key-file-input').setInputFiles(KEY_FILE_ALPHA);
-    await page.waitForTimeout(400);
     await page.getByTestId('unlock-button').click();
     await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
 

--- a/tests/e2e/locker-show.spec.ts
+++ b/tests/e2e/locker-show.spec.ts
@@ -65,7 +65,7 @@ test('wrong passphrase shows error and lock shake animation', async ({ page }) =
     await page.getByTestId('unlock-button').click();
 
     await expect(page.getByTestId('decrypt-error')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/Incorrect passphrase|Decryption failed/i)).toBeVisible();
+    await expect(page.getByText(/Credentials do not match|Decryption failed/i)).toBeVisible();
 });
 
 test('after submitting wrong passphrase, lock shake animation plays and error message appears', async ({ page }) => {
@@ -101,7 +101,7 @@ test('repeated wrong passphrase shows permanent loss warning', async ({ page }) 
         clearCache();
     }
 
-    await expect(page.getByText(/passphrase is lost/i)).toBeVisible();
+    await expect(page.getByText(/credentials are lost/i)).toBeVisible();
 });
 
 test('update panel is always visible with lost token warning', async ({ page }) => {

--- a/tools/flashview-cli/src/crypto.js
+++ b/tools/flashview-cli/src/crypto.js
@@ -19,4 +19,6 @@ export {
     decryptFileFromBuffer,
     deriveSigningKeypair,
     signChallenge,
+    deriveKeyFromFile,
+    combineLockerKeyMaterials,
 } from '@pioneer-dynamics/flashview-crypto';

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -832,6 +832,37 @@ export async function signChallenge(privateKey, challengeHex) {
     return uint8ArrayToBase64(new Uint8Array(sigBuffer));
 }
 
+/**
+ * Compute the SHA-256 digest of a file buffer as a hex string.
+ * Used as key material for key-file authentication — file contents are never stored or transmitted.
+ *
+ * @param {ArrayBuffer|Uint8Array} fileBuffer
+ * @returns {Promise<string>} 64-char hex
+ */
+export async function deriveKeyFromFile(fileBuffer) {
+    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', fileBuffer);
+    return bufferToHex(new Uint8Array(hashBuffer));
+}
+
+/**
+ * Fold N key materials (passphrase string and/or file hash hex strings) into a
+ * single deterministic hex string for use as the effective passphrase.
+ *
+ * Algorithm: SHA-256(materials joined by null byte) → 64-char hex.
+ * Order matters — the same materials in a different order produce a different output.
+ *
+ * @param {string[]} materials  One or more strings: passphrase and/or file hashes
+ * @returns {Promise<string>} 64-char hex
+ */
+export async function combineLockerKeyMaterials(materials) {
+    if (!materials || materials.length === 0) {
+        throw new Error('combineLockerKeyMaterials requires at least one material');
+    }
+    const combined = new TextEncoder().encode(materials.join('\x00'));
+    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', combined);
+    return bufferToHex(new Uint8Array(hashBuffer));
+}
+
 // ─── Message Decryption (legacy PBKDF2 / OpenCrypto) ─────────────────────────
 
 /**

--- a/tools/flashview-crypto/tests/crypto.test.js
+++ b/tools/flashview-crypto/tests/crypto.test.js
@@ -6,6 +6,7 @@ import {
     encryptFileToBuffer, decryptFileFromBuffer,
     generateFileKey, wrapFileKey, unwrapFileKey,
     deriveSigningKeypair, signChallenge,
+    deriveKeyFromFile, combineLockerKeyMaterials,
 } from '../src/index.js';
 
 // Known vectors generated from the pre-migration CLI implementation (tools/flashview-cli/src/crypto.js)
@@ -530,5 +531,90 @@ describe('signChallenge', () => {
             challengeBytes
         );
         assert.ok(! isValid, 'Signature from key1 must not verify with key2 public key');
+    });
+});
+
+describe('deriveKeyFromFile', () => {
+    it('returns a deterministic 64-char hex string', async () => {
+        const buf = new TextEncoder().encode('test-file-contents').buffer;
+        const result = await deriveKeyFromFile(buf);
+        assert.equal(typeof result, 'string', 'Result should be a string');
+        assert.equal(result.length, 64, 'Result should be 64 hex chars');
+        assert.match(result, /^[0-9a-f]{64}$/, 'Result should be lowercase hex');
+    });
+
+    it('is deterministic for the same input', async () => {
+        const buf = new TextEncoder().encode('deterministic-file').buffer;
+        const r1 = await deriveKeyFromFile(buf);
+        const r2 = await deriveKeyFromFile(buf);
+        assert.equal(r1, r2, 'Same input should produce same hash');
+    });
+
+    it('produces different hashes for different inputs', async () => {
+        const buf1 = new TextEncoder().encode('file-a').buffer;
+        const buf2 = new TextEncoder().encode('file-b').buffer;
+        const r1 = await deriveKeyFromFile(buf1);
+        const r2 = await deriveKeyFromFile(buf2);
+        assert.notEqual(r1, r2, 'Different inputs should produce different hashes');
+    });
+
+    it('accepts Uint8Array as input', async () => {
+        const arr = new TextEncoder().encode('uint8array-input');
+        const result = await deriveKeyFromFile(arr);
+        assert.equal(result.length, 64, 'Should work with Uint8Array');
+    });
+});
+
+describe('combineLockerKeyMaterials', () => {
+    it('returns a deterministic 64-char hex string', async () => {
+        const result = await combineLockerKeyMaterials(['passphrase123', 'filehash456']);
+        assert.equal(typeof result, 'string', 'Result should be a string');
+        assert.equal(result.length, 64, 'Result should be 64 hex chars');
+        assert.match(result, /^[0-9a-f]{64}$/, 'Result should be lowercase hex');
+    });
+
+    it('is deterministic for the same inputs in the same order', async () => {
+        const materials = ['passphrase', 'hash1', 'hash2'];
+        const r1 = await combineLockerKeyMaterials(materials);
+        const r2 = await combineLockerKeyMaterials(materials);
+        assert.equal(r1, r2, 'Same inputs in same order should produce same result');
+    });
+
+    it('is order-sensitive — different order produces different output', async () => {
+        const r1 = await combineLockerKeyMaterials(['aaa', 'bbb']);
+        const r2 = await combineLockerKeyMaterials(['bbb', 'aaa']);
+        assert.notEqual(r1, r2, 'Different order should produce different results');
+    });
+
+    it('works with a single material', async () => {
+        const result = await combineLockerKeyMaterials(['single-material']);
+        assert.equal(result.length, 64, 'Single-material result should be 64 hex chars');
+    });
+
+    it('combining a file hash differs from hashing the raw file bytes directly', async () => {
+        // Simulate key_file mode: derive hash from file bytes, then combine
+        const fileBytes = new TextEncoder().encode('original-file-content').buffer;
+        const fileHash = await deriveKeyFromFile(fileBytes);            // = SHA-256(fileBytes) as hex
+        const effectivePassphrase = await combineLockerKeyMaterials([fileHash]); // = SHA-256(UTF-8(fileHash))
+
+        // effective passphrase must differ from the raw file hash — it is SHA-256 of the hex string
+        assert.notEqual(effectivePassphrase, fileHash, 'Effective passphrase must differ from the raw file hash');
+        // effective passphrase must also differ from hashing the file bytes again (same as fileHash)
+        const directHash = await deriveKeyFromFile(fileBytes);
+        assert.equal(directHash, fileHash, 'deriveKeyFromFile is deterministic');
+        assert.notEqual(effectivePassphrase, directHash, 'Effective passphrase must differ from direct hash of file bytes');
+    });
+
+    it('throws on empty array', async () => {
+        await assert.rejects(
+            () => combineLockerKeyMaterials([]),
+            /at least one material/,
+            'Should throw when called with empty array'
+        );
+    });
+
+    it('throws on null or undefined', async () => {
+        await assert.rejects(() => combineLockerKeyMaterials(null), Error);
+        await assert.rejects(() => combineLockerKeyMaterials(undefined), Error);
     });
 });


### PR DESCRIPTION
## Summary

- Extends eLocker authentication beyond passphrase-only to support **key files** (SHA-256 of a file's contents as key material) and **combined mode** (passphrase + all key files required)
- New crypto primitives `deriveKeyFromFile` and `combineLockerKeyMaterials` in `flashview-crypto`, delegated via thin wrappers in both `encryption.js` and `cli/src/crypto.js`
- Database migration adds `auth_mode` and `key_file_count` to `lockers` table; existing lockers default to `passphrase` mode — fully backwards-compatible
- New `GET /lockers/{accountId}/auth-info` endpoint for Show page to detect required credential types on load; returns fake passphrase defaults for non-existent accounts
- Create page: mode selector (Passphrase / Key File(s) / Both), file accumulator with fingerprint display, recovery acknowledgement checkbox, credential download extended with ordered fingerprint sequence
- Show page: dedicated `effectivePassphrase` ref (separate from raw passphrase input), mode-aware unlock guard, key file accumulator UI, Change Passphrase panel hidden for key-file modes with clear rotation limitation notice
- 60 PHPUnit tests (9 new), 66 crypto unit tests (10 new), 16 Playwright E2E tests (all new)

## Regression risks (informational)

- All existing passphrase-only lockers work unchanged (migration default + `sometimes` validation rule)
- 4 pre-existing locker-show E2E test failures exist on `develop` (404 enumeration test, update-token UI tests, file locker helpers) — confirmed pre-existing, not introduced by this branch

## Test plan

- [ ] Create a key-file-only locker, download credentials, navigate to show page, load the same file, verify unlock and decrypted content
- [ ] Attempt unlock with a different file — verify shake/error with order hint
- [ ] Create a combined-mode locker, unlock with both passphrase and key file
- [ ] Create with 2 key files, verify both required (button disabled with only 1)
- [ ] Create a standard passphrase locker — verify existing flow is unchanged
- [ ] Verify Change Passphrase panel is hidden for key-file/combined lockers with the rotation limitation notice
- [ ] Check credential download file contains ordered fingerprints for key-file modes