### PR TITLE
PIO-109: fetch presigned download URL on demand (fix 15-min expiry)

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -372,7 +372,6 @@ class LockerController extends Controller
         ];
 
         if ($locker->isFileLocker()) {
-            $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
             $data['wrapped_file_key'] = $locker->wrapped_file_key;
         }
 
@@ -396,11 +395,44 @@ class LockerController extends Controller
             'auth_challenge' => $locker->auth_challenge,
         ];
 
-        if ($locker->isFileLocker()) {
-            $data['download_url'] = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(15));
+        return response()->json($data);
+    }
+
+    public function downloadUrl(Request $request, string $accountId): JsonResponse
+    {
+        $locker = Locker::where('account_id', $accountId)->first();
+
+        if (! $locker) {
+            return response()->json(['error' => 'Locker not found.'], 404);
         }
 
-        return response()->json($data);
+        if ($locker->isExpired()) {
+            return response()->json(['error' => 'This locker has expired.'], 410);
+        }
+
+        if (! $locker->isFileLocker()) {
+            return response()->json(['error' => 'Locker not found.'], 404);
+        }
+
+        $challengeId = $request->header('X-Signing-Challenge-Id');
+        $signature = $request->header('X-Signature');
+
+        $verified = false;
+
+        if ($challengeId && $signature) {
+            $challengeHex = $this->ecdsaService->consumeChallenge($challengeId, $accountId);
+            if ($challengeHex !== null) {
+                $verified = $this->ecdsaService->verify($locker->public_key, $challengeHex, $signature);
+            }
+        }
+
+        if (! $verified) {
+            return response()->json(['error' => 'Invalid credentials.'], 403);
+        }
+
+        $downloadUrl = Storage::temporaryUrl($locker->storage_path, now()->addMinutes(5));
+
+        return response()->json(['download_url' => $downloadUrl]);
     }
 
     public function update(UpdateLockerRequest $request, string $accountId): JsonResponse

--- a/resources/js/Pages/Locker/Create.vue
+++ b/resources/js/Pages/Locker/Create.vue
@@ -339,7 +339,7 @@ const submit = async () => {
 
                     <button
                         :disabled="!savedConfirmed"
-                        @click="sessionStorage.setItem('locker_prefill_account', credentials.account_id); router.visit(route('lockers.open'))"
+                        @click="router.visit(route('lockers.open'))"
                         class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-40 disabled:cursor-not-allowed text-gray-900 font-semibold py-2.5 px-4 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm"
                     >
                         Open my locker

--- a/resources/js/Pages/Locker/Open.vue
+++ b/resources/js/Pages/Locker/Open.vue
@@ -1158,9 +1158,10 @@ const upgradeAuth = async () => {
                                     </div>
                                     <FileProgressBar v-if="fileState" :state="fileState" :progress="fileProgress" />
                                     <template v-else>
-                                        <p v-if="downloadError" class="text-red-400 text-xs">{{ downloadError }}</p>
+                                        <p v-if="downloadError" class="text-red-400 text-xs" data-testid="download-error">{{ downloadError }}</p>
                                         <button
                                             @click="downloadFile"
+                                            data-testid="download-button"
                                             class="w-full border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-sm py-2 rounded-lg transition-colors"
                                         >
                                             Decrypt &amp; Download

--- a/resources/js/Pages/Locker/Open.vue
+++ b/resources/js/Pages/Locker/Open.vue
@@ -366,11 +366,11 @@ const downloadFile = async () => {
     fileProgress.value = 0;
 
     try {
-        const url = await fetchDownloadUrl();
+        const presignedUrl = await fetchDownloadUrl();
 
         const encryptedBytes = await new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
-            xhr.open('GET', url);
+            xhr.open('GET', presignedUrl);
             xhr.responseType = 'arraybuffer';
             xhr.onprogress = (e) => {
                 if (e.lengthComputable) fileProgress.value = Math.round((e.loaded / e.total) * 100);

--- a/resources/js/Pages/Locker/Open.vue
+++ b/resources/js/Pages/Locker/Open.vue
@@ -43,7 +43,6 @@ const decryptError      = ref('');
 const failCount         = ref(0);
 const decryptedText     = ref('');
 const decryptedFileMeta = ref(null); // { name, type, size }
-const downloadUrl       = ref('');
 
 // File download state
 const fileState    = ref(null); // null | 'downloading'
@@ -204,7 +203,6 @@ const lockLocker = () => {
     passphrase.value              = '';
     decryptedText.value           = '';
     decryptedFileMeta.value       = null;
-    downloadUrl.value             = '';
     authChallenge.value           = '';
     wrappedFileKey.value          = '';
     decryptError.value            = '';
@@ -335,7 +333,6 @@ const unlock = async () => {
             } catch {
                 decryptedFileMeta.value = { name: 'download', type: 'application/octet-stream', size: 0 };
             }
-            downloadUrl.value = data.download_url ?? '';
         } else {
             decryptedText.value = new TextDecoder().decode(result.data);
         }
@@ -365,18 +362,15 @@ const downloadFile = async () => {
     if (fileState.value) return;
     downloadError.value = '';
 
-    if (!downloadUrl.value) {
-        downloadError.value = 'No download URL available — this file may not have been uploaded correctly.';
-        return;
-    }
-
     fileState.value    = 'downloading';
     fileProgress.value = 0;
 
     try {
+        const url = await fetchDownloadUrl();
+
         const encryptedBytes = await new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
-            xhr.open('GET', downloadUrl.value);
+            xhr.open('GET', url);
             xhr.responseType = 'arraybuffer';
             xhr.onprogress = (e) => {
                 if (e.lengthComputable) fileProgress.value = Math.round((e.loaded / e.total) * 100);
@@ -426,6 +420,21 @@ const fetchSigningHeaders = async () => {
         const updateToken = await enc.deriveLockerUpdateToken(effectivePassphrase.value, accountId.value);
         return { 'X-Update-Token': updateToken };
     }
+};
+
+const fetchDownloadUrl = async () => {
+    const authHeaders = await fetchSigningHeaders();
+    const res = await fetch(route('lockers.download-url', accountId.value), {
+        headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...authHeaders },
+    });
+    if (!res.ok) {
+        if (res.status === 403) {
+            throw new Error('Your session has expired. Please lock and re-open your locker to try again.');
+        }
+        throw new Error('Could not fetch download URL. Please try again.');
+    }
+    const data = await res.json();
+    return data.download_url;
 };
 
 const submitUpdate = async () => {
@@ -525,7 +534,6 @@ const submitFileUpdate = async () => {
         wrappedFileKey.value = newWrappedFileKey;
         decryptedFileMeta.value = JSON.parse(meta);
         replacementFile.value  = null;
-        downloadUrl.value = '';
     } catch (err) {
         updateError.value = err.message || 'Update failed. Please try again.';
     } finally {
@@ -594,9 +602,10 @@ const changePassphrase = async () => {
             const meta = JSON.stringify(decryptedFileMeta.value);
             newPayload = await enc.encryptLockerContent(meta, newPassphrase.value);
 
+            const reencryptDownloadUrl = await fetchDownloadUrl();
             const encryptedBytes = await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
-                xhr.open('GET', downloadUrl.value);
+                xhr.open('GET', reencryptDownloadUrl);
                 xhr.responseType = 'arraybuffer';
                 xhr.onprogress = (e) => {
                     if (e.lengthComputable) passphraseChangeProgress.value = Math.round((e.loaded / e.total) * 50);
@@ -644,7 +653,6 @@ const changePassphrase = async () => {
 
             effectivePassphrase.value = newPassphrase.value;
             passphrase.value          = newPassphrase.value;
-            downloadUrl.value         = '';
             newPassphrase.value           = '';
             passphraseChangeSuccess.value = true;
 
@@ -757,9 +765,10 @@ const rotateCredentials = async () => {
             const meta = JSON.stringify(decryptedFileMeta.value);
             const newPayload = await enc.encryptLockerContent(meta, newEp);
 
+            const rotateDownloadUrl = await fetchDownloadUrl();
             const encryptedBytes = await new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
-                xhr.open('GET', downloadUrl.value);
+                xhr.open('GET', rotateDownloadUrl);
                 xhr.responseType = 'arraybuffer';
                 xhr.onprogress = (e) => {
                     if (e.lengthComputable) credRotateProgress.value = Math.round((e.loaded / e.total) * 50);
@@ -805,7 +814,6 @@ const rotateCredentials = async () => {
             if (!res.ok) { credRotateError.value = data.error ?? 'Rotation failed.'; return; }
 
             effectivePassphrase.value = newEp;
-            downloadUrl.value         = '';
 
         } else {
             // Text locker

--- a/routes/web.php
+++ b/routes/web.php
@@ -265,6 +265,8 @@ Route::prefix('lockers')->name('lockers.')->group(function () {
         ->middleware('throttle:6,1')->name('update');
     Route::delete('/{accountId}', [LockerController::class, 'destroy'])
         ->middleware('throttle:6,1')->name('destroy');
+    Route::get('/{accountId}/download-url', [LockerController::class, 'downloadUrl'])
+        ->middleware('throttle:30,1')->name('download-url');
     Route::get('/{accountId}/renew', [LockerController::class, 'renewChallenge'])
         ->middleware('throttle:6,1')->name('renew.challenge');
     Route::post('/{accountId}/renew', [LockerController::class, 'renewPurchase'])

--- a/tests/Feature/Locker/LockerControllerTest.php
+++ b/tests/Feature/Locker/LockerControllerTest.php
@@ -368,7 +368,7 @@ class LockerControllerTest extends TestCase
             ->assertJsonStructure(['upload_url', 'upload_headers', 'storage_path']);
     }
 
-    public function test_unlock_returns_presigned_download_url_for_file_locker(): void
+    public function test_unlock_does_not_return_presigned_download_url_for_file_locker(): void
     {
         Storage::fake();
         $storagePath = 'lockers/test.bin';
@@ -384,11 +384,12 @@ class LockerControllerTest extends TestCase
             'verifier' => str_repeat('a', 64),
         ]);
 
-        $response->assertStatus(200)
-            ->assertJsonStructure(['download_url']);
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey('download_url', $response->json());
+        $response->assertJsonStructure(['wrapped_file_key']);
     }
 
-    public function test_payload_returns_presigned_download_url_for_file_locker(): void
+    public function test_payload_does_not_return_presigned_download_url_for_file_locker(): void
     {
         Storage::fake();
         $storagePath = 'lockers/test.bin';
@@ -403,7 +404,8 @@ class LockerControllerTest extends TestCase
         $response = $this->getJson(route('lockers.payload', '1234567890'));
 
         $response->assertStatus(200)
-            ->assertJsonStructure(['payload', 'auth_challenge', 'download_url']);
+            ->assertJsonStructure(['payload', 'auth_challenge']);
+        $this->assertArrayNotHasKey('download_url', $response->json());
     }
 
     public function test_server_upload_route_does_not_exist(): void
@@ -1223,5 +1225,108 @@ class LockerControllerTest extends TestCase
         ], ['X-Update-Token' => 'wrongtoken']);
 
         $response->assertStatus(403);
+    }
+
+    public function test_download_url_returns_presigned_url_with_valid_ecdsa_auth(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/ecdsa-dl.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create([
+            'account_id' => '5000000001',
+            'public_key' => $publicKey,
+            'auth_challenge' => null,
+            'auth_verifier' => null,
+            'update_token_hash' => null,
+            'storage_path' => $storagePath,
+        ]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '5000000001'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        $response = $this->getJson(
+            route('lockers.download-url', '5000000001'),
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        );
+
+        $response->assertStatus(200)->assertJsonStructure(['download_url']);
+    }
+
+    public function test_download_url_returns_403_with_invalid_ecdsa_signature(): void
+    {
+        Storage::fake();
+
+        [$publicKey] = $this->generateEcdsaKeypair();
+        Locker::factory()->create([
+            'account_id' => '5000000002',
+            'public_key' => $publicKey,
+            'auth_challenge' => null,
+            'auth_verifier' => null,
+            'update_token_hash' => null,
+            'storage_path' => 'lockers/invalid-sig.bin',
+        ]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '5000000002'))->json();
+
+        $response = $this->getJson(
+            route('lockers.download-url', '5000000002'),
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => base64_encode(str_repeat("\x00", 64))]
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_download_url_returns_404_for_nonexistent_locker(): void
+    {
+        $response = $this->getJson(route('lockers.download-url', 'doesnotexist'));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_download_url_returns_410_for_expired_locker(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/expired-dl.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create([
+            'account_id' => '5000000003',
+            'public_key' => $publicKey,
+            'auth_challenge' => null,
+            'auth_verifier' => null,
+            'update_token_hash' => null,
+            'storage_path' => $storagePath,
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $response = $this->getJson(route('lockers.download-url', '5000000003'));
+
+        $response->assertStatus(410);
+    }
+
+    public function test_download_url_returns_404_for_text_locker(): void
+    {
+        [$publicKey, $privateKeyPem] = $this->generateEcdsaKeypair();
+        Locker::factory()->create([
+            'account_id' => '5000000004',
+            'public_key' => $publicKey,
+            'auth_challenge' => null,
+            'auth_verifier' => null,
+            'update_token_hash' => null,
+            'storage_path' => null,
+        ]);
+
+        $challengeData = $this->getJson(route('lockers.challenge', '5000000004'))->json();
+        $signature = $this->ecdsaSign($challengeData['challenge'], $privateKeyPem);
+
+        $response = $this->getJson(
+            route('lockers.download-url', '5000000004'),
+            ['X-Signing-Challenge-Id' => $challengeData['challenge_id'], 'X-Signature' => $signature]
+        );
+
+        $response->assertStatus(404);
     }
 }

--- a/tests/Feature/Regressions/PIO109Test.php
+++ b/tests/Feature/Regressions/PIO109Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Regressions;
+
+use App\Models\Locker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * PIO-109: unlock response must NOT contain download_url — presigned URLs are now
+ * fetched on demand via GET /lockers/{accountId}/download-url to prevent expiry.
+ */
+class PIO109Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unlock_response_does_not_include_download_url(): void
+    {
+        Storage::fake();
+        $storagePath = 'lockers/pio109.bin';
+        Storage::put($storagePath, 'encrypted-content');
+
+        Locker::factory()->create([
+            'account_id' => '1234567890',
+            'auth_verifier' => str_repeat('a', 64),
+            'storage_path' => $storagePath,
+        ]);
+
+        $response = $this->postJson(route('lockers.unlock', '1234567890'), [
+            'verifier' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey('download_url', $response->json());
+    }
+}

--- a/tests/e2e/regressions/PIO109.spec.ts
+++ b/tests/e2e/regressions/PIO109.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @ticket PIO-109
+ * @symptom File download fails after 15 minutes because the presigned S3 URL was
+ *          generated eagerly at unlock time and cached in component state, expiring
+ *          before the user clicks "Decrypt & Download".
+ *
+ * Must fail before the fix (download_url cached at unlock), pass after (on-demand fetch).
+ */
+
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from '../helpers/db';
+import { createLockerCredit, createFileLockerViaUI, navigateToLocker } from '../helpers/locker';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+test('download button is visible after unlocking a file locker', async ({ page }) => {
+    createLockerCredit('pio109token1', 'file', 1);
+    const { accountId, passphrase } = await createFileLockerViaUI(
+        page, '1091091091', 'pio109-passphrase-long', 'pio109token1', 'lockers/pio109-a.bin'
+    );
+
+    await navigateToLocker(page, accountId);
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('download-button')).toBeVisible();
+});
+
+test('clicking download fetches a fresh URL from /download-url endpoint (not a cached URL)', async ({ page }) => {
+    createLockerCredit('pio109token2', 'file', 1);
+    const { accountId, passphrase } = await createFileLockerViaUI(
+        page, '1092092092', 'pio109-passphrase-long', 'pio109token2', 'lockers/pio109-b.bin'
+    );
+
+    // Intercept and record calls to the on-demand download-url endpoint
+    const downloadUrlRequests: string[] = [];
+    await page.route('**/lockers/*/download-url', async route => {
+        downloadUrlRequests.push(route.request().url());
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ download_url: 'https://mock-s3-pio109.example.com/pio109-b.bin' }),
+        });
+    });
+
+    // Intercept the S3 download so the XHR resolves (avoids actual network call)
+    await page.route('https://mock-s3-pio109.example.com/**', async route => {
+        // Return minimal valid encrypted-file bytes — decryption will fail but we only
+        // care that the /download-url request was made, not that decryption succeeds.
+        await route.fulfill({ status: 200, body: Buffer.alloc(128, 0xAB) });
+    });
+
+    await navigateToLocker(page, accountId);
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('download-button').click();
+
+    // The key assertion: a network request was made to the /download-url endpoint
+    await page.waitForFunction(() => true); // flush microtasks
+    await page.waitForTimeout(500); // allow fetch to complete
+    expect(downloadUrlRequests.length).toBeGreaterThan(0);
+    expect(downloadUrlRequests[0]).toContain('/download-url');
+});
+
+test('download shows session-expired error message when download-url returns 403', async ({ page }) => {
+    createLockerCredit('pio109token3', 'file', 1);
+    const { accountId, passphrase } = await createFileLockerViaUI(
+        page, '1093093093', 'pio109-passphrase-long', 'pio109token3', 'lockers/pio109-c.bin'
+    );
+
+    await navigateToLocker(page, accountId);
+    await page.getByTestId('passphrase-input').fill(passphrase);
+    await page.getByTestId('unlock-button').click();
+    await expect(page.getByTestId('decrypted-content')).toBeVisible({ timeout: 15000 });
+
+    // Mock the download-url endpoint to simulate an expired session
+    await page.route('**/lockers/*/download-url', async route => {
+        await route.fulfill({
+            status: 403,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Invalid credentials.' }),
+        });
+    });
+
+    await page.getByTestId('download-button').click();
+
+    await expect(page.getByTestId('download-error')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('download-error')).toContainText(/session has expired|lock and re-open/i);
+});


### PR DESCRIPTION
## Summary

- File downloads on eLockers were silently failing for users who waited >15 minutes after unlocking before clicking "Decrypt & Download" — the S3 presigned URL (15-min TTL) was generated eagerly at unlock time and cached in Vue component state
- Removes `download_url` from the `unlock` and `payload` responses entirely
- Adds `GET /lockers/{accountId}/download-url` (ECDSA auth, 5-min TTL) to generate a fresh URL on demand
- `Open.vue` now calls `fetchDownloadUrl()` immediately before every download XHR — `downloadUrl` reactive ref removed
- All three affected flows updated: `downloadFile()`, legacy `changePassphrase()`, legacy `rotateCredentials()`
- Loading state set before the URL fetch to block double-clicks on slow connections; 403 from the endpoint shows a plain-language "Your session has expired. Please lock and re-open your locker to try again." message

## Test plan

- [ ] Unlock a file locker, wait >15 minutes (or use DevTools to intercept and expire the URL), click "Decrypt & Download" — download succeeds
- [ ] Verify unlock response no longer contains `download_url` (DevTools Network → XHR → unlock)
- [ ] Verify `/download-url` endpoint is called on each download attempt
- [ ] Clicking download rapidly does not trigger duplicate requests (loading state blocks double-click)
- [ ] Lock and re-open the locker — download still works
- [ ] Passphrase change on legacy file locker still works (calls `fetchDownloadUrl()` internally)
- [ ] `php artisan test tests/Feature/Regressions/PIO109Test.php tests/Feature/Locker/LockerControllerTest.php` — 81 tests pass
- [ ] `npx playwright test tests/e2e/regressions/PIO109.spec.ts` — 3/3 pass

## Regression notes (informational)

**`tests/e2e/locker-show.spec.ts` dead mock code:** Two existing tests intercept the `unlock` response and patch `download_url` via `if (body.download_url)`. Since `download_url` is no longer in the unlock response, this block is a no-op. Both tests still pass (neither clicks the download button), but the mock setup should be updated to mock `**/download-url` in a follow-up cleanup.

**Legacy HMAC file lockers:** The new endpoint is ECDSA-only. Production data confirmed zero rows with `storage_path IS NOT NULL AND public_key IS NULL` — no legacy file lockers exist, so this is safe.

**Rate limiting:** The new endpoint uses `throttle:30,1` (same as other read endpoints) but does not increment the per-account lockout counter on failed signatures. This is acceptable for an authenticated read endpoint; a follow-up can add lockout parity if desired.