### PR TITLE
PIO-114: WebRTC Signaling for N:N Calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,3 +494,7 @@ Rules:
 - `crypto.subtle`, `PBKDF2`, `AES-GCM`, and key derivation logic must ONLY appear in `tools/flashview-crypto/src/index.js`
 - When adding a new crypto operation (e.g., `encryptBuffer`, `decryptBuffer`), add it to flashview-crypto first, then import and use it in both wrappers
 - Thin wrappers in `encryption.js` and `crypto.js` may add platform-specific helpers (e.g., reading a `File` object for browser, reading from disk for CLI) but must delegate all crypto to the shared package
+
+## Issue Tracking
+
+This project uses **Linear** (not Jira) for issue tracking. Ticket IDs follow the format `PIO-###`. Use the `mcp__linear-server__*` tools to look up, create, and update issues — never the Atlassian/Jira tools.

--- a/app/Http/Controllers/Api/CallSignalController.php
+++ b/app/Http/Controllers/Api/CallSignalController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Call\CreateCallSignalRequest;
+use App\Http\Requests\Call\ListCallSignalsRequest;
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use App\Models\CallSignal;
+use Illuminate\Http\JsonResponse;
+
+class CallSignalController extends Controller
+{
+    public function participants(CallSession $callSession): JsonResponse
+    {
+        if (! $callSession->isActive()) {
+            return response()->json(['message' => 'Call session has ended.'], 404);
+        }
+
+        $participants = $callSession->participants()
+            ->whereNull('left_at')
+            ->get(['id', 'joined_at', 'public_key']);
+
+        return response()->json(['participants' => $participants]);
+    }
+
+    public function store(CreateCallSignalRequest $request, CallSession $callSession): JsonResponse
+    {
+        if (! $callSession->isActive()) {
+            return response()->json(['message' => 'Call session has ended.'], 404);
+        }
+
+        $fromExists = CallParticipant::where('id', $request->from_participant_id)
+            ->where('call_session_id', $callSession->id)
+            ->exists();
+
+        $toExists = CallParticipant::where('id', $request->to_participant_id)
+            ->where('call_session_id', $callSession->id)
+            ->exists();
+
+        if (! $fromExists || ! $toExists) {
+            return response()->json(['message' => 'Invalid participant ID for this session.'], 422);
+        }
+
+        $signal = CallSignal::create([
+            'call_session_id' => $callSession->id,
+            'from_participant_id' => $request->from_participant_id,
+            'to_participant_id' => $request->to_participant_id,
+            'type' => $request->type,
+            'payload' => $request->payload,
+        ]);
+
+        return response()->json(['signal_id' => $signal->id], 201);
+    }
+
+    public function index(ListCallSignalsRequest $request, CallSession $callSession): JsonResponse
+    {
+        if (! $callSession->isActive()) {
+            return response()->json(['message' => 'Call session has ended.'], 404);
+        }
+
+        $participantExists = CallParticipant::where('id', $request->participant_id)
+            ->where('call_session_id', $callSession->id)
+            ->exists();
+
+        if (! $participantExists) {
+            return response()->json(['message' => 'Invalid participant ID for this session.'], 422);
+        }
+
+        $signals = CallSignal::where('call_session_id', $callSession->id)
+            ->where('to_participant_id', $request->participant_id)
+            ->where('id', '>', (int) ($request->after ?? 0))
+            ->orderBy('id')
+            ->get(['id', 'from_participant_id', 'type', 'payload']);
+
+        return response()->json(['signals' => $signals]);
+    }
+}

--- a/app/Http/Requests/Call/CreateCallSignalRequest.php
+++ b/app/Http/Requests/Call/CreateCallSignalRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Call;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateCallSignalRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'from_participant_id' => ['required', 'uuid'],
+            'to_participant_id' => ['required', 'uuid', 'different:from_participant_id'],
+            'type' => ['required', 'string', 'in:offer,answer,ice-candidate,key-exchange'],
+            'payload' => ['required', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Call/ListCallSignalsRequest.php
+++ b/app/Http/Requests/Call/ListCallSignalsRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Call;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListCallSignalsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'participant_id' => ['required', 'uuid'],
+            'after' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Jobs/ClearExpiredCallSessions.php
+++ b/app/Jobs/ClearExpiredCallSessions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\CallSession;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ClearExpiredCallSessions implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        CallSession::where('ends_at', '<', now()->subDays(config('secrets.prune_after')))
+            ->each(fn (CallSession $session) => $session->delete());
+    }
+}

--- a/app/Models/CallSignal.php
+++ b/app/Models/CallSignal.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\CallSignalFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CallSignal extends Model
+{
+    /** @use HasFactory<CallSignalFactory> */
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'call_session_id',
+        'from_participant_id',
+        'to_participant_id',
+        'type',
+        'payload',
+    ];
+
+    protected function casts(): array
+    {
+        return ['payload' => 'array'];
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(CallSession::class, 'call_session_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -125,6 +125,10 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for('call-sessions-join', function (Request $request) {
             return Limit::perMinute(10)->by($request->ip().'|'.$request->route('callSession'));
         });
+
+        RateLimiter::for('call-signal-store', fn (Request $request) => Limit::perMinute(120)->by($request->ip()));
+
+        RateLimiter::for('call-signal-poll', fn (Request $request) => Limit::perMinute(300)->by($request->ip()));
     }
 
     private function planThrottleLimit(User $user): Limit

--- a/database/factories/CallSignalFactory.php
+++ b/database/factories/CallSignalFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use App\Models\CallSignal;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CallSignal>
+ */
+class CallSignalFactory extends Factory
+{
+    public function definition(): array
+    {
+        $session = CallSession::factory()->create();
+        $from = CallParticipant::factory()->for($session, 'session')->create();
+        $to = CallParticipant::factory()->for($session, 'session')->create();
+
+        return [
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => $this->faker->randomElement(['offer', 'answer', 'ice-candidate', 'key-exchange']),
+            'payload' => ['sdp' => $this->faker->text(100)],
+        ];
+    }
+}

--- a/database/migrations/2026_06_14_071643_create_call_signals_table.php
+++ b/database/migrations/2026_06_14_071643_create_call_signals_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('call_signals', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('call_session_id')->constrained()->cascadeOnDelete();
+            $table->uuid('from_participant_id');
+            $table->uuid('to_participant_id');
+            $table->enum('type', ['offer', 'answer', 'ice-candidate', 'key-exchange']);
+            $table->longText('payload'); // longText chosen over json — SDP blobs can exceed MySQL's 65 535-byte json column limit
+            $table->timestamp('created_at')->useCurrent();
+
+            // Efficient poll: all signals in a session addressed to me, in order
+            $table->index(['call_session_id', 'to_participant_id', 'id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('call_signals');
+    }
+};

--- a/database/migrations/2026_06_14_071643_create_call_signals_table.php
+++ b/database/migrations/2026_06_14_071643_create_call_signals_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->timestamp('created_at')->useCurrent();
 
             // Efficient poll: all signals in a session addressed to me, in order
-            $table->index(['call_session_id', 'to_participant_id', 'id']);
+            $table->index(['call_session_id', 'to_participant_id', 'id'], 'idx_call_signals_session_to_id');
         });
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\CallSignalController;
 use App\Http\Controllers\Api\ConfigController;
 use App\Http\Controllers\Api\FileUploadController;
 use App\Http\Controllers\Api\PipeController;
@@ -7,6 +8,7 @@ use App\Http\Controllers\Api\PipePairingController;
 use App\Http\Controllers\Api\PipeSignalController;
 use App\Http\Controllers\Api\SecretController;
 use App\Http\Controllers\Api\WebhookController;
+use App\Http\Controllers\CallSessionController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -73,5 +75,21 @@ Route::prefix('v1')->as('api.v1.')->group(function () {
         Route::delete('pipe/{sessionId}', [PipeController::class, 'destroy'])->name('pipe.destroy');
         Route::post('pipe/{sessionId}/signal', [PipeSignalController::class, 'store'])->name('pipe.signal.store');
         Route::get('pipe/{sessionId}/signal', [PipeSignalController::class, 'index'])->name('pipe.signal.index');
+    });
+
+    // Call routes — no auth required; Ed25519 challenge-response gates join, participant UUID gates signaling
+    Route::prefix('calls')->name('calls.')->group(function () {
+        Route::post('{callSession}/join', [CallSessionController::class, 'join'])
+            ->name('join')
+            ->middleware('throttle:call-sessions-join');
+        Route::get('{callSession}/participants', [CallSignalController::class, 'participants'])
+            ->name('participants')
+            ->middleware('throttle:call-signal-poll');
+        Route::post('{callSession}/signal', [CallSignalController::class, 'store'])
+            ->name('signal.store')
+            ->middleware('throttle:call-signal-store');
+        Route::get('{callSession}/signal', [CallSignalController::class, 'index'])
+            ->name('signal.index')
+            ->middleware('throttle:call-signal-poll');
     });
 });

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\ClearExpiredCallSessions;
 use App\Jobs\ClearExpiredLockers;
 use App\Jobs\ClearExpiredPipeDevices;
 use App\Jobs\ClearExpiredPipeSessions;
@@ -11,6 +12,7 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::job(new ClearExpiredSecrets)->daily();
 Schedule::job(new ClearExpiredLockers)->hourly();
 Schedule::job(new PurgeMetadataForExpiredMessages)->daily();
+Schedule::job(new ClearExpiredCallSessions)->daily();
 Schedule::job(new PurgeCallParticipantMetadata)->daily();
 Schedule::job(new ClearExpiredPipeSessions)->daily();
 Schedule::job(new ClearExpiredPipeDevices)->daily();

--- a/tests/Feature/Call/CallSignalTest.php
+++ b/tests/Feature/Call/CallSignalTest.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use App\Models\CallSignal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CallSignalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function activeSession(): CallSession
+    {
+        return CallSession::factory()->create();
+    }
+
+    private function inactiveSession(): CallSession
+    {
+        return CallSession::factory()->inactive()->create();
+    }
+
+    private function participantIn(CallSession $session): CallParticipant
+    {
+        return CallParticipant::factory()->for($session, 'session')->create();
+    }
+
+    // ─── participants ──────────────────────────────────────────────────────────
+
+    public function test_participants_returns_active_participants(): void
+    {
+        $session = $this->activeSession();
+        $participant = $this->participantIn($session);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/participants");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'participants')
+            ->assertJsonPath('participants.0.id', $participant->id);
+    }
+
+    public function test_participants_does_not_include_ip_address(): void
+    {
+        $session = $this->activeSession();
+        $this->participantIn($session);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/participants");
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('ip_address', $response->json('participants.0'));
+    }
+
+    public function test_participants_excludes_participants_who_have_left(): void
+    {
+        $session = $this->activeSession();
+        CallParticipant::factory()->for($session, 'session')->create(['left_at' => now()]);
+        $active = $this->participantIn($session);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/participants");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'participants')
+            ->assertJsonPath('participants.0.id', $active->id);
+    }
+
+    public function test_participants_includes_expected_fields(): void
+    {
+        $session = $this->activeSession();
+        $this->participantIn($session);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/participants");
+
+        $response->assertOk()
+            ->assertJsonStructure(['participants' => [['id', 'joined_at', 'public_key']]]);
+    }
+
+    public function test_participants_returns_404_for_inactive_session(): void
+    {
+        $session = $this->inactiveSession();
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/participants");
+
+        $response->assertNotFound();
+    }
+
+    // ─── store (POST signal) ───────────────────────────────────────────────────
+
+    public function test_store_creates_signal_and_returns_201(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertCreated()->assertJsonStructure(['signal_id']);
+        $this->assertDatabaseHas('call_signals', [
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+        ]);
+    }
+
+    public function test_store_returns_422_when_from_participant_not_in_session(): void
+    {
+        $session = $this->activeSession();
+        $to = $this->participantIn($session);
+        $strangerUuid = Str::uuid()->toString();
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $strangerUuid,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertUnprocessable()->assertJsonPath('message', 'Invalid participant ID for this session.');
+    }
+
+    public function test_store_returns_422_when_to_participant_not_in_session(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $strangerUuid = Str::uuid()->toString();
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $strangerUuid,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertUnprocessable()->assertJsonPath('message', 'Invalid participant ID for this session.');
+    }
+
+    public function test_store_returns_422_when_self_signal(): void
+    {
+        $session = $this->activeSession();
+        $participant = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $participant->id,
+            'to_participant_id' => $participant->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertUnprocessable()->assertJsonValidationErrors(['to_participant_id']);
+    }
+
+    public function test_store_returns_422_for_invalid_signal_type(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'unknown-type',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertUnprocessable()->assertJsonValidationErrors(['type']);
+    }
+
+    public function test_store_returns_422_when_payload_is_missing(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+        ]);
+
+        $response->assertUnprocessable()->assertJsonValidationErrors(['payload']);
+    }
+
+    public function test_store_returns_404_for_inactive_session(): void
+    {
+        $session = $this->inactiveSession();
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => Str::uuid()->toString(),
+            'to_participant_id' => Str::uuid()->toString(),
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_store_accepts_key_exchange_signal_type(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/signal", [
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'key-exchange',
+            'payload' => ['wrapped_key' => base64_encode(random_bytes(32))],
+        ]);
+
+        $response->assertCreated();
+    }
+
+    // ─── index (GET signal) ────────────────────────────────────────────────────
+
+    public function test_index_returns_signals_addressed_to_participant(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$to->id}");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'signals')
+            ->assertJsonPath('signals.0.from_participant_id', $from->id)
+            ->assertJsonPath('signals.0.type', 'offer');
+    }
+
+    public function test_index_does_not_return_signals_addressed_to_other_participants(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+        $other = $this->participantIn($session);
+
+        CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $other->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$to->id}");
+
+        $response->assertOk()->assertJsonCount(0, 'signals');
+    }
+
+    public function test_index_respects_after_cursor(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        $signal1 = CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'answer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$to->id}&after={$signal1->id}");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'signals')
+            ->assertJsonPath('signals.0.type', 'answer');
+    }
+
+    public function test_index_returns_empty_array_when_no_signals(): void
+    {
+        $session = $this->activeSession();
+        $participant = $this->participantIn($session);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$participant->id}");
+
+        $response->assertOk()->assertJsonCount(0, 'signals');
+    }
+
+    public function test_index_returns_422_when_participant_not_in_session(): void
+    {
+        $session = $this->activeSession();
+        $strangerUuid = Str::uuid()->toString();
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$strangerUuid}");
+
+        $response->assertUnprocessable()->assertJsonPath('message', 'Invalid participant ID for this session.');
+    }
+
+    public function test_index_returns_404_for_inactive_session(): void
+    {
+        $session = $this->inactiveSession();
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id=".Str::uuid()->toString());
+
+        $response->assertNotFound();
+    }
+
+    public function test_index_includes_from_participant_id_in_response(): void
+    {
+        $session = $this->activeSession();
+        $from = $this->participantIn($session);
+        $to = $this->participantIn($session);
+
+        CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        $response = $this->getJson("/api/v1/calls/{$session->hash_id}/signal?participant_id={$to->id}");
+
+        $response->assertOk()
+            ->assertJsonStructure(['signals' => [['id', 'from_participant_id', 'type', 'payload']]]);
+    }
+
+    // ─── join via API route ────────────────────────────────────────────────────
+
+    public function test_join_via_api_route_returns_correct_response_structure(): void
+    {
+        $keyPair = sodium_crypto_sign_keypair();
+        $privateKey = sodium_crypto_sign_secretkey($keyPair);
+        $publicKey = sodium_crypto_sign_publickey($keyPair);
+
+        $session = CallSession::factory()->create([
+            'public_key' => base64_encode($publicKey),
+        ]);
+
+        $challenge = bin2hex(random_bytes(32));
+        cache()->put("call-challenge:{$session->id}", $challenge, 60);
+
+        $signature = base64_encode(sodium_crypto_sign_detached(hex2bin($challenge), $privateKey));
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/join", [
+            'signature' => $signature,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'session' => ['bridge_number', 'starts_at', 'ends_at', 'max_participants', 'current_participant_count'],
+                'participant_id',
+                'ice_servers',
+                'turn_available',
+            ]);
+    }
+}

--- a/tests/Feature/Call/ClearExpiredCallSessionsTest.php
+++ b/tests/Feature/Call/ClearExpiredCallSessionsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Jobs\ClearExpiredCallSessions;
+use App\Models\CallParticipant;
+use App\Models\CallSession;
+use App\Models\CallSignal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClearExpiredCallSessionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private int $pruneAfter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pruneAfter = config('secrets.prune_after');
+    }
+
+    public function test_deletes_sessions_past_prune_window(): void
+    {
+        $old = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter + 1),
+        ]);
+
+        (new ClearExpiredCallSessions)->handle();
+
+        $this->assertDatabaseMissing('call_sessions', ['id' => $old->id]);
+    }
+
+    public function test_preserves_sessions_within_prune_window(): void
+    {
+        $recent = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter - 1),
+        ]);
+
+        (new ClearExpiredCallSessions)->handle();
+
+        $this->assertDatabaseHas('call_sessions', ['id' => $recent->id]);
+    }
+
+    public function test_preserves_active_sessions(): void
+    {
+        $active = CallSession::factory()->create();
+
+        (new ClearExpiredCallSessions)->handle();
+
+        $this->assertDatabaseHas('call_sessions', ['id' => $active->id]);
+    }
+
+    public function test_cascade_deletes_participants_when_session_is_pruned(): void
+    {
+        $session = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter + 1),
+        ]);
+        $participant = CallParticipant::factory()->for($session, 'session')->create();
+
+        (new ClearExpiredCallSessions)->handle();
+
+        $this->assertDatabaseMissing('call_participants', ['id' => $participant->id]);
+    }
+
+    public function test_cascade_deletes_signals_when_session_is_pruned(): void
+    {
+        $session = CallSession::factory()->create([
+            'ends_at' => now()->subDays($this->pruneAfter + 1),
+        ]);
+        $from = CallParticipant::factory()->for($session, 'session')->create();
+        $to = CallParticipant::factory()->for($session, 'session')->create();
+
+        $signal = CallSignal::create([
+            'call_session_id' => $session->id,
+            'from_participant_id' => $from->id,
+            'to_participant_id' => $to->id,
+            'type' => 'offer',
+            'payload' => ['sdp' => 'v=0'],
+        ]);
+
+        (new ClearExpiredCallSessions)->handle();
+
+        $this->assertDatabaseMissing('call_signals', ['id' => $signal->id]);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `call_signals` table with composite index, `CallSignal` model, and factory
- Adds 4 new API endpoints under `/api/v1/calls/{bridgeNumber}/` (no Sanctum — participant UUID from join acts as identity token):
  - `POST /join` — reuses existing `CallSessionController::join()`, returns ICE server credentials
  - `GET /participants` — lists active participants; required for N:N mesh bootstrap
  - `POST /signal` — routes a WebRTC signal (`offer`, `answer`, `ice-candidate`, `key-exchange`) to a specific participant UUID
  - `GET /signal?participant_id=X&after=Y` — cursor-based poll for signals addressed to me
- Adds `call-signal-store` (120/min) and `call-signal-poll` (300/min) named rate limiters
- Adds `ClearExpiredCallSessions` daily job — prunes sessions (and cascade-deletes participants + signals) after `prune_after` days, closing the data retention gap

## Key decisions

- `key-exchange` signal type included now to support PIO-115 (E2E Group Key Exchange) without a future schema migration
- `longText` for payload (not `json`) — SDP blobs can exceed MySQL's 65,535-byte json column limit
- Composite index named explicitly to stay well under MySQL's 64-char identifier limit
- No FK constraints on participant UUID columns in `call_signals` — avoids blocking participant eviction in future tickets

## Regression risks

Low — entirely additive. Shared `throttle:call-sessions-join` bucket between web and API join routes is intentional (both consume from the same 10/min limiter per IP+session).

## Test plan

- [ ] 21 PHPUnit feature tests in `tests/Feature/Call/CallSignalTest.php` — all pass
- [ ] 5 PHPUnit feature tests in `tests/Feature/Call/ClearExpiredCallSessionsTest.php` — all pass
- [ ] No UI tests required (browser UI is PIO-116)
- [ ] Manual API test steps in `.claude.d/PIO-114.test.md`