### PR TITLE
PIO-115: E2E Group Key Exchange — crypto primitives & join endpoint

### DIFF
--- a/app/Http/Controllers/CallSessionController.php
+++ b/app/Http/Controllers/CallSessionController.php
@@ -45,6 +45,7 @@ class CallSessionController extends Controller
         $participant = $callSession->participants()->create([
             'joined_at' => now(),
             'ip_address' => $request->ip(),
+            'public_key' => $request->input('public_key'),
         ]);
 
         $remainingSeconds = max(60, (int) now()->diffInSeconds($callSession->ends_at, absolute: true));

--- a/app/Http/Requests/Call/JoinCallSessionRequest.php
+++ b/app/Http/Requests/Call/JoinCallSessionRequest.php
@@ -15,6 +15,7 @@ class JoinCallSessionRequest extends FormRequest
     {
         return [
             'signature' => ['required', 'string'],
+            'public_key' => ['nullable', 'string', 'max:512'],
         ];
     }
 }

--- a/resources/js/encryption.js
+++ b/resources/js/encryption.js
@@ -7,6 +7,8 @@ import {
     deriveAuthKey, computeVerifier, generateChallenge, deriveUpdateToken,
     deriveSigningKeypair, signChallenge,
     deriveKeyFromFile, combineLockerKeyMaterials,
+    generateCallEphemeralKeypair, generateCallSessionAesKey,
+    wrapCallSessionKey, unwrapCallSessionKey,
 } from '@pioneer-dynamics/flashview-crypto';
 export { LockerBlobVersionError, LockerDecryptionError } from '@pioneer-dynamics/flashview-crypto';
 
@@ -132,5 +134,21 @@ export class encryption {
 
     async combineLockerKeyMaterials(materials) {
         return combineLockerKeyMaterials(materials);
+    }
+
+    async generateCallEphemeralKeypair() {
+        return generateCallEphemeralKeypair();
+    }
+
+    generateCallSessionAesKey() {
+        return generateCallSessionAesKey();
+    }
+
+    async wrapCallSessionKey(sessionKeyBase64, peerPublicKeyBase64, ownPrivateKeyBase64) {
+        return wrapCallSessionKey(sessionKeyBase64, peerPublicKeyBase64, ownPrivateKeyBase64);
+    }
+
+    async unwrapCallSessionKey(wrappedKeyBase64, ownPrivateKeyBase64, peerPublicKeyBase64) {
+        return unwrapCallSessionKey(wrappedKeyBase64, ownPrivateKeyBase64, peerPublicKeyBase64);
     }
 }

--- a/tests/Feature/Call/JoinCallSessionTest.php
+++ b/tests/Feature/Call/JoinCallSessionTest.php
@@ -181,4 +181,47 @@ class JoinCallSessionTest extends TestCase
         $this->assertNotEquals((string) $session->id, $bridgeNumber);
         $this->assertEquals($session->hash_id, $bridgeNumber);
     }
+
+    public function test_join_stores_public_key_when_provided(): void
+    {
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+        $signature = $this->signChallenge($privateKey, $challenge);
+        // Synthetic placeholder — not a real P-256 JWK; tests DB persistence only
+        $publicKey = base64_encode(random_bytes(65));
+
+        $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $signature,
+            'public_key' => $publicKey,
+        ])->assertOk();
+
+        $this->assertDatabaseHas('call_participants', [
+            'call_session_id' => $session->id,
+            'public_key' => $publicKey,
+        ]);
+    }
+
+    public function test_join_succeeds_when_public_key_is_omitted(): void
+    {
+        [$privateKey, , $session] = $this->generateKeyPairAndSession();
+        $challenge = $this->fetchChallenge($session);
+        $signature = $this->signChallenge($privateKey, $challenge);
+
+        $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => $signature,
+        ])->assertOk();
+
+        $participant = $session->fresh()->participants->first();
+        $this->assertNull($participant->public_key);
+    }
+
+    public function test_join_rejects_oversized_public_key(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $this->postJson("/call-sessions/{$session->hash_id}/join", [
+            'signature' => base64_encode(random_bytes(64)),
+            'public_key' => str_repeat('A', 513),
+        ])->assertUnprocessable()->assertJsonValidationErrors(['public_key']);
+    }
 }

--- a/tools/flashview-cli/package-lock.json
+++ b/tools/flashview-cli/package-lock.json
@@ -694,10 +694,11 @@
             }
         },
         "node_modules/@pioneer-dynamics/flashview-crypto": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@pioneer-dynamics/flashview-crypto/-/flashview-crypto-2.0.0.tgz",
-            "integrity": "sha512-9iS5R+V4Lx1XO6XGj8G8P15748fHAw4DQ6XpVxyJ5spLvuODqawmiLAJWhxR1V9sqOHRzwarN3Ze6LjcsJfZiw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@pioneer-dynamics/flashview-crypto/-/flashview-crypto-2.2.0.tgz",
+            "integrity": "sha512-dwbbZHXODWUx/kcfsrdZ+om1QSM+sfDEx6kGacMY0nnRXPv+0fvzCvluqRJTnLj6Jls9TxjEEamiiDfoxKcdCQ==",
             "dependencies": {
+                "@noble/curves": "^1.9.7",
                 "random-words": "^2.0.0"
             },
             "engines": {

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -957,3 +957,161 @@ export function signCallChallenge(privateKeyBytes, challengeHex) {
     const signature = ed25519.sign(hexToBuffer(challengeHex), privateKeyBytes);
     return uint8ArrayToBase64(new Uint8Array(signature));
 }
+
+// ─── Call Key Exchange (E2E) ──────────────────────────────────────────────────
+
+const CALL_KEY_EXCHANGE_HKDF_SALT = new TextEncoder().encode('flashview-call-key-exchange-v1');
+
+/**
+ * Generate an ephemeral P-256 ECDH key pair for call E2E key exchange.
+ * Each participant generates a fresh pair on join; the private key never leaves the browser.
+ *
+ * @returns {Promise<{ publicKeyBase64: string, privateKeyBase64: string }>} JWK-format, base64-encoded
+ */
+export async function generateCallEphemeralKeypair() {
+    const keypair = await globalThis.crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' },
+        true,
+        ['deriveBits'],
+    );
+
+    const [publicJwk, privateJwk] = await Promise.all([
+        globalThis.crypto.subtle.exportKey('jwk', keypair.publicKey),
+        globalThis.crypto.subtle.exportKey('jwk', keypair.privateKey),
+    ]);
+
+    return {
+        publicKeyBase64: btoa(JSON.stringify(publicJwk)),
+        privateKeyBase64: btoa(JSON.stringify(privateJwk)),
+    };
+}
+
+/**
+ * Generate a random 256-bit AES-GCM session key for call E2E encryption.
+ *
+ * @returns {string} base64-encoded 32-byte key
+ */
+export function generateCallSessionAesKey() {
+    const key = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(key);
+    return uint8ArrayToBase64(key);
+}
+
+/**
+ * ECIES: wrap an AES session key for a specific call participant.
+ *
+ * Algorithm:
+ *   1. sharedSecret = ECDH(ownPrivateKey, peerPublicKey)
+ *   2. wrappingKey = HKDF-SHA-256(ikm=sharedSecret, salt='flashview-call-key-exchange-v1', info='wrapCallSessionKey', length=32)
+ *   3. iv = 12 random bytes
+ *   4. ciphertext+tag = AES-256-GCM(plaintext=sessionKeyBytes, key=wrappingKey, iv, aad=none)
+ *   5. blob = base64( iv[12] || ciphertext || tag[16] )
+ *
+ * @param {string} sessionKeyBase64 - 32-byte AES session key, base64-encoded
+ * @param {string} peerPublicKeyBase64 - recipient's ECDH public key, JWK base64
+ * @param {string} ownPrivateKeyBase64 - sender's ECDH private key, JWK base64
+ * @returns {Promise<string>} base64-encoded ECIES blob
+ */
+export async function wrapCallSessionKey(sessionKeyBase64, peerPublicKeyBase64, ownPrivateKeyBase64) {
+    const peerPublicKey = await globalThis.crypto.subtle.importKey(
+        'jwk',
+        JSON.parse(atob(peerPublicKeyBase64)),
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        [],
+    );
+    const ownPrivateKey = await globalThis.crypto.subtle.importKey(
+        'jwk',
+        JSON.parse(atob(ownPrivateKeyBase64)),
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        ['deriveBits'],
+    );
+
+    const sharedBits = await globalThis.crypto.subtle.deriveBits(
+        { name: 'ECDH', public: peerPublicKey },
+        ownPrivateKey,
+        256,
+    );
+
+    const sharedKey = await globalThis.crypto.subtle.importKey('raw', sharedBits, 'HKDF', false, ['deriveKey']);
+    const aesKey = await globalThis.crypto.subtle.deriveKey(
+        {
+            name: 'HKDF',
+            hash: 'SHA-256',
+            salt: CALL_KEY_EXCHANGE_HKDF_SALT,
+            info: new TextEncoder().encode('wrapCallSessionKey'),
+        },
+        sharedKey,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt'],
+    );
+
+    const iv = new Uint8Array(12);
+    globalThis.crypto.getRandomValues(iv);
+
+    const keyBytes = base64ToUint8Array(sessionKeyBase64);
+    const ciphertext = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, keyBytes);
+
+    const blob = new Uint8Array(12 + ciphertext.byteLength);
+    blob.set(iv);
+    blob.set(new Uint8Array(ciphertext), 12);
+    return uint8ArrayToBase64(blob);
+}
+
+/**
+ * ECIES: unwrap an AES session key received via the signaling channel.
+ *
+ * ECDH is symmetric: ECDH(A_priv, B_pub) == ECDH(B_priv, A_pub).
+ * The argument order is swapped vs wrapCallSessionKey — pass the recipient's
+ * private key and the sender's public key.
+ *
+ * @param {string} wrappedKeyBase64 - base64-encoded blob (iv[12] + ciphertext + tag[16])
+ * @param {string} ownPrivateKeyBase64 - recipient's ECDH private key, JWK base64
+ * @param {string} peerPublicKeyBase64 - sender's ECDH public key, JWK base64
+ * @returns {Promise<string>} session key as base64
+ */
+export async function unwrapCallSessionKey(wrappedKeyBase64, ownPrivateKeyBase64, peerPublicKeyBase64) {
+    const peerPublicKey = await globalThis.crypto.subtle.importKey(
+        'jwk',
+        JSON.parse(atob(peerPublicKeyBase64)),
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        [],
+    );
+    const ownPrivateKey = await globalThis.crypto.subtle.importKey(
+        'jwk',
+        JSON.parse(atob(ownPrivateKeyBase64)),
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        ['deriveBits'],
+    );
+
+    const sharedBits = await globalThis.crypto.subtle.deriveBits(
+        { name: 'ECDH', public: peerPublicKey },
+        ownPrivateKey,
+        256,
+    );
+
+    const sharedKey = await globalThis.crypto.subtle.importKey('raw', sharedBits, 'HKDF', false, ['deriveKey']);
+    const aesKey = await globalThis.crypto.subtle.deriveKey(
+        {
+            name: 'HKDF',
+            hash: 'SHA-256',
+            salt: CALL_KEY_EXCHANGE_HKDF_SALT,
+            info: new TextEncoder().encode('wrapCallSessionKey'),
+        },
+        sharedKey,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt'],
+    );
+
+    const blob = base64ToUint8Array(wrappedKeyBase64);
+    const iv = blob.slice(0, 12);
+    const ciphertext = blob.slice(12);
+
+    const decrypted = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, aesKey, ciphertext);
+    return uint8ArrayToBase64(new Uint8Array(decrypted));
+}

--- a/tools/flashview-crypto/tests/crypto.test.js
+++ b/tools/flashview-crypto/tests/crypto.test.js
@@ -7,6 +7,9 @@ import {
     generateFileKey, wrapFileKey, unwrapFileKey,
     deriveSigningKeypair, signChallenge,
     deriveKeyFromFile, combineLockerKeyMaterials,
+    encryptKeyForDevice, decryptKeyFromDevice,
+    generateCallEphemeralKeypair, generateCallSessionAesKey,
+    wrapCallSessionKey, unwrapCallSessionKey,
 } from '../src/index.js';
 
 // Known vectors generated from the pre-migration CLI implementation (tools/flashview-cli/src/crypto.js)
@@ -616,5 +619,123 @@ describe('combineLockerKeyMaterials', () => {
     it('throws on null or undefined', async () => {
         await assert.rejects(() => combineLockerKeyMaterials(null), Error);
         await assert.rejects(() => combineLockerKeyMaterials(undefined), Error);
+    });
+});
+
+// ─── Call Key Exchange (E2E) ──────────────────────────────────────────────────
+
+describe('generateCallEphemeralKeypair', () => {
+    it('returns publicKeyBase64 and privateKeyBase64 strings', async () => {
+        const keypair = await generateCallEphemeralKeypair();
+        assert.equal(typeof keypair.publicKeyBase64, 'string', 'publicKeyBase64 should be a string');
+        assert.equal(typeof keypair.privateKeyBase64, 'string', 'privateKeyBase64 should be a string');
+        assert.ok(keypair.publicKeyBase64.length > 0, 'publicKeyBase64 should be non-empty');
+        assert.ok(keypair.privateKeyBase64.length > 0, 'privateKeyBase64 should be non-empty');
+    });
+
+    it('publicKeyBase64 decodes to a valid P-256 JWK without d field (public only)', async () => {
+        const { publicKeyBase64 } = await generateCallEphemeralKeypair();
+        const jwk = JSON.parse(atob(publicKeyBase64));
+        assert.equal(jwk.kty, 'EC', 'JWK kty should be EC');
+        assert.equal(jwk.crv, 'P-256', 'JWK crv should be P-256');
+        assert.ok(jwk.x, 'JWK should have x coordinate');
+        assert.ok(jwk.y, 'JWK should have y coordinate');
+        assert.equal(jwk.d, undefined, 'Public JWK must not contain d (private scalar)');
+    });
+
+    it('generates unique keypairs on each call', async () => {
+        const a = await generateCallEphemeralKeypair();
+        const b = await generateCallEphemeralKeypair();
+        assert.notEqual(a.publicKeyBase64, b.publicKeyBase64, 'Two keypairs should have different public keys');
+        assert.notEqual(a.privateKeyBase64, b.privateKeyBase64, 'Two keypairs should have different private keys');
+    });
+});
+
+describe('generateCallSessionAesKey', () => {
+    it('returns a base64 string that decodes to 32 bytes', () => {
+        const key = generateCallSessionAesKey();
+        assert.equal(typeof key, 'string', 'Should return a string');
+        const bytes = Uint8Array.from(atob(key), c => c.charCodeAt(0));
+        assert.equal(bytes.length, 32, 'Decoded key should be exactly 32 bytes');
+    });
+
+    it('generates unique keys on each call', () => {
+        const a = generateCallSessionAesKey();
+        const b = generateCallSessionAesKey();
+        assert.notEqual(a, b, 'Two generated keys should differ');
+    });
+});
+
+describe('wrapCallSessionKey + unwrapCallSessionKey', () => {
+    it('roundtrips a session key between two participants', async () => {
+        const senderKeypair = await generateCallEphemeralKeypair();
+        const recipientKeypair = await generateCallEphemeralKeypair();
+        const sessionKey = generateCallSessionAesKey();
+
+        const wrapped = await wrapCallSessionKey(
+            sessionKey,
+            recipientKeypair.publicKeyBase64,
+            senderKeypair.privateKeyBase64,
+        );
+
+        const unwrapped = await unwrapCallSessionKey(
+            wrapped,
+            recipientKeypair.privateKeyBase64,
+            senderKeypair.publicKeyBase64,
+        );
+
+        assert.equal(unwrapped, sessionKey, 'Unwrapped key must match original session key');
+    });
+
+    it('fails to unwrap with wrong private key', async () => {
+        const senderKeypair = await generateCallEphemeralKeypair();
+        const recipientKeypair = await generateCallEphemeralKeypair();
+        const wrongKeypair = await generateCallEphemeralKeypair();
+        const sessionKey = generateCallSessionAesKey();
+
+        const wrapped = await wrapCallSessionKey(
+            sessionKey,
+            recipientKeypair.publicKeyBase64,
+            senderKeypair.privateKeyBase64,
+        );
+
+        await assert.rejects(
+            () => unwrapCallSessionKey(wrapped, wrongKeypair.privateKeyBase64, senderKeypair.publicKeyBase64),
+            'Should reject when unwrapping with the wrong private key',
+        );
+    });
+
+    it('produces different output each call due to random IV', async () => {
+        const senderKeypair = await generateCallEphemeralKeypair();
+        const recipientKeypair = await generateCallEphemeralKeypair();
+        const sessionKey = generateCallSessionAesKey();
+
+        const wrapped1 = await wrapCallSessionKey(
+            sessionKey, recipientKeypair.publicKeyBase64, senderKeypair.privateKeyBase64,
+        );
+        const wrapped2 = await wrapCallSessionKey(
+            sessionKey, recipientKeypair.publicKeyBase64, senderKeypair.privateKeyBase64,
+        );
+
+        assert.notEqual(wrapped1, wrapped2, 'Random IV should produce different blobs each call');
+    });
+
+    it('is domain-separated from decryptKeyFromDevice (pipe pairing cannot decrypt call-wrapped key)', async () => {
+        // Same ECDH key pair used for both operations — isolates the HKDF salt as the only difference
+        const keypair = await generateCallEphemeralKeypair();
+        const sessionKey = generateCallSessionAesKey();
+
+        const callWrapped = await wrapCallSessionKey(
+            sessionKey,
+            keypair.publicKeyBase64,
+            keypair.privateKeyBase64,
+        );
+
+        // Pipe pairing uses HKDF salt 'flashview-pipe-pairing-v1'; call uses 'flashview-call-key-exchange-v1'
+        // Attempting to unwrap the call blob with the pipe pairing function must fail
+        await assert.rejects(
+            () => decryptKeyFromDevice(callWrapped, keypair.privateKeyBase64, keypair.publicKeyBase64),
+            'Pipe pairing decryption must not succeed on a call-domain wrapped key',
+        );
     });
 });


### PR DESCRIPTION
## Summary

- Adds 4 new call-specific ECDH/ECIES crypto functions to `flashview-crypto` (`generateCallEphemeralKeypair`, `generateCallSessionAesKey`, `wrapCallSessionKey`, `unwrapCallSessionKey`), domain-separated from pipe pairing via HKDF salt `flashview-call-key-exchange-v1`
- Re-exports all 4 functions through `resources/js/encryption.js` for consumption by the call UI (PIO-116)
- `POST /call-sessions/{hash_id}/join` and `POST /api/v1/calls/{callSession}/join` now accept an optional `public_key` field (`nullable|string|max:512`) and persist it to `call_participants.public_key` — no migration needed (column existed from PIO-112)
- Updates `flashview-cli` lockfile: `flashview-crypto` 2.0.0 → 2.2.0 (was causing CLI test suite build failures)

## Test plan

- [ ] `node --test tools/flashview-crypto/tests/crypto.test.js` — 75 tests pass (includes 9 new tests covering roundtrip, wrong-key rejection, random-IV uniqueness, and domain separation)
- [ ] `php artisan test tests/Feature/Call/JoinCallSessionTest.php` — 13 tests pass (includes 3 new: stores key, null when omitted, rejects oversized key)
- [ ] `cd tools/flashview-cli && npm test` — 105 tests pass
- [ ] Join a call session via `POST /call-sessions/{hash_id}/join` with a `public_key` field and verify it appears in `GET /api/v1/calls/{hash_id}/participants`
- [ ] Join without `public_key` and verify existing callers are unaffected (null stored)
- [ ] Send a `public_key` > 512 chars and verify 422 response

## Regression risks (from regression-detector)

- `GET /api/v1/calls/{callSession}/participants` will now return non-null `public_key` values for participants that joined with a key — this is the intended behaviour and no existing consumers break
- CLI does not expose the 4 new call crypto functions — intentional, CLI has no audio/video call support