### PR TITLE
PIO-112: Call Session Model & Database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,22 @@ VITE_POSTHOG_HOST=
 SECRET_PRUNE_AFTER_EXPIRY_DAYS_PLUS=30
 NIGHTWATCH_TOKEN=
 
+# Hashids salt for call session join codes (set a strong random value in production)
+HASH_ID_SALT_CALL_SESSION=
+
+# WebRTC TURN relay — hosted provider (default: metered)
+# Switch driver: TURN_DRIVER=xirsys
+TURN_DRIVER=metered
+
+# Metered.ca
+TURN_METERED_API_KEY=
+TURN_METERED_DOMAIN=
+
+# Xirsys (alternative)
+TURN_XIRSYS_API_KEY=
+TURN_XIRSYS_SECRET=
+TURN_XIRSYS_CHANNEL=flashview
+
 # Passkey authentication logo (must be a data URI, e.g. data:image/svg+xml;utf8,<svg ...>)
 PASSKEY_APP_LOGO=
 

--- a/app/Console/Commands/LegalCallMetadata.php
+++ b/app/Console/Commands/LegalCallMetadata.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CallSession;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+
+class LegalCallMetadata extends Command implements PromptsForMissingInput
+{
+    protected $signature = 'legal:call-metadata {hash_id : The hash ID (join code) of the call session}';
+
+    protected $description = 'Retrieve the metadata for a call session.';
+
+    public function handle(): void
+    {
+        try {
+            $session = CallSession::findByHashID($this->argument('hash_id'));
+        } catch (\Throwable) {
+            $this->fail('Call session not found.');
+        }
+
+        $session->load('participants');
+
+        $this->info('Session');
+        $this->table(['Property', 'Value'], [
+            ['Bridge Number', $session->hash_id],
+            ['Starts At', $session->starts_at],
+            ['Ends At', $session->ends_at],
+            ['Max Participants', $session->max_participants],
+        ]);
+
+        $this->newLine();
+        $this->info('Participants');
+        $this->table(
+            ['Participant ID', 'Joined At', 'Left At', 'IP Address'],
+            $session->participants->map(fn ($p) => [
+                $p->id,
+                $p->joined_at,
+                $p->left_at ?? '—',
+                $p->ip_address,
+            ])->toArray()
+        );
+    }
+}

--- a/app/Contracts/TurnProvider.php
+++ b/app/Contracts/TurnProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Contracts;
+
+interface TurnProvider
+{
+    /**
+     * @return array<int, array{urls: string|string[], username?: string, credential?: string}>
+     */
+    public function getIceServers(): array;
+}

--- a/app/Facades/Turn.php
+++ b/app/Facades/Turn.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Facades;
+
+use App\Turn\TurnManager;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static array getIceServers()
+ * @method static \App\Contracts\TurnProvider driver(\UnitEnum|string|null $driver = null)
+ *
+ * @see TurnManager
+ */
+class Turn extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return TurnManager::class;
+    }
+}

--- a/app/Http/Controllers/CallSessionController.php
+++ b/app/Http/Controllers/CallSessionController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Facades\Turn;
+use App\Http\Requests\Call\JoinCallSessionRequest;
+use App\Models\CallSession;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+
+class CallSessionController extends Controller
+{
+    public function challenge(CallSession $callSession): JsonResponse
+    {
+        $challenge = bin2hex(random_bytes(32));
+        cache()->put("call-challenge:{$callSession->id}", $challenge, 60);
+
+        return response()->json([
+            'challenge' => $challenge,
+            'salt' => $callSession->key_salt,
+        ]);
+    }
+
+    public function join(JoinCallSessionRequest $request, CallSession $callSession): JsonResponse
+    {
+        $challenge = cache()->pull("call-challenge:{$callSession->id}");
+
+        if (! $challenge) {
+            return response()->json(['message' => 'Challenge expired or not found. Request a new challenge.'], 422);
+        }
+
+        $signature = base64_decode($request->input('signature'));
+        $publicKey = base64_decode($callSession->public_key);
+
+        try {
+            $valid = sodium_crypto_sign_verify_detached($signature, hex2bin($challenge), $publicKey);
+        } catch (\SodiumException) {
+            $valid = false;
+        }
+
+        if (! $valid) {
+            return response()->json(['message' => 'Unauthorised'], 401);
+        }
+
+        $participant = $callSession->participants()->create([
+            'joined_at' => now(),
+            'ip_address' => $request->ip(),
+        ]);
+
+        try {
+            $iceServers = Turn::getIceServers();
+        } catch (\RuntimeException $e) {
+            Log::warning('TURN provider failed during join', ['error' => $e->getMessage()]);
+            $iceServers = [];
+        }
+
+        return response()->json([
+            'session' => [
+                'bridge_number' => $callSession->hash_id,
+                'starts_at' => $callSession->starts_at,
+                'ends_at' => $callSession->ends_at,
+                'max_participants' => $callSession->max_participants,
+                'current_participant_count' => $callSession->participants()->count(),
+            ],
+            'participant_id' => $participant->id,
+            'ice_servers' => $iceServers,
+            'turn_available' => ! empty($iceServers),
+        ]);
+    }
+}

--- a/app/Http/Requests/Call/JoinCallSessionRequest.php
+++ b/app/Http/Requests/Call/JoinCallSessionRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Call;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JoinCallSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'signature' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Jobs/PurgeCallParticipantMetadata.php
+++ b/app/Jobs/PurgeCallParticipantMetadata.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\CallParticipant;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class PurgeCallParticipantMetadata implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        CallParticipant::whereHas(
+            'session',
+            fn ($q) => $q->where('ends_at', '<', now()->subDays(config('secrets.prune_after')))
+        )->each(fn (CallParticipant $participant) => $participant->delete());
+    }
+}

--- a/app/Models/CallParticipant.php
+++ b/app/Models/CallParticipant.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\CallParticipantFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CallParticipant extends Model
+{
+    /** @use HasFactory<CallParticipantFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'call_session_id',
+        'public_key',
+        'joined_at',
+        'left_at',
+        'ip_address',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'joined_at' => 'datetime',
+            'left_at' => 'datetime',
+            'ip_address' => 'encrypted',
+        ];
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(CallSession::class, 'call_session_id');
+    }
+}

--- a/app/Models/CallSession.php
+++ b/app/Models/CallSession.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasHashId;
+use Database\Factories\CallSessionFactory;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CallSession extends Model
+{
+    /** @use HasFactory<CallSessionFactory> */
+    use HasFactory, HasHashId;
+
+    protected $fillable = [
+        'public_key',
+        'key_salt',
+        'starts_at',
+        'ends_at',
+        'max_participants',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
+            'max_participants' => 'integer',
+            'metadata' => 'array',
+        ];
+    }
+
+    #[Scope]
+    protected function active($query): void
+    {
+        $query->where('starts_at', '<=', now())->where('ends_at', '>=', now());
+    }
+
+    #[Scope]
+    protected function joinable($query): void
+    {
+        // TODO(PIO-118): Add participant count enforcement with pessimistic locking
+        $query->active();
+    }
+
+    public function participants(): HasMany
+    {
+        return $this->hasMany(CallParticipant::class);
+    }
+
+    public function isActive(): bool
+    {
+        return now()->between($this->starts_at, $this->ends_at);
+    }
+
+    public function isFull(): bool
+    {
+        return $this->participants()->count() >= $this->max_participants;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -117,6 +117,14 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for('locker-account-lock', fn (Request $request) => Limit::perHour(3)->by($request->route('accountId')));
         // Controller key pattern: 'locker-account-cooldown:{accountId}' — NOT 'locker-account-cooldown|{accountId}'.
         RateLimiter::for('locker-account-cooldown', fn (Request $request) => Limit::perMinutes(5, 1)->by($request->route('accountId')));
+
+        RateLimiter::for('call-sessions-challenge', function (Request $request) {
+            return Limit::perMinute(20)->by($request->ip().'|'.$request->route('callSession'));
+        });
+
+        RateLimiter::for('call-sessions-join', function (Request $request) {
+            return Limit::perMinute(10)->by($request->ip().'|'.$request->route('callSession'));
+        });
     }
 
     private function planThrottleLimit(User $user): Limit

--- a/app/Providers/TurnServiceProvider.php
+++ b/app/Providers/TurnServiceProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Providers;
+
+use App\Turn\TurnManager;
+use Illuminate\Support\ServiceProvider;
+
+class TurnServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(TurnManager::class, fn ($app) => new TurnManager($app));
+    }
+}

--- a/app/Turn/MeteredTurnProvider.php
+++ b/app/Turn/MeteredTurnProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Turn;
+
+use App\Contracts\TurnProvider;
+use Illuminate\Support\Facades\Http;
+
+class MeteredTurnProvider implements TurnProvider
+{
+    public function __construct(private readonly array $config) {}
+
+    public function getIceServers(): array
+    {
+        $domain = $this->config['domain'];
+        $apiKey = $this->config['api_key'];
+
+        $response = Http::post(
+            "https://{$domain}.metered.ca/api/v1/turn/credentials?apiKey={$apiKey}"
+        );
+
+        if (! $response->successful()) {
+            throw new \RuntimeException('Metered.ca TURN API returned '.$response->status());
+        }
+
+        return $response->json();
+    }
+}

--- a/app/Turn/TurnManager.php
+++ b/app/Turn/TurnManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Turn;
+
+use App\Contracts\TurnProvider;
+use Illuminate\Support\Manager;
+
+class TurnManager extends Manager
+{
+    public function getDefaultDriver(): string
+    {
+        return config('turn.default', 'metered');
+    }
+
+    public function createMeteredDriver(): TurnProvider
+    {
+        return new MeteredTurnProvider(config('turn.drivers.metered'));
+    }
+
+    public function createXirsysDriver(): TurnProvider
+    {
+        return new XirsysTurnProvider(config('turn.drivers.xirsys'));
+    }
+}

--- a/app/Turn/XirsysTurnProvider.php
+++ b/app/Turn/XirsysTurnProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Turn;
+
+use App\Contracts\TurnProvider;
+use Illuminate\Support\Facades\Http;
+
+class XirsysTurnProvider implements TurnProvider
+{
+    public function __construct(private readonly array $config) {}
+
+    public function getIceServers(): array
+    {
+        $response = Http::withBasicAuth($this->config['api_key'], $this->config['secret'])
+            ->put("https://global.xirsys.net/_turn/{$this->config['channel']}");
+
+        if (! $response->successful()) {
+            throw new \RuntimeException('Xirsys TURN API returned '.$response->status());
+        }
+
+        return data_get($response->json(), 'v.iceServers', []);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -44,6 +44,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'cli/token',
             'cli/device/initiate',
             'cli/device/poll',
+            'call-sessions/*',
         ]);
 
         $middleware->alias([

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,17 +1,27 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\FortifyServiceProvider;
+use App\Providers\HorizonServiceProvider;
+use App\Providers\JetstreamServiceProvider;
+use App\Providers\TurnServiceProvider;
+use Monicahq\Cloudflare\TrustedProxyServiceProvider;
+use PioneerDynamics\LaravelPasskey\Providers\PasskeyServiceProvider;
+use Vinkla\Hashids\HashidsServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\FortifyServiceProvider::class,
-    App\Providers\HorizonServiceProvider::class,
-    App\Providers\JetstreamServiceProvider::class,
+    AppServiceProvider::class,
+    FortifyServiceProvider::class,
+    HorizonServiceProvider::class,
+    JetstreamServiceProvider::class,
+    TurnServiceProvider::class,
 
     /*
      * Package providers that require manual registration due to
      * Composer package repository overrides (no auto-discovery).
      * Remove these once upstream packages release L13-compatible versions.
      */
-    Vinkla\Hashids\HashidsServiceProvider::class,
-    Monicahq\Cloudflare\TrustedProxyServiceProvider::class,
-    PioneerDynamics\LaravelPasskey\Providers\PasskeyServiceProvider::class,
+    HashidsServiceProvider::class,
+    TrustedProxyServiceProvider::class,
+    PasskeyServiceProvider::class,
 ];

--- a/config/hashids.php
+++ b/config/hashids.php
@@ -34,6 +34,11 @@ return [
             // 'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
         ],
 
+        'CallSession' => [
+            'salt' => env('HASH_ID_SALT_CALL_SESSION', ''),
+            'length' => 10,
+        ],
+
     ],
 
 ];

--- a/config/turn.php
+++ b/config/turn.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default TURN Driver
+    |--------------------------------------------------------------------------
+    |
+    | Supported: "metered", "xirsys"
+    |
+    */
+
+    'default' => env('TURN_DRIVER', 'metered'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | TURN Drivers
+    |--------------------------------------------------------------------------
+    */
+
+    'drivers' => [
+
+        'metered' => [
+            'api_key' => env('TURN_METERED_API_KEY', ''),
+            'domain' => env('TURN_METERED_DOMAIN', ''),  // e.g. 'myapp' → myapp.metered.ca
+        ],
+
+        'xirsys' => [
+            'api_key' => env('TURN_XIRSYS_API_KEY', ''),
+            'secret' => env('TURN_XIRSYS_SECRET', ''),
+            'channel' => env('TURN_XIRSYS_CHANNEL', 'flashview'),
+        ],
+
+    ],
+
+];

--- a/database/factories/CallParticipantFactory.php
+++ b/database/factories/CallParticipantFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CallParticipant>
+ */
+class CallParticipantFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'call_session_id' => CallSession::factory(),
+            'public_key' => null,
+            'joined_at' => now(),
+            'left_at' => null,
+            'ip_address' => '127.0.0.1',
+        ];
+    }
+}

--- a/database/factories/CallSessionFactory.php
+++ b/database/factories/CallSessionFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CallSession;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CallSession>
+ */
+class CallSessionFactory extends Factory
+{
+    public function definition(): array
+    {
+        $keyPair = sodium_crypto_sign_keypair();
+
+        return [
+            'public_key' => base64_encode(sodium_crypto_sign_publickey($keyPair)),
+            'key_salt' => base64_encode(random_bytes(32)),
+            'starts_at' => now()->subMinutes(5),
+            'ends_at' => now()->addMinutes(55),
+            'max_participants' => 2,
+            'metadata' => null,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(['ends_at' => now()->subMinute()]);
+    }
+
+    public function notYetStarted(): static
+    {
+        return $this->state(['starts_at' => now()->addMinutes(10)]);
+    }
+}

--- a/database/migrations/2026_06_14_021729_create_call_sessions_table.php
+++ b/database/migrations/2026_06_14_021729_create_call_sessions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('call_sessions', function (Blueprint $table) {
+            $table->id();                                                // auto-increment bigint — encoded as hash_id, never exposed as integer
+            $table->text('public_key');                                  // Ed25519 public key (base64, 32 bytes) — server never sees the password
+            $table->string('key_salt', 64);                             // PBKDF2 salt (base64, 32 bytes) — returned by challenge endpoint
+            $table->timestamp('starts_at');
+            $table->timestamp('ends_at');
+            $table->unsignedTinyInteger('max_participants')->default(2);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('call_sessions');
+    }
+};

--- a/database/migrations/2026_06_14_021748_create_call_participants_table.php
+++ b/database/migrations/2026_06_14_021748_create_call_participants_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->text('public_key')->nullable(); // ECDH public key — populated in PIO-115 key exchange
             $table->timestamp('joined_at');
             $table->timestamp('left_at')->nullable();
-            $table->string('ip_address'); // encrypted via model cast
+            $table->text('ip_address'); // encrypted via model cast — text required for ciphertext length
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_06_14_021748_create_call_participants_table.php
+++ b/database/migrations/2026_06_14_021748_create_call_participants_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('call_participants', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('call_session_id')->constrained()->cascadeOnDelete();
+            $table->text('public_key')->nullable(); // ECDH public key — populated in PIO-115 key exchange
+            $table->timestamp('joined_at');
+            $table->timestamp('left_at')->nullable();
+            $table->string('ip_address'); // encrypted via model cast
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('call_participants');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,12 +4,14 @@ use App\Jobs\ClearExpiredLockers;
 use App\Jobs\ClearExpiredPipeDevices;
 use App\Jobs\ClearExpiredPipeSessions;
 use App\Jobs\ClearExpiredSecrets;
+use App\Jobs\PurgeCallParticipantMetadata;
 use App\Jobs\PurgeMetadataForExpiredMessages;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::job(new ClearExpiredSecrets)->daily();
 Schedule::job(new ClearExpiredLockers)->hourly();
 Schedule::job(new PurgeMetadataForExpiredMessages)->daily();
+Schedule::job(new PurgeCallParticipantMetadata)->daily();
 Schedule::job(new ClearExpiredPipeSessions)->daily();
 Schedule::job(new ClearExpiredPipeDevices)->daily();
 Schedule::command('cloudflare:reload')->daily();

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Admin\AdminPlanController;
 use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\BlogController;
+use App\Http\Controllers\CallSessionController;
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\CliDeviceController;
 use App\Http\Controllers\CliInstallationController;
@@ -231,6 +232,17 @@ Route::middleware([
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::post('users/{user}/suspend', [AdminUserController::class, 'suspend'])->name('users.suspend');
     Route::delete('users/{user}/suspend', [AdminUserController::class, 'unsuspend'])->name('users.unsuspend');
+});
+
+// Call session routes — no auth required; Ed25519 challenge-response verifies access
+Route::prefix('call-sessions')->name('call-sessions.')->group(function () {
+    Route::get('/{callSession}/challenge', [CallSessionController::class, 'challenge'])
+        ->name('challenge')
+        ->middleware('throttle:call-sessions-challenge');
+
+    Route::post('/{callSession}/join', [CallSessionController::class, 'join'])
+        ->name('join')
+        ->middleware('throttle:call-sessions-join');
 });
 
 // eLocker routes — no auth required; all anonymous

--- a/tests/Feature/Call/CallParticipantTest.php
+++ b/tests/Feature/Call/CallParticipantTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class CallParticipantTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_participant_belongs_to_call_session(): void
+    {
+        $session = CallSession::factory()->create();
+        $participant = CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        $this->assertTrue($participant->session->is($session));
+    }
+
+    public function test_call_session_has_many_participants(): void
+    {
+        $session = CallSession::factory()->create();
+        CallParticipant::factory()->count(3)->create(['call_session_id' => $session->id]);
+
+        $this->assertCount(3, $session->participants);
+    }
+
+    public function test_ip_address_is_encrypted_at_rest(): void
+    {
+        $session = CallSession::factory()->create();
+        $participant = CallParticipant::factory()->create([
+            'call_session_id' => $session->id,
+            'ip_address' => '192.168.1.100',
+        ]);
+
+        // The raw database value should not equal the plaintext IP
+        $raw = DB::table('call_participants')
+            ->where('id', $participant->id)
+            ->value('ip_address');
+
+        $this->assertNotEquals('192.168.1.100', $raw);
+
+        // But the model attribute should transparently decrypt it
+        $this->assertEquals('192.168.1.100', $participant->fresh()->ip_address);
+    }
+}

--- a/tests/Feature/Call/CallSessionTest.php
+++ b/tests/Feature/Call/CallSessionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CallSessionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_call_session_can_be_created_with_factory(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $this->assertDatabaseHas('call_sessions', ['id' => $session->id]);
+        $this->assertNotEmpty($session->public_key);
+        $this->assertNotEmpty($session->key_salt);
+    }
+
+    public function test_hash_id_is_computed_from_integer_pk(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $this->assertNotEmpty($session->hash_id);
+        $this->assertIsString($session->hash_id);
+        $this->assertEquals(10, strlen($session->hash_id));
+    }
+
+    public function test_active_scope_returns_sessions_within_time_window(): void
+    {
+        $active = CallSession::factory()->create([
+            'starts_at' => now()->subMinutes(10),
+            'ends_at' => now()->addMinutes(50),
+        ]);
+
+        $this->assertDatabaseHas('call_sessions', ['id' => $active->id]);
+        $this->assertCount(1, CallSession::active()->get());
+    }
+
+    public function test_active_scope_excludes_sessions_outside_time_window(): void
+    {
+        CallSession::factory()->inactive()->create();
+        CallSession::factory()->notYetStarted()->create();
+
+        $this->assertCount(0, CallSession::active()->get());
+    }
+
+    public function test_joinable_scope_delegates_to_active(): void
+    {
+        $active = CallSession::factory()->create();
+        CallSession::factory()->inactive()->create();
+
+        $joinable = CallSession::joinable()->get();
+
+        $this->assertCount(1, $joinable);
+        $this->assertTrue($joinable->first()->is($active));
+    }
+
+    public function test_is_full_returns_true_when_participants_at_max(): void
+    {
+        $session = CallSession::factory()->create(['max_participants' => 2]);
+        CallParticipant::factory()->count(2)->create(['call_session_id' => $session->id]);
+
+        $this->assertTrue($session->isFull());
+    }
+
+    public function test_is_full_returns_false_when_below_max(): void
+    {
+        $session = CallSession::factory()->create(['max_participants' => 2]);
+        CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        $this->assertFalse($session->isFull());
+    }
+
+    public function test_is_active_returns_true_for_active_session(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $this->assertTrue($session->isActive());
+    }
+
+    public function test_is_active_returns_false_for_inactive_session(): void
+    {
+        $session = CallSession::factory()->inactive()->create();
+
+        $this->assertFalse($session->isActive());
+    }
+}

--- a/tests/Feature/Call/ChallengeCallSessionTest.php
+++ b/tests/Feature/Call/ChallengeCallSessionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class ChallengeCallSessionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_challenge_returns_challenge_and_salt_for_valid_hash_id(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $response = $this->getJson("/call-sessions/{$session->hash_id}/challenge");
+
+        $response->assertOk()
+            ->assertJsonStructure(['challenge', 'salt'])
+            ->assertJsonPath('salt', $session->key_salt);
+
+        $this->assertEquals(64, strlen($response->json('challenge')));
+    }
+
+    public function test_challenge_returns_404_for_unknown_hash_id(): void
+    {
+        $response = $this->getJson('/call-sessions/unknownhash/challenge');
+
+        $response->assertNotFound();
+    }
+
+    public function test_challenge_is_stored_in_cache_with_60_second_ttl(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $response = $this->getJson("/call-sessions/{$session->hash_id}/challenge");
+
+        $response->assertOk();
+
+        $cached = Cache::get("call-challenge:{$session->id}");
+        $this->assertNotNull($cached);
+        $this->assertEquals($response->json('challenge'), $cached);
+    }
+}

--- a/tests/Feature/Call/JoinCallSessionTest.php
+++ b/tests/Feature/Call/JoinCallSessionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class JoinCallSessionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function generateKeyPairAndSession(): array
+    {
+        $keyPair = sodium_crypto_sign_keypair();
+        $privateKey = sodium_crypto_sign_secretkey($keyPair);
+        $publicKey = sodium_crypto_sign_publickey($keyPair);
+
+        $session = CallSession::factory()->create([
+            'public_key' => base64_encode($publicKey),
+        ]);
+
+        return [$privateKey, $publicKey, $session];
+    }
+
+    private function fetchChallenge(CallSession $session): string
+    {
+        $response = $this->getJson("/call-sessions/{$session->hash_id}/challenge");
+        $response->assertOk();
+
+        return $response->json('challenge');
+    }
+
+    private function signChallenge(string $privateKey, string $challengeHex): string
+    {
+        $signature = sodium_crypto_sign_detached(hex2bin($challengeHex), $privateKey);
+
+        return base64_encode($signature);
+    }
+
+    public function test_can_join_with_correct_signature(): void
+    {
+        Http::fake(['*' => Http::response([['urls' => 'stun:stun.example.com']], 200)]);
+
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+        $signature = $this->signChallenge($privateKey, $challenge);
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $signature,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'session' => ['bridge_number', 'starts_at', 'ends_at', 'max_participants', 'current_participant_count'],
+                'participant_id',
+                'ice_servers',
+                'turn_available',
+            ]);
+    }
+
+    public function test_cannot_join_with_wrong_signature(): void
+    {
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $this->fetchChallenge($session);
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => base64_encode(random_bytes(64)),
+        ]);
+
+        $response->assertStatus(401)->assertJsonPath('message', 'Unauthorised');
+    }
+
+    public function test_join_returns_422_when_no_challenge_exists(): void
+    {
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => base64_encode(random_bytes(64)),
+        ]);
+
+        $response->assertStatus(422)->assertJsonPath('message', fn ($v) => str_contains($v, 'Challenge expired'));
+    }
+
+    public function test_join_prevents_challenge_replay(): void
+    {
+        Http::fake(['*' => Http::response([['urls' => 'stun:stun.example.com']], 200)]);
+
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+        $signature = $this->signChallenge($privateKey, $challenge);
+
+        // First join succeeds
+        $this->postJson("/call-sessions/{$session->hash_id}/join", ['signature' => $signature])
+            ->assertOk();
+
+        // Second join with same signature fails — challenge was consumed
+        $this->postJson("/call-sessions/{$session->hash_id}/join", ['signature' => $signature])
+            ->assertStatus(422);
+    }
+
+    public function test_join_returns_ice_servers_from_turn_service(): void
+    {
+        $fakeServers = [['urls' => 'turn:relay.example.com', 'username' => 'u', 'credential' => 'p']];
+        Http::fake(['*' => Http::response($fakeServers, 200)]);
+
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $this->signChallenge($privateKey, $challenge),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('turn_available', true)
+            ->assertJsonCount(1, 'ice_servers');
+    }
+
+    public function test_join_returns_empty_ice_servers_when_turn_service_fails(): void
+    {
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+
+        // Fake TURN provider failure AFTER the challenge request (avoids intercepting Cloudflare proxy lookup)
+        Http::fake(['*.metered.ca/*' => Http::response('error', 500)]);
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $this->signChallenge($privateKey, $challenge),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('turn_available', false)
+            ->assertJsonPath('ice_servers', []);
+    }
+
+    public function test_join_creates_participant_record(): void
+    {
+        Http::fake(['*' => Http::response([], 200)]);
+
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+
+        $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $this->signChallenge($privateKey, $challenge),
+        ])->assertOk();
+
+        $this->assertCount(1, $session->fresh()->participants);
+    }
+
+    public function test_join_returns_404_for_unknown_hash_id(): void
+    {
+        $response = $this->postJson('/call-sessions/unknownhash/join', [
+            'signature' => base64_encode(random_bytes(64)),
+        ]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_join_requires_signature_field(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", []);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['signature']);
+    }
+
+    public function test_join_response_includes_hash_id_not_integer_pk(): void
+    {
+        Http::fake(['*' => Http::response([], 200)]);
+
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+
+        $response = $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $this->signChallenge($privateKey, $challenge),
+        ])->assertOk();
+
+        $bridgeNumber = $response->json('session.bridge_number');
+        $this->assertNotEquals((string) $session->id, $bridgeNumber);
+        $this->assertEquals($session->hash_id, $bridgeNumber);
+    }
+}

--- a/tests/Feature/Call/LegalCallMetadataTest.php
+++ b/tests/Feature/Call/LegalCallMetadataTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LegalCallMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_outputs_session_and_participants(): void
+    {
+        $session = CallSession::factory()->create();
+        CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        $this->artisan('legal:call-metadata', ['hash_id' => $session->hash_id])
+            ->assertSuccessful()
+            ->expectsOutputToContain($session->hash_id)
+            ->expectsOutputToContain('Session')
+            ->expectsOutputToContain('Participants');
+    }
+
+    public function test_command_decrypts_ip_address_in_output(): void
+    {
+        $session = CallSession::factory()->create();
+        CallParticipant::factory()->create([
+            'call_session_id' => $session->id,
+            'ip_address' => '10.0.0.1',
+        ]);
+
+        $this->artisan('legal:call-metadata', ['hash_id' => $session->hash_id])
+            ->assertSuccessful()
+            ->expectsOutputToContain('10.0.0.1');
+    }
+
+    public function test_command_fails_for_unknown_bridge_number(): void
+    {
+        $this->artisan('legal:call-metadata', ['hash_id' => 'unknownhash'])
+            ->assertFailed()
+            ->expectsOutputToContain('not found');
+    }
+
+    public function test_command_outputs_empty_participants_table_when_already_purged(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $this->artisan('legal:call-metadata', ['hash_id' => $session->hash_id])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Participants');
+    }
+}

--- a/tests/Feature/Call/PurgeCallParticipantMetadataTest.php
+++ b/tests/Feature/Call/PurgeCallParticipantMetadataTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Jobs\PurgeCallParticipantMetadata;
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurgeCallParticipantMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function pruneAfter(): int
+    {
+        return config('secrets.prune_after', 30);
+    }
+
+    public function test_purge_job_deletes_participants_from_sessions_past_retention_window(): void
+    {
+        $session = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter() + 1),
+        ]);
+        $participant = CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        dispatch(new PurgeCallParticipantMetadata);
+
+        $this->assertDatabaseMissing('call_participants', ['id' => $participant->id]);
+    }
+
+    public function test_purge_job_retains_participants_from_recently_ended_sessions(): void
+    {
+        $session = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter() - 1),
+        ]);
+        $participant = CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        dispatch(new PurgeCallParticipantMetadata);
+
+        $this->assertDatabaseHas('call_participants', ['id' => $participant->id]);
+    }
+
+    public function test_purge_job_retains_participants_from_active_sessions(): void
+    {
+        $session = CallSession::factory()->create();
+        $participant = CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        dispatch(new PurgeCallParticipantMetadata);
+
+        $this->assertDatabaseHas('call_participants', ['id' => $participant->id]);
+    }
+
+    public function test_purge_job_retains_call_session_record_after_purging_participants(): void
+    {
+        $session = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter() + 1),
+        ]);
+        CallParticipant::factory()->create(['call_session_id' => $session->id]);
+
+        dispatch(new PurgeCallParticipantMetadata);
+
+        $this->assertDatabaseHas('call_sessions', ['id' => $session->id]);
+    }
+}

--- a/tests/Unit/Turn/MeteredTurnProviderTest.php
+++ b/tests/Unit/Turn/MeteredTurnProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Turn;
+
+use App\Turn\MeteredTurnProvider;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class MeteredTurnProviderTest extends TestCase
+{
+    public function test_calls_correct_metered_endpoint(): void
+    {
+        Http::fake(['*.metered.ca/*' => Http::response([['urls' => 'stun:stun.example.com']], 200)]);
+
+        $provider = new MeteredTurnProvider(['domain' => 'myapp', 'api_key' => 'key123']);
+        $provider->getIceServers();
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'myapp.metered.ca'));
+    }
+
+    public function test_returns_formatted_ice_servers(): void
+    {
+        $servers = [
+            ['urls' => 'turn:relay.example.com', 'username' => 'u', 'credential' => 'p'],
+        ];
+        Http::fake(['*' => Http::response($servers, 200)]);
+
+        $provider = new MeteredTurnProvider(['domain' => 'myapp', 'api_key' => 'key123']);
+        $result = $provider->getIceServers();
+
+        $this->assertEquals($servers, $result);
+    }
+
+    public function test_throws_runtime_exception_on_http_error(): void
+    {
+        Http::fake(['*' => Http::response('error', 503)]);
+
+        $provider = new MeteredTurnProvider(['domain' => 'myapp', 'api_key' => 'key123']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('503');
+
+        $provider->getIceServers();
+    }
+}

--- a/tests/Unit/Turn/TurnManagerTest.php
+++ b/tests/Unit/Turn/TurnManagerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Turn;
+
+use App\Contracts\TurnProvider;
+use App\Turn\MeteredTurnProvider;
+use App\Turn\TurnManager;
+use App\Turn\XirsysTurnProvider;
+use Tests\TestCase;
+
+class TurnManagerTest extends TestCase
+{
+    public function test_default_driver_comes_from_config(): void
+    {
+        config(['turn.default' => 'metered']);
+
+        $manager = new TurnManager($this->app);
+
+        $this->assertEquals('metered', $manager->getDefaultDriver());
+    }
+
+    public function test_can_resolve_metered_driver(): void
+    {
+        config(['turn.drivers.metered' => ['api_key' => 'k', 'domain' => 'd']]);
+
+        $manager = new TurnManager($this->app);
+
+        $this->assertInstanceOf(MeteredTurnProvider::class, $manager->driver('metered'));
+    }
+
+    public function test_can_resolve_xirsys_driver(): void
+    {
+        config(['turn.drivers.xirsys' => ['api_key' => 'k', 'secret' => 's', 'channel' => 'c']]);
+
+        $manager = new TurnManager($this->app);
+
+        $this->assertInstanceOf(XirsysTurnProvider::class, $manager->driver('xirsys'));
+    }
+
+    public function test_can_switch_driver_at_runtime(): void
+    {
+        config([
+            'turn.default' => 'metered',
+            'turn.drivers.metered' => ['api_key' => 'k', 'domain' => 'd'],
+            'turn.drivers.xirsys' => ['api_key' => 'k', 'secret' => 's', 'channel' => 'c'],
+        ]);
+
+        $manager = new TurnManager($this->app);
+
+        $this->assertInstanceOf(TurnProvider::class, $manager->driver('xirsys'));
+        $this->assertInstanceOf(XirsysTurnProvider::class, $manager->driver('xirsys'));
+    }
+}

--- a/tests/Unit/Turn/XirsysTurnProviderTest.php
+++ b/tests/Unit/Turn/XirsysTurnProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Turn;
+
+use App\Turn\XirsysTurnProvider;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class XirsysTurnProviderTest extends TestCase
+{
+    public function test_calls_correct_xirsys_endpoint_with_basic_auth(): void
+    {
+        Http::fake(['*.xirsys.net/*' => Http::response(['v' => ['iceServers' => []]], 200)]);
+
+        $provider = new XirsysTurnProvider([
+            'api_key' => 'user',
+            'secret' => 'pass',
+            'channel' => 'flashview',
+        ]);
+        $provider->getIceServers();
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'xirsys.net/_turn/flashview')
+            && $request->hasHeader('Authorization')
+        );
+    }
+
+    public function test_returns_ice_servers_from_response(): void
+    {
+        $servers = [['urls' => 'turn:relay.example.com']];
+        Http::fake(['*' => Http::response(['v' => ['iceServers' => $servers]], 200)]);
+
+        $provider = new XirsysTurnProvider([
+            'api_key' => 'user',
+            'secret' => 'pass',
+            'channel' => 'flashview',
+        ]);
+
+        $this->assertEquals($servers, $provider->getIceServers());
+    }
+
+    public function test_throws_runtime_exception_on_http_error(): void
+    {
+        Http::fake(['*' => Http::response('error', 503)]);
+
+        $provider = new XirsysTurnProvider([
+            'api_key' => 'user',
+            'secret' => 'pass',
+            'channel' => 'flashview',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('503');
+
+        $provider->getIceServers();
+    }
+}

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -1,5 +1,6 @@
 import { generate } from 'random-words';
 import { p256 } from '@noble/curves/p256';
+import { ed25519 } from '@noble/curves/ed25519';
 
 const PBKDF2_ITERATIONS = 64000;
 const KEY_LENGTH_BITS = 256;
@@ -897,4 +898,62 @@ export async function decryptMessage(ciphertextString, passphrase) {
     );
 
     return new TextDecoder().decode(decrypted);
+}
+
+// ─── Call Session Auth ────────────────────────────────────────────────────────
+
+/**
+ * Derives a deterministic Ed25519 key pair from a password and PBKDF2 salt.
+ *
+ * SHA-256 is used here (not SHA-512 like other PBKDF2 derivations in this module)
+ * because Ed25519 private key seeds are 32 bytes, and deriving 256 bits with SHA-256
+ * is marginally faster. Security margin is equivalent — PBKDF2 iteration count
+ * (64,000) is the primary hardening factor, not the hash choice.
+ *
+ * @param {string} password
+ * @param {string} saltBase64 - base64-encoded 32-byte salt (from session's key_salt column)
+ * @returns {Promise<{ privateKey: Uint8Array, publicKey: Uint8Array, publicKeyBase64: string }>}
+ */
+export async function deriveCallKeyPair(password, saltBase64) {
+    const enc = new TextEncoder();
+    const keyMaterial = await globalThis.crypto.subtle.importKey(
+        'raw',
+        enc.encode(password),
+        'PBKDF2',
+        false,
+        ['deriveBits'],
+    );
+
+    const privateKeyBytes = new Uint8Array(
+        await globalThis.crypto.subtle.deriveBits(
+            {
+                name: 'PBKDF2',
+                salt: Uint8Array.from(atob(saltBase64), (c) => c.charCodeAt(0)),
+                iterations: 64000,
+                hash: 'SHA-256',
+            },
+            keyMaterial,
+            256,
+        ),
+    );
+
+    const publicKeyBytes = ed25519.getPublicKey(privateKeyBytes);
+
+    return {
+        privateKey: privateKeyBytes,
+        publicKey: publicKeyBytes,
+        publicKeyBase64: uint8ArrayToBase64(publicKeyBytes),
+    };
+}
+
+/**
+ * Signs a challenge hex string with an Ed25519 private key.
+ *
+ * @param {Uint8Array} privateKeyBytes
+ * @param {string} challengeHex - hex string from GET /call-sessions/{hash_id}/challenge
+ * @returns {string} base64-encoded 64-byte signature
+ */
+export function signCallChallenge(privateKeyBytes, challengeHex) {
+    const signature = ed25519.sign(hexToBuffer(challengeHex), privateKeyBytes);
+    return uint8ArrayToBase64(new Uint8Array(signature));
 }


### PR DESCRIPTION
## Summary

- Implements `CallSession` and `CallParticipant` models, migrations, factories, and supporting infrastructure for the ephemeral E2E encrypted call service
- Zero-knowledge Ed25519 challenge-response authentication — server stores only the public key, password never leaves the browser
- Multi-driver TURN architecture (`Turn::getIceServers()` via metered or Xirsys) with graceful fallback when TURN is unavailable
- Hash ID join codes via `HasHashId` trait — DB stores integer PKs `(1, 2, 3)`, join codes are Hashids-encoded opaque 10-char strings

## Changes

**Database:**
- `call_sessions` table — integer auto-increment PK (encoded as `hash_id`), Ed25519 public key, PBKDF2 salt, time window, max participants
- `call_participants` table — UUID PK, FK to `call_sessions`, encrypted IP address (`text` column for ciphertext length), join/leave timestamps

**Models & Factories:**
- `CallSession` with `HasHashId`, `active()`/`joinable()` scopes (`joinable()` stubbed for PIO-118), `isActive()`/`isFull()` helpers
- `CallParticipant` with `HasUuids`, `ip_address` encrypted cast, `session()` relationship

**TURN Driver Architecture:**
- `TurnProvider` contract → `MeteredTurnProvider` + `XirsysTurnProvider` → `TurnManager` (extends `Illuminate\Support\Manager`) → `TurnServiceProvider` → `Turn` facade
- `Turn::getIceServers()` or `Turn::driver('xirsys')->getIceServers()`

**API:**
- `GET /call-sessions/{hash_id}/challenge` — returns random hex challenge + PBKDF2 salt; challenge cached 60s
- `POST /call-sessions/{hash_id}/join` — verifies Ed25519 signature via `sodium_crypto_sign_verify_detached`, creates participant, returns ICE servers + `turn_available`
- Named rate limiters: `call-sessions-challenge` (20/min) and `call-sessions-join` (10/min), keyed on `IP|hash_id`
- CSRF exemption for `call-sessions/*`

**Crypto (`tools/flashview-crypto`):**
- `deriveCallKeyPair(password, saltBase64)` — PBKDF2-SHA-256 → 32-byte Ed25519 seed → key pair
- `signCallChallenge(privateKeyBytes, challengeHex)` — Ed25519 sign, returns base64 signature

**Retention & Compliance:**
- `PurgeCallParticipantMetadata` job — deletes participant PII after `config('secrets.prune_after')` days post-session-end; runs daily
- `legal:call-metadata {hash_id}` command — prints session + participant table with decrypted IP addresses

## Test plan

- [ ] `php artisan test tests/Feature/Call tests/Unit/Turn` — 43 tests, all pass
- [ ] `php artisan migrate:fresh` runs cleanly
- [ ] `php artisan legal:call-metadata {hash_id}` outputs session + participants table
- [ ] `GET /call-sessions/{hash_id}/challenge` returns `{ challenge, salt }` with 64-char hex challenge
- [ ] `POST /call-sessions/{hash_id}/join` with correct Ed25519 signature returns 200 with ICE servers
- [ ] Wrong signature → 401; missing challenge → 422; invalid hash_id → 404
- [ ] TURN provider failure returns 200 with `ice_servers: []` and `turn_available: false` (not a 500)
- [ ] Verify `ip_address` stored encrypted in DB, readable via model

## Deployment notes

- Set `HASH_ID_SALT_CALL_SESSION` to a strong random value in production `.env` before deploying — if left empty, join codes are predictable
- Set `TURN_METERED_API_KEY` and `TURN_METERED_DOMAIN` (or configure Xirsys via `TURN_DRIVER=xirsys`)

## Regression risks

Low — all changes are additive. No existing routes, middleware, or services were modified.

## Downstream coordination

- **PIO-114 (WebRTC Signaling):** Must not create a second join endpoint — use `POST /call-sessions/{hash_id}/join` as the canonical endpoint
- **PIO-116 (Browser UI):** `deriveCallKeyPair` and `signCallChallenge` are available in `@pioneer-dynamics/flashview-crypto` — import and re-export from `resources/js/encryption.js` when building the call UI
- **PIO-117 (CLI):** Same crypto functions available — re-export from `tools/flashview-cli/src/crypto.js` when building the CLI call command
- **PIO-118 (Time-gate & max-participant enforcement):** `joinable()` scope is stubbed as `$query->active()` with `// TODO(PIO-118)` — that ticket implements pessimistic locking