### PR TITLE
PIO-116: Browser Call UI (Vue)

### DIFF
--- a/app/Http/Controllers/Api/CallSignalController.php
+++ b/app/Http/Controllers/Api/CallSignalController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Call\CreateCallSignalRequest;
+use App\Http\Requests\Call\LeaveCallRequest;
 use App\Http\Requests\Call\ListCallSignalsRequest;
 use App\Models\CallParticipant;
 use App\Models\CallSession;
@@ -52,6 +53,21 @@ class CallSignalController extends Controller
         ]);
 
         return response()->json(['signal_id' => $signal->id], 201);
+    }
+
+    public function leave(LeaveCallRequest $request, CallSession $callSession): JsonResponse
+    {
+        $participant = CallParticipant::where('id', $request->participant_id)
+            ->where('call_session_id', $callSession->id)
+            ->first();
+
+        if (! $participant) {
+            return response()->json(['message' => 'Participant not found.'], 404);
+        }
+
+        $participant->update(['left_at' => now()]);
+
+        return response()->json(['message' => 'Left.']);
     }
 
     public function index(ListCallSignalsRequest $request, CallSession $callSession): JsonResponse

--- a/app/Http/Controllers/CallPageController.php
+++ b/app/Http/Controllers/CallPageController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CallSession;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CallPageController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Call/Index');
+    }
+
+    public function show(CallSession $callSession): Response
+    {
+        return Inertia::render('Call/Join', [
+            'session' => [
+                'bridge_number' => $callSession->hash_id,
+                'starts_at' => $callSession->starts_at,
+                'ends_at' => $callSession->ends_at,
+                'is_active' => $callSession->isActive(),
+            ],
+        ]);
+    }
+
+    public function room(CallSession $callSession): Response
+    {
+        return Inertia::render('Call/Room', [
+            'session' => [
+                'bridge_number' => $callSession->hash_id,
+                'ends_at' => $callSession->ends_at,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Call/LeaveCallRequest.php
+++ b/app/Http/Requests/Call/LeaveCallRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Call;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LeaveCallRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'participant_id' => ['required', 'uuid'],
+        ];
+    }
+}

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -125,6 +125,9 @@ const logout = () => {
                                                 </div>
                                             </div>
                                         </div>
+                                        <NavLink :href="route('calls.index')" :active="route().current('calls.*')">
+                                            Secure Line
+                                        </NavLink>
                                         <NavLink :href="route('blog.index')" :active="route().current('blog.*')">
                                             Blog
                                         </NavLink>
@@ -376,6 +379,9 @@ const logout = () => {
                                 </ResponsiveNavLink>
                                 <ResponsiveNavLink :href="route('lockers.buy')" :active="route().current('lockers.buy')">
                                     eLocker — Buy
+                                </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('calls.index')" :active="route().current('calls.*')">
+                                    Secure Line
                                 </ResponsiveNavLink>
                                 <ResponsiveNavLink :href="route('blog.index')" :active="route().current('blog.*')">
                                     Blog

--- a/resources/js/Pages/Call/Index.vue
+++ b/resources/js/Pages/Call/Index.vue
@@ -1,0 +1,74 @@
+<script setup>
+import { ref } from 'vue';
+import { router, Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+const bridgeNumber = ref('');
+
+function joinLine() {
+    const trimmed = bridgeNumber.value.trim();
+    if (!trimmed) return;
+    router.visit(route('calls.join', trimmed));
+}
+</script>
+
+<template>
+    <AppLayout title="Secure Line">
+        <div class="dark min-h-screen bg-gray-950 py-16 px-4">
+            <div class="max-w-3xl mx-auto space-y-10">
+
+                <!-- Hero -->
+                <div class="text-center">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Secure Line</div>
+                    <h1 class="text-3xl font-bold text-white mb-3">Encrypted, Ephemeral Video Calls</h1>
+                    <p class="text-gray-400 text-sm max-w-lg mx-auto">
+                        Time-limited, end-to-end encrypted calls. No account needed to join — just a bridge number and password.
+                    </p>
+                </div>
+
+                <!-- Two-column action cards -->
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+                    <!-- Join a Line -->
+                    <div class="bg-gray-900 border border-gray-700 rounded-xl p-6 space-y-4 shadow-neon-cyan-sm">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Join a Line</div>
+                        <p class="text-gray-400 text-sm">Enter the bridge number you received to join a secure call.</p>
+                        <input
+                            v-model="bridgeNumber"
+                            type="text"
+                            placeholder="Bridge number"
+                            @keydown.enter="joinLine"
+                            data-testid="bridge-number-input"
+                            class="w-full bg-gray-950 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none"
+                        />
+                        <button
+                            @click="joinLine"
+                            :disabled="!bridgeNumber.trim()"
+                            data-testid="join-line-button"
+                            class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-40 disabled:cursor-not-allowed text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
+                        >
+                            Join Line →
+                        </button>
+                    </div>
+
+                    <!-- Buy a Line -->
+                    <div class="bg-gray-900 border border-gray-700 rounded-xl p-6 space-y-4 shadow-neon-cyan-sm">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Buy a Line</div>
+                        <p class="text-gray-400 text-sm">
+                            Host your own encrypted call window. Time-limited, zero-knowledge, no account needed for participants.
+                        </p>
+                        <Link
+                            :href="route('plans.index')"
+                            prefetch
+                            class="block w-full text-center bg-gamboge-300 hover:bg-gamboge-400 text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
+                        >
+                            Buy a Line →
+                        </Link>
+                    </div>
+
+                </div>
+
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Index.vue
+++ b/resources/js/Pages/Call/Index.vue
@@ -20,7 +20,7 @@ function joinLine() {
                 <!-- Hero -->
                 <div class="text-center">
                     <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Secure Line</div>
-                    <h1 class="text-3xl font-bold text-white mb-3">Encrypted, Ephemeral Video Calls</h1>
+                    <h1 class="text-3xl font-bold text-white mb-3">Encrypted, Ephemeral Audio Calls</h1>
                     <p class="text-gray-400 text-sm max-w-lg mx-auto">
                         Time-limited, end-to-end encrypted calls. No account needed to join — just a bridge number and password.
                     </p>

--- a/resources/js/Pages/Call/Join.vue
+++ b/resources/js/Pages/Call/Join.vue
@@ -1,0 +1,185 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+import { router } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import Alert from '@/Components/Alert.vue';
+import axios from 'axios';
+import { encryption } from '@/encryption.js';
+
+const props = defineProps({
+    session: {
+        type: Object,
+        required: true,
+        // { bridge_number, starts_at, ends_at, is_active }
+    },
+});
+
+const stage = ref('form'); // 'form' | 'joining' | 'turn_warning' | 'error'
+const password = ref('');
+const errorMessage = ref('');
+const isActive = ref(props.session.is_active);
+const turnWarning = ref(false);
+
+function formatDateTime(isoString) {
+    return new Date(isoString).toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+}
+
+onMounted(() => {
+    if (!isActive.value) {
+        const sessionOpenMs = new Date(props.session.starts_at).getTime();
+        const timer = setInterval(() => {
+            if (Date.now() >= sessionOpenMs) {
+                isActive.value = true;
+                clearInterval(timer);
+            }
+        }, 1000);
+        onUnmounted(() => clearInterval(timer));
+    }
+});
+
+async function handleJoin() {
+    stage.value = 'joining';
+    try {
+        const { data: challengeData } = await axios.get(
+            route('call-sessions.challenge', props.session.bridge_number)
+        );
+
+        const enc = new encryption();
+        const keypair = await enc.deriveCallKeyPair(password.value, challengeData.salt);
+        const ecdhKeypair = await enc.generateCallEphemeralKeypair();
+
+        // signCallChallenge is synchronous — no await
+        const signature = enc.signCallChallenge(keypair.privateKey, challengeData.challenge);
+
+        const { data: responseData } = await axios.post(
+            route('call-sessions.join', props.session.bridge_number),
+            { signature, public_key: ecdhKeypair.publicKeyBase64 }
+        );
+
+        const storageKey = `call_session:${props.session.bridge_number}`;
+        sessionStorage.setItem(storageKey, JSON.stringify({
+            participant_id:   responseData.participant_id,
+            ice_servers:      responseData.ice_servers,
+            ecdh_private_key: ecdhKeypair.privateKeyBase64,
+            ecdh_public_key:  ecdhKeypair.publicKeyBase64,
+            turn_warning:     !responseData.turn_available,
+            session:          responseData.session,
+        }));
+
+        if (!responseData.turn_available) {
+            turnWarning.value = true;
+            stage.value = 'turn_warning';
+            return;
+        }
+
+        router.visit(route('calls.room', props.session.bridge_number));
+    } catch (e) {
+        stage.value = 'error';
+        const status = e.response?.status;
+        const msg = e.response?.data?.message ?? '';
+        if (status === 401) {
+            errorMessage.value = 'Incorrect password. Please check and try again.';
+        } else if (status === 404) {
+            errorMessage.value = 'This call session was not found. Check the bridge number.';
+        } else if (status === 422 && msg.toLowerCase().includes('full')) {
+            errorMessage.value = 'This call is currently full.';
+        } else if (status === 422) {
+            errorMessage.value = 'This call has already ended.';
+        } else {
+            errorMessage.value = 'Unable to join the call. Please try again.';
+        }
+    }
+}
+
+function continueToRoom() {
+    router.visit(route('calls.room', props.session.bridge_number));
+}
+
+function retryJoin() {
+    stage.value = 'form';
+    errorMessage.value = '';
+}
+</script>
+
+<template>
+    <AppLayout title="Join Secure Line">
+        <div class="dark min-h-screen bg-gray-950 py-16 px-4">
+            <div class="max-w-md mx-auto space-y-6">
+
+                <!-- Header -->
+                <div class="text-center">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Secure Line</div>
+                    <h1 class="text-2xl font-bold text-white mb-1">Join Call</h1>
+                    <div class="font-mono text-gamboge-300 text-lg tracking-widest">{{ session.bridge_number }}</div>
+                </div>
+
+                <!-- Not yet started state -->
+                <div v-if="!isActive" class="bg-gray-900 border border-gray-700 rounded-xl p-6 space-y-3 text-center">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Not Yet Started</div>
+                    <p class="text-white text-sm">This call starts at</p>
+                    <p class="text-gamboge-300 font-mono text-sm">{{ formatDateTime(session.starts_at) }}</p>
+                    <p class="text-gray-400 text-xs">The form will enable automatically when the call window opens.</p>
+                    <button
+                        disabled
+                        class="w-full mt-2 bg-gamboge-300 opacity-40 cursor-not-allowed text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm"
+                    >
+                        Join Call →
+                    </button>
+                </div>
+
+                <!-- Join form -->
+                <div v-else-if="stage === 'form' || stage === 'joining'" class="bg-gray-900 border border-gray-700 rounded-xl p-6 space-y-4">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Enter Password</div>
+                    <input
+                        v-model="password"
+                        type="password"
+                        placeholder="Call password"
+                        @keydown.enter="handleJoin"
+                        :disabled="stage === 'joining'"
+                        data-testid="call-password-input"
+                        class="w-full bg-gray-950 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none disabled:opacity-50"
+                    />
+                    <button
+                        @click="handleJoin"
+                        :disabled="!password || stage === 'joining'"
+                        data-testid="join-call-button"
+                        class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-40 disabled:cursor-not-allowed text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
+                        :class="{ 'animate-pulse': stage === 'joining' }"
+                    >
+                        <span v-if="stage === 'joining'">Joining…</span>
+                        <span v-else>Join Call →</span>
+                    </button>
+                </div>
+
+                <!-- TURN warning interstitial -->
+                <div v-else-if="stage === 'turn_warning'" class="bg-gray-900 border border-amber-700/50 rounded-xl p-6 space-y-4">
+                    <Alert type="Warning">
+                        Your network may limit call quality. If you experience issues, try switching to a different network or connection.
+                    </Alert>
+                    <button
+                        @click="continueToRoom"
+                        data-testid="continue-to-call-button"
+                        class="w-full bg-gamboge-300 hover:bg-gamboge-400 text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm"
+                    >
+                        Continue to call →
+                    </button>
+                </div>
+
+                <!-- Error state -->
+                <div v-else-if="stage === 'error'" class="bg-gray-900 border border-gray-700 rounded-xl p-6 space-y-4">
+                    <Alert type="Error">{{ errorMessage }}</Alert>
+                    <button
+                        @click="retryJoin"
+                        class="w-full border border-gray-700 text-gray-300 hover:text-white hover:border-gray-500 py-2.5 rounded-lg font-mono text-sm transition-colors"
+                    >
+                        Try again
+                    </button>
+                </div>
+
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -117,8 +117,6 @@ function createPeerConnection(peerId) {
             sendSignal(peerId, 'ice-candidate', { candidate });
         }
     };
-    pc.onicegatheringstatechange = () => { };
-    pc.oniceconnectionstatechange = () => { };
     pc.onconnectionstatechange = () => {
         if (pc.connectionState === 'failed') {
             // Spread to a new object so Vue 3 detects the change
@@ -235,7 +233,7 @@ async function pollParticipants() {
                 createPeerConnection(p.id);
             }
         }
-    } catch (e) { console.error('[WebRTC] pollParticipants error:', e); }
+    } catch (e) { }
     participantPollTimer.value = setTimeout(pollParticipants, 3000);
 }
 
@@ -249,11 +247,9 @@ async function pollSignals() {
         for (const signal of data.signals) {
             try {
                 await processSignal(signal);
-            } catch (e) {
-                console.error('[WebRTC] processSignal error:', signal.type, e);
-            }
+            } catch (e) { }
         }
-    } catch (e) { console.error('[WebRTC] pollSignals error:', e); }
+    } catch (e) { }
     signalPollTimer.value = setTimeout(pollSignals, 1500);
 }
 

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -106,41 +106,28 @@ function sanitizeSdp(sdpString) {
     // treats the last line as invalid if it is not CRLF-terminated.
     const lines = sdpString.split('\r\n');
     const filtered = lines.filter(line => !/^a=ssrc:/.test(line));
-    console.log('[D] sanitizeSdp: lines before:', lines.length, 'after:', filtered.length, '(removed', lines.length - filtered.length, 'a=ssrc: lines)', '| input ends CRLF:', sdpString.endsWith('\r\n'));
     const joined = filtered.join('\r\n');
     const result = joined.endsWith('\r\n') ? joined : joined + '\r\n';
-    console.log('[D] sanitized SDP dump:\n' + result);
     return result;
 }
 
 function createPeerConnection(peerId) {
-    console.log('[D] createPeerConnection', peerId, 'iceServers:', JSON.stringify(sessionData.ice_servers));
     const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
     localStream.value.getTracks().forEach(track => {
-        console.log('[D] addTrack', track.kind, track.label);
         pc.addTrack(track, localStream.value);
     });
     pc.onicecandidate = ({ candidate }) => {
-        console.log('[D] icecandidate', candidate ? candidate.type + ' ' + candidate.protocol : 'null (gathering complete)');
         if (candidate) {
             sendSignal(peerId, 'ice-candidate', { candidate });
         }
     };
-    pc.onicegatheringstatechange = () => {
-        console.log('[D] iceGatheringState ->', pc.iceGatheringState);
-    };
-    pc.oniceconnectionstatechange = () => {
-        console.log('[D] iceConnectionState ->', pc.iceConnectionState);
-    };
     pc.onconnectionstatechange = () => {
-        console.log('[D] connectionState ->', pc.connectionState);
         if (pc.connectionState === 'failed') {
             // Spread to a new object so Vue 3 detects the change
             peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
         }
     };
-    pc.ontrack = ({ streams, track }) => {
-        console.log('[D] ontrack', track.kind, 'streams:', streams.length);
+    pc.ontrack = ({ streams }) => {
         if (streams[0]) {
             // Play remote audio via a hidden <audio> element (audio-only call)
             if (!remoteAudioElements[peerId]) {
@@ -152,9 +139,7 @@ function createPeerConnection(peerId) {
             }
             remoteAudioElements[peerId].srcObject = streams[0];
             // Autoplay may be blocked after Inertia client-side navigation; call play() explicitly
-            remoteAudioElements[peerId].play()
-                .then(() => console.log('[D] audio.play() resolved'))
-                .catch(err => console.log('[D] audio.play() rejected:', err.message));
+            remoteAudioElements[peerId].play().catch(() => {});
         }
     };
     // Spread to a new object so Vue 3 detects the key addition
@@ -180,30 +165,25 @@ async function processSignal(signal) {
     }
 
     if (type === 'offer') {
-        console.log('[D] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
         const offerSdp = payload.sdp?.sdp
             ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
             : payload.sdp;
         await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
-        console.log('[D] setRemoteDescription (offer) OK, signalingState:', pc.signalingState);
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
         await sendSignal(fromId, 'answer', { sdp: answer });
-        console.log('[D] answer sent to', fromId);
         return;
     }
 
     if (type === 'answer') {
-        console.log('[D] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
             const answerSdp = payload.sdp?.sdp
                 ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
                 : payload.sdp;
             await pc.setRemoteDescription(new RTCSessionDescription(answerSdp));
-            console.log('[D] setRemoteDescription (answer) OK, signalingState:', pc.signalingState);
             await drainPendingCandidates(fromId, pc);
         }
         return;
@@ -236,7 +216,6 @@ async function pollParticipants() {
                 const pc = createPeerConnection(p.id);
                 const offer = await pc.createOffer();
                 await pc.setLocalDescription(offer);
-                console.log('[D] sending offer to', p.id);
                 await sendSignal(p.id, 'offer', { sdp: offer });
 
                 if (p.public_key) {
@@ -258,7 +237,7 @@ async function pollParticipants() {
                 createPeerConnection(p.id);
             }
         }
-    } catch (e) { console.log('[D] pollParticipants error:', e.message); }
+    } catch { }
     participantPollTimer.value = setTimeout(pollParticipants, 3000);
 }
 
@@ -272,9 +251,9 @@ async function pollSignals() {
         for (const signal of data.signals) {
             try {
                 await processSignal(signal);
-            } catch (e) { console.log('[D] processSignal error:', signal.type, e.message); }
+            } catch { }
         }
-    } catch (e) { console.log('[D] pollSignals error:', e.message); }
+    } catch { }
     signalPollTimer.value = setTimeout(pollSignals, 1500);
 }
 

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -305,7 +305,7 @@ onUnmounted(cleanup);
                     </p>
                     <button
                         @click="router.visit(route('calls.join', session.bridge_number))"
-                        class="w-full border border-gray-700 text-gray-300 hover:text-white py-2.5 rounded-lg font-mono text-sm transition-colors"
+                        class="w-full border border-gray-700 text-gray-300 hover:text-white py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm"
                     >
                         ← Back to join page
                     </button>
@@ -404,7 +404,7 @@ onUnmounted(cleanup);
                                 @click="toggleMute"
                                 :title="isMuted ? 'Unmute' : 'Mute'"
                                 :class="isMuted ? 'bg-red-700 hover:bg-red-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'"
-                                class="p-3 rounded-full transition-colors"
+                                class="p-3 rounded-full transition-colors shadow-neon-cyan-sm"
                             >
                                 <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
                                     <path v-if="!isMuted" stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"/>
@@ -415,7 +415,7 @@ onUnmounted(cleanup);
                                 @click="toggleCamera"
                                 :title="isCameraOff ? 'Turn camera on' : 'Turn camera off'"
                                 :class="isCameraOff ? 'bg-red-700 hover:bg-red-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'"
-                                class="p-3 rounded-full transition-colors"
+                                class="p-3 rounded-full transition-colors shadow-neon-cyan-sm"
                             >
                                 <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
                                     <path v-if="!isCameraOff" stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"/>
@@ -434,7 +434,7 @@ onUnmounted(cleanup);
                             <button
                                 v-else
                                 @click="requestLeave"
-                                class="bg-red-800 hover:bg-red-700 text-white font-mono text-sm px-4 py-2 rounded-lg transition-colors"
+                                class="bg-red-800 hover:bg-red-700 text-white font-mono text-sm px-4 py-2 rounded-lg transition-colors shadow-neon-cyan-sm"
                             >
                                 Leave
                             </button>

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -2,7 +2,6 @@
 import { ref, onMounted, onUnmounted } from 'vue';
 import { router } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import Alert from '@/Components/Alert.vue';
 import axios from 'axios';
 import { encryption } from '@/encryption.js';
 
@@ -23,9 +22,8 @@ const sessionData = raw ? JSON.parse(raw) : null;
 
 // Reactive state
 const localStream = ref(null);
-const peers = ref({});         // { [participantId]: { pc, stream, connectionFailed } }
+const peers = ref({});         // { [participantId]: { pc, connectionFailed } }
 const isMuted = ref(false);
-const isCameraOff = ref(false);
 const mediaError = ref(null);  // null | 'denied' | 'unavailable'
 const timeRemaining = ref(null);
 const callEnded = ref(false);
@@ -34,6 +32,9 @@ const signalCursor = ref(null);
 const confirmingLeave = ref(false);
 const participantCount = ref(1);
 const showTurnWarning = ref(sessionData?.turn_warning === true);
+
+// Hidden <audio> elements for remote participants — not reactive, managed directly
+const remoteAudioElements = {};
 
 // Timer handles
 const participantPollTimer = ref(null);
@@ -105,14 +106,26 @@ function createPeerConnection(peerId) {
         }
     };
     pc.ontrack = ({ streams }) => {
-        peers.value[peerId] = { ...peers.value[peerId], stream: streams[0] };
+        if (streams[0]) {
+            // Play remote audio via a hidden <audio> element (audio-only call)
+            if (!remoteAudioElements[peerId]) {
+                const audio = document.createElement('audio');
+                audio.autoplay = true;
+                audio.style.display = 'none';
+                document.body.appendChild(audio);
+                remoteAudioElements[peerId] = audio;
+            }
+            remoteAudioElements[peerId].srcObject = streams[0];
+        }
     };
     pc.onconnectionstatechange = () => {
         if (pc.connectionState === 'failed') {
-            peers.value[peerId] = { ...peers.value[peerId], connectionFailed: true };
+            // Spread to a new object so Vue 3 detects the change
+            peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
         }
     };
-    peers.value[peerId] = { pc, stream: null, connectionFailed: false };
+    // Spread to a new object so Vue 3 detects the key addition
+    peers.value = { ...peers.value, [peerId]: { pc, connectionFailed: false } };
     return pc;
 }
 
@@ -250,17 +263,16 @@ function cleanup() {
     clearInterval(redirectTimer.value);
     Object.values(peers.value).forEach(({ pc }) => pc.close());
     localStream.value?.getTracks().forEach(t => t.stop());
+    Object.values(remoteAudioElements).forEach(a => {
+        a.srcObject = null;
+        a.remove();
+    });
     sessionStorage.removeItem(storageKey);
 }
 
 function toggleMute() {
     isMuted.value = !isMuted.value;
     localStream.value?.getAudioTracks().forEach(t => { t.enabled = !isMuted.value; });
-}
-
-function toggleCamera() {
-    isCameraOff.value = !isCameraOff.value;
-    localStream.value?.getVideoTracks().forEach(t => { t.enabled = !isCameraOff.value; });
 }
 
 function requestLeave()  { confirmingLeave.value = true; }
@@ -271,7 +283,7 @@ onMounted(async () => {
     if (!sessionData) return;
 
     try {
-        localStream.value = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        localStream.value = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (e) {
         mediaError.value = e.name === 'NotFoundError' ? 'unavailable' : 'denied';
         return;
@@ -288,20 +300,20 @@ onUnmounted(cleanup);
     <AppLayout title="Secure Line — Call">
         <div class="dark min-h-screen bg-gray-950">
 
-            <!-- Media permission error screen -->
+            <!-- Microphone permission error screen -->
             <div v-if="mediaError" class="flex items-center justify-center min-h-screen px-4">
                 <div class="max-w-md w-full bg-gray-900 border border-red-700/50 rounded-xl p-8 space-y-4 text-center">
                     <div class="text-red-400 font-mono text-xs uppercase tracking-widest mb-2">Permission Required</div>
-                    <h2 class="text-white text-xl font-bold">Camera &amp; Microphone Access Needed</h2>
+                    <h2 class="text-white text-xl font-bold">Microphone Access Needed</h2>
                     <p v-if="mediaError === 'unavailable'" class="text-gray-400 text-sm">
-                        No camera or microphone was found on this device. Please connect a webcam and microphone and reload.
+                        No microphone was found on this device. Please connect a microphone and reload.
                     </p>
                     <p v-else class="text-gray-400 text-sm">
-                        Camera and microphone access was denied. To join the call, allow access in your browser settings and reload this page.
+                        Microphone access was denied. To join the call, allow access in your browser settings and reload this page.
                     </p>
                     <p class="text-gray-500 text-xs">
-                        In Chrome: click the lock icon in the address bar → Site settings → Allow Camera and Microphone.<br>
-                        In Firefox: click the camera icon in the address bar → Remove block.
+                        In Chrome: click the lock icon in the address bar → Site settings → Allow Microphone.<br>
+                        In Firefox: click the microphone icon in the address bar → Remove block.
                     </p>
                     <button
                         @click="router.visit(route('calls.join', session.bridge_number))"
@@ -330,61 +342,59 @@ onUnmounted(cleanup);
                     <button @click="showTurnWarning = false" class="text-amber-400 hover:text-amber-200 text-xs font-mono shrink-0">Dismiss</button>
                 </div>
 
-                <!-- Video grid -->
-                <div class="flex-1 p-4">
-                    <div class="grid gap-4 h-full" :class="Object.keys(peers).length === 0 ? 'grid-cols-1' : 'grid-cols-1 sm:grid-cols-2'">
+                <!-- Audio call area — pb-24 clears the fixed controls bar -->
+                <div class="flex-1 flex flex-col items-center justify-center gap-10 pb-24 px-8">
 
-                        <!-- Local video tile -->
-                        <div class="relative bg-gray-900 rounded-xl overflow-hidden aspect-video">
-                            <video
-                                v-if="localStream"
-                                :srcObject="localStream"
-                                autoplay
-                                muted
-                                playsinline
-                                class="w-full h-full object-cover"
-                            />
-                            <div v-else class="flex items-center justify-center h-full text-gray-600">
-                                <span class="font-mono text-sm">Loading camera…</span>
-                            </div>
-                            <div class="absolute bottom-2 left-2 text-xs font-mono text-gamboge-300 bg-gray-950/70 px-2 py-0.5 rounded">You</div>
-                            <div v-if="isMuted" class="absolute top-2 right-2 text-red-400 bg-gray-950/70 rounded-full p-1">
-                                <svg class="size-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 19L5 5m5.5 4.5A4 4 0 0 0 12 12v3m-4 2.5c.8.8 2 1.5 4 1.5s3.2-.7 4-1.5m.5-8.5a4 4 0 0 0-8 0v4"/></svg>
-                            </div>
+                    <!-- Waiting state — shown until a second participant joins -->
+                    <div v-if="participantCount <= 1" class="text-center space-y-4">
+                        <div class="w-24 h-24 rounded-full bg-gray-900 border-2 border-gray-700 flex items-center justify-center mx-auto">
+                            <svg class="w-10 h-10 text-gray-600 animate-pulse" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"/>
+                            </svg>
                         </div>
-
-                        <!-- Remote video tiles -->
-                        <template v-for="(peer, peerId) in peers" :key="peerId">
-                            <div class="relative bg-gray-900 rounded-xl overflow-hidden aspect-video">
-                                <video
-                                    v-if="peer.stream"
-                                    :srcObject="peer.stream"
-                                    autoplay
-                                    playsinline
-                                    class="w-full h-full object-cover"
-                                />
-                                <div v-else class="flex items-center justify-center h-full text-gray-600">
-                                    <span class="font-mono text-sm animate-pulse">Connecting…</span>
-                                </div>
-                                <!-- Connection failed overlay -->
-                                <div v-if="peer.connectionFailed" class="absolute inset-0 bg-gray-950/80 flex items-center justify-center p-4">
-                                    <p class="text-red-400 text-xs text-center font-mono">
-                                        Connection lost. This may recover automatically — if not, ask the participant to rejoin.
-                                    </p>
-                                </div>
-                            </div>
-                        </template>
-
-                        <!-- Empty state — no peers yet -->
-                        <div v-if="Object.keys(peers).length === 0" class="bg-gray-900/50 border border-gray-700/50 rounded-xl aspect-video flex items-center justify-center">
-                            <p class="text-gray-500 font-mono text-sm animate-pulse">Waiting for others to join…</p>
-                        </div>
-
+                        <p class="text-gray-500 font-mono text-sm">Waiting for others to join…</p>
                     </div>
+
+                    <!-- Active call — participant circles, one per person -->
+                    <div v-else class="flex flex-wrap gap-8 justify-center">
+                        <!-- You -->
+                        <div class="flex flex-col items-center gap-2">
+                            <div
+                                class="w-20 h-20 rounded-full bg-gray-800 border-2 flex items-center justify-center transition-colors"
+                                :class="isMuted ? 'border-gray-700' : 'border-gamboge-300 shadow-neon-cyan-sm'"
+                            >
+                                <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"/>
+                                </svg>
+                            </div>
+                            <span class="text-xs font-mono text-gamboge-300">You{{ isMuted ? ' (muted)' : '' }}</span>
+                        </div>
+
+                        <!-- Remote participants — one circle per additional participant -->
+                        <div
+                            v-for="i in (participantCount - 1)"
+                            :key="i"
+                            class="flex flex-col items-center gap-2"
+                        >
+                            <div class="w-20 h-20 rounded-full bg-gray-800 border-2 border-gray-600 flex items-center justify-center">
+                                <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"/>
+                                </svg>
+                            </div>
+                            <span class="text-xs font-mono text-gray-400">Participant {{ i }}</span>
+                        </div>
+                    </div>
+
+                    <!-- Bridge number display -->
+                    <div class="text-center">
+                        <p class="text-xs uppercase tracking-widest text-gray-600 font-mono mb-1">Bridge</p>
+                        <p class="font-mono text-gamboge-300 text-lg tracking-widest">{{ session.bridge_number }}</p>
+                    </div>
+
                 </div>
 
-                <!-- Controls bar -->
-                <div class="bg-gray-900 border-t border-gray-800 px-4 py-4">
+                <!-- Controls bar — fixed to viewport bottom, above any page footer -->
+                <div class="fixed bottom-0 left-0 right-0 z-10 bg-gray-900 border-t border-gray-800 px-4 py-4">
                     <div class="max-w-lg mx-auto flex items-center justify-between gap-4">
 
                         <!-- Left — participant count + time -->
@@ -398,7 +408,7 @@ onUnmounted(cleanup);
                             </div>
                         </div>
 
-                        <!-- Centre — mic / camera -->
+                        <!-- Centre — mute only (audio-only call, no camera button) -->
                         <div class="flex gap-3">
                             <button
                                 @click="toggleMute"
@@ -409,17 +419,6 @@ onUnmounted(cleanup);
                                 <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
                                     <path v-if="!isMuted" stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"/>
                                     <path v-else stroke-linecap="round" stroke-linejoin="round" d="M19 19L5 5m5.5 4.5A4 4 0 0 0 12 12v3m-4 2.5c.8.8 2 1.5 4 1.5s3.2-.7 4-1.5m.5-8.5a4 4 0 0 0-8 0v4"/>
-                                </svg>
-                            </button>
-                            <button
-                                @click="toggleCamera"
-                                :title="isCameraOff ? 'Turn camera on' : 'Turn camera off'"
-                                :class="isCameraOff ? 'bg-red-700 hover:bg-red-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'"
-                                class="p-3 rounded-full transition-colors shadow-neon-cyan-sm"
-                            >
-                                <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                    <path v-if="!isCameraOff" stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"/>
-                                    <path v-else stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5 4.72-4.72m0 0a.75.75 0 0 0-1.28.53v11.38a.75.75 0 0 0 1.28.53l4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"/>
                                 </svg>
                             </button>
                         </div>

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -427,8 +427,8 @@ onUnmounted(cleanup);
                         <div class="text-right">
                             <div v-if="confirmingLeave" class="flex gap-2 items-center">
                                 <span class="text-xs text-gray-400 font-mono">Leave call?</span>
-                                <button @click="cancelLeave" class="text-xs text-gray-400 hover:text-white font-mono border border-gray-700 px-2 py-1 rounded transition-colors">Stay</button>
-                                <button @click="confirmLeave" class="text-xs text-red-400 hover:text-red-300 font-mono border border-red-700 px-2 py-1 rounded transition-colors">Leave call</button>
+                                <button @click="cancelLeave" class="text-xs text-gray-400 hover:text-white font-mono border border-gray-700 px-2 py-1 rounded transition-colors shadow-neon-cyan-sm">Stay</button>
+                                <button @click="confirmLeave" class="text-xs text-red-400 hover:text-red-300 font-mono border border-red-700 px-2 py-1 rounded transition-colors shadow-neon-cyan-sm">Leave call</button>
                             </div>
                             <button
                                 v-else

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -1,0 +1,450 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+import { router } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import Alert from '@/Components/Alert.vue';
+import axios from 'axios';
+import { encryption } from '@/encryption.js';
+
+const props = defineProps({
+    session: {
+        type: Object,
+        required: true,
+        // { bridge_number, ends_at }
+    },
+});
+
+const storageKey = `call_session:${props.session.bridge_number}`;
+const raw = sessionStorage.getItem(storageKey);
+if (!raw) {
+    router.visit(route('calls.join', props.session.bridge_number));
+}
+const sessionData = raw ? JSON.parse(raw) : null;
+
+// Reactive state
+const localStream = ref(null);
+const peers = ref({});         // { [participantId]: { pc, stream, connectionFailed } }
+const isMuted = ref(false);
+const isCameraOff = ref(false);
+const mediaError = ref(null);  // null | 'denied' | 'unavailable'
+const timeRemaining = ref(null);
+const callEnded = ref(false);
+const redirectCountdown = ref(5);
+const signalCursor = ref(null);
+const confirmingLeave = ref(false);
+const participantCount = ref(1);
+const showTurnWarning = ref(sessionData?.turn_warning === true);
+
+// Timer handles
+const participantPollTimer = ref(null);
+const signalPollTimer = ref(null);
+const expiryTimer = ref(null);
+const redirectTimer = ref(null);
+
+// ICE candidate queue — plain object, not reactive
+const pendingCandidates = {};
+
+// Participant ECDH public key cache — populated during participant polling
+const participantPublicKeys = {};
+
+// Group AES key — in memory only, never persisted
+let groupAesKey = null;
+
+// API URLs — template literals; API routes are not in Ziggy's manifest
+const PARTICIPANTS_URL = `/api/v1/calls/${props.session.bridge_number}/participants`;
+const SIGNAL_STORE_URL = `/api/v1/calls/${props.session.bridge_number}/signal`;
+
+function signalPollUrl(cursor) {
+    let url = `/api/v1/calls/${props.session.bridge_number}/signal?participant_id=${sessionData.participant_id}`;
+    if (cursor) {
+        url += `&after=${cursor}`;
+    }
+    return url;
+}
+
+function formatTimeRemaining(seconds) {
+    if (seconds === null) return '';
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+async function sendSignal(toParticipantId, type, payload) {
+    await axios.post(SIGNAL_STORE_URL, {
+        from_participant_id: sessionData.participant_id,
+        to_participant_id:   toParticipantId,
+        type,
+        payload,
+    });
+}
+
+async function handleIceCandidate(fromId, payload) {
+    const pc = peers.value[fromId]?.pc;
+    if (!pc) return;
+    if (!pc.remoteDescription) {
+        pendingCandidates[fromId] = pendingCandidates[fromId] ?? [];
+        pendingCandidates[fromId].push(payload.candidate);
+    } else {
+        await pc.addIceCandidate(new RTCIceCandidate(payload.candidate));
+    }
+}
+
+async function drainPendingCandidates(fromId, pc) {
+    for (const c of pendingCandidates[fromId] ?? []) {
+        await pc.addIceCandidate(new RTCIceCandidate(c));
+    }
+    delete pendingCandidates[fromId];
+}
+
+function createPeerConnection(peerId) {
+    const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
+    localStream.value.getTracks().forEach(track => pc.addTrack(track, localStream.value));
+    pc.onicecandidate = ({ candidate }) => {
+        if (candidate) {
+            sendSignal(peerId, 'ice-candidate', { candidate });
+        }
+    };
+    pc.ontrack = ({ streams }) => {
+        peers.value[peerId] = { ...peers.value[peerId], stream: streams[0] };
+    };
+    pc.onconnectionstatechange = () => {
+        if (pc.connectionState === 'failed') {
+            peers.value[peerId] = { ...peers.value[peerId], connectionFailed: true };
+        }
+    };
+    peers.value[peerId] = { pc, stream: null, connectionFailed: false };
+    return pc;
+}
+
+async function processSignal(signal) {
+    const { from_participant_id: fromId, type, payload } = signal;
+
+    if (type === 'key-exchange') {
+        // sender_public_key is included in the payload by the organiser;
+        // fall back to participant cache for backwards compatibility
+        const senderPublicKey = payload.sender_public_key ?? participantPublicKeys[fromId];
+        if (!senderPublicKey) return;
+        const enc = new encryption();
+        groupAesKey = await enc.unwrapCallSessionKey(
+            payload.wrapped_key,
+            sessionData.ecdh_private_key,
+            senderPublicKey
+        );
+        return;
+    }
+
+    if (type === 'offer') {
+        const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
+        await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+        await drainPendingCandidates(fromId, pc);
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        await sendSignal(fromId, 'answer', { sdp: answer });
+        return;
+    }
+
+    if (type === 'answer') {
+        const pc = peers.value[fromId]?.pc;
+        if (pc) {
+            await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+            await drainPendingCandidates(fromId, pc);
+        }
+        return;
+    }
+
+    if (type === 'ice-candidate') {
+        await handleIceCandidate(fromId, payload);
+    }
+}
+
+async function pollParticipants() {
+    try {
+        const { data } = await axios.get(PARTICIPANTS_URL);
+        participantCount.value = data.participants.length;
+        for (const p of data.participants) {
+            if (p.public_key) {
+                participantPublicKeys[p.id] = p.public_key;
+            }
+
+            if (p.id === sessionData.participant_id) continue;
+            if (peers.value[p.id]) continue;
+
+            // Both IDs are UUID strings from call_participants; string < produces a deterministic total order
+            if (sessionData.participant_id < p.id) {
+                // We are the offerer (lower UUID) — also the key organiser
+                if (!groupAesKey) {
+                    const enc = new encryption();
+                    groupAesKey = enc.generateCallSessionAesKey(); // synchronous
+                }
+                const pc = createPeerConnection(p.id);
+                const offer = await pc.createOffer();
+                await pc.setLocalDescription(offer);
+                await sendSignal(p.id, 'offer', { sdp: offer });
+
+                if (p.public_key) {
+                    const enc = new encryption();
+                    const wrappedKey = await enc.wrapCallSessionKey(
+                        groupAesKey,
+                        p.public_key,
+                        sessionData.ecdh_private_key
+                    );
+                    // Include sender_public_key so the receiver can unwrap immediately
+                    // without waiting for a pollParticipants cycle to populate participantPublicKeys
+                    await sendSignal(p.id, 'key-exchange', {
+                        wrapped_key:       wrappedKey,
+                        sender_public_key: sessionData.ecdh_public_key,
+                    });
+                }
+            } else {
+                // We are the answerer — create RTCPeerConnection and wait for their offer
+                createPeerConnection(p.id);
+            }
+        }
+    } catch (_) { /* swallow poll errors */ }
+    participantPollTimer.value = setTimeout(pollParticipants, 3000);
+}
+
+async function pollSignals() {
+    try {
+        const { data } = await axios.get(signalPollUrl(signalCursor.value));
+        for (const signal of data.signals) {
+            await processSignal(signal);
+        }
+        if (data.signals.length > 0) {
+            signalCursor.value = data.signals.at(-1).id;
+        }
+    } catch (_) { /* swallow poll errors */ }
+    signalPollTimer.value = setTimeout(pollSignals, 1500);
+}
+
+function startPolling() {
+    pollParticipants();
+    pollSignals();
+}
+
+function startExpiryCountdown() {
+    const endsAtMs = new Date(props.session.ends_at).getTime();
+    expiryTimer.value = setInterval(() => {
+        const remaining = Math.max(0, Math.floor((endsAtMs - Date.now()) / 1000));
+        timeRemaining.value = remaining;
+        if (remaining === 0) {
+            callEnded.value = true;
+            clearInterval(expiryTimer.value);
+            redirectCountdown.value = 5;
+            redirectTimer.value = setInterval(() => {
+                redirectCountdown.value--;
+                if (redirectCountdown.value <= 0) {
+                    clearInterval(redirectTimer.value);
+                    cleanup();
+                    router.visit(route('calls.index'));
+                }
+            }, 1000);
+        }
+    }, 1000);
+}
+
+function cleanup() {
+    clearTimeout(participantPollTimer.value);
+    clearTimeout(signalPollTimer.value);
+    clearInterval(expiryTimer.value);
+    clearInterval(redirectTimer.value);
+    Object.values(peers.value).forEach(({ pc }) => pc.close());
+    localStream.value?.getTracks().forEach(t => t.stop());
+    sessionStorage.removeItem(storageKey);
+}
+
+function toggleMute() {
+    isMuted.value = !isMuted.value;
+    localStream.value?.getAudioTracks().forEach(t => { t.enabled = !isMuted.value; });
+}
+
+function toggleCamera() {
+    isCameraOff.value = !isCameraOff.value;
+    localStream.value?.getVideoTracks().forEach(t => { t.enabled = !isCameraOff.value; });
+}
+
+function requestLeave()  { confirmingLeave.value = true; }
+function cancelLeave()   { confirmingLeave.value = false; }
+function confirmLeave()  { cleanup(); router.visit(route('calls.index')); }
+
+onMounted(async () => {
+    if (!sessionData) return;
+
+    try {
+        localStream.value = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    } catch (e) {
+        mediaError.value = e.name === 'NotFoundError' ? 'unavailable' : 'denied';
+        return;
+    }
+
+    startPolling();
+    startExpiryCountdown();
+});
+
+onUnmounted(cleanup);
+</script>
+
+<template>
+    <AppLayout title="Secure Line — Call">
+        <div class="dark min-h-screen bg-gray-950">
+
+            <!-- Media permission error screen -->
+            <div v-if="mediaError" class="flex items-center justify-center min-h-screen px-4">
+                <div class="max-w-md w-full bg-gray-900 border border-red-700/50 rounded-xl p-8 space-y-4 text-center">
+                    <div class="text-red-400 font-mono text-xs uppercase tracking-widest mb-2">Permission Required</div>
+                    <h2 class="text-white text-xl font-bold">Camera &amp; Microphone Access Needed</h2>
+                    <p v-if="mediaError === 'unavailable'" class="text-gray-400 text-sm">
+                        No camera or microphone was found on this device. Please connect a webcam and microphone and reload.
+                    </p>
+                    <p v-else class="text-gray-400 text-sm">
+                        Camera and microphone access was denied. To join the call, allow access in your browser settings and reload this page.
+                    </p>
+                    <p class="text-gray-500 text-xs">
+                        In Chrome: click the lock icon in the address bar → Site settings → Allow Camera and Microphone.<br>
+                        In Firefox: click the camera icon in the address bar → Remove block.
+                    </p>
+                    <button
+                        @click="router.visit(route('calls.join', session.bridge_number))"
+                        class="w-full border border-gray-700 text-gray-300 hover:text-white py-2.5 rounded-lg font-mono text-sm transition-colors"
+                    >
+                        ← Back to join page
+                    </button>
+                </div>
+            </div>
+
+            <!-- Call ended overlay -->
+            <div v-else-if="callEnded" class="fixed inset-0 bg-gray-950/95 flex items-center justify-center z-50">
+                <div class="text-center space-y-4">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Call Ended</div>
+                    <h2 class="text-white text-2xl font-bold">This call has ended</h2>
+                    <p class="text-gray-400 text-sm">Returning to home in {{ redirectCountdown }}…</p>
+                </div>
+            </div>
+
+            <!-- Main call UI -->
+            <div v-else-if="sessionData" class="flex flex-col min-h-screen">
+
+                <!-- TURN warning banner -->
+                <div v-if="showTurnWarning" class="bg-amber-900/30 border-b border-amber-700/40 px-4 py-2 flex items-center justify-between gap-4">
+                    <span class="text-amber-300 text-sm">Your network may limit call quality. If you experience issues, try switching to a different connection.</span>
+                    <button @click="showTurnWarning = false" class="text-amber-400 hover:text-amber-200 text-xs font-mono shrink-0">Dismiss</button>
+                </div>
+
+                <!-- Video grid -->
+                <div class="flex-1 p-4">
+                    <div class="grid gap-4 h-full" :class="Object.keys(peers).length === 0 ? 'grid-cols-1' : 'grid-cols-1 sm:grid-cols-2'">
+
+                        <!-- Local video tile -->
+                        <div class="relative bg-gray-900 rounded-xl overflow-hidden aspect-video">
+                            <video
+                                v-if="localStream"
+                                :srcObject="localStream"
+                                autoplay
+                                muted
+                                playsinline
+                                class="w-full h-full object-cover"
+                            />
+                            <div v-else class="flex items-center justify-center h-full text-gray-600">
+                                <span class="font-mono text-sm">Loading camera…</span>
+                            </div>
+                            <div class="absolute bottom-2 left-2 text-xs font-mono text-gamboge-300 bg-gray-950/70 px-2 py-0.5 rounded">You</div>
+                            <div v-if="isMuted" class="absolute top-2 right-2 text-red-400 bg-gray-950/70 rounded-full p-1">
+                                <svg class="size-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 19L5 5m5.5 4.5A4 4 0 0 0 12 12v3m-4 2.5c.8.8 2 1.5 4 1.5s3.2-.7 4-1.5m.5-8.5a4 4 0 0 0-8 0v4"/></svg>
+                            </div>
+                        </div>
+
+                        <!-- Remote video tiles -->
+                        <template v-for="(peer, peerId) in peers" :key="peerId">
+                            <div class="relative bg-gray-900 rounded-xl overflow-hidden aspect-video">
+                                <video
+                                    v-if="peer.stream"
+                                    :srcObject="peer.stream"
+                                    autoplay
+                                    playsinline
+                                    class="w-full h-full object-cover"
+                                />
+                                <div v-else class="flex items-center justify-center h-full text-gray-600">
+                                    <span class="font-mono text-sm animate-pulse">Connecting…</span>
+                                </div>
+                                <!-- Connection failed overlay -->
+                                <div v-if="peer.connectionFailed" class="absolute inset-0 bg-gray-950/80 flex items-center justify-center p-4">
+                                    <p class="text-red-400 text-xs text-center font-mono">
+                                        Connection lost. This may recover automatically — if not, ask the participant to rejoin.
+                                    </p>
+                                </div>
+                            </div>
+                        </template>
+
+                        <!-- Empty state — no peers yet -->
+                        <div v-if="Object.keys(peers).length === 0" class="bg-gray-900/50 border border-gray-700/50 rounded-xl aspect-video flex items-center justify-center">
+                            <p class="text-gray-500 font-mono text-sm animate-pulse">Waiting for others to join…</p>
+                        </div>
+
+                    </div>
+                </div>
+
+                <!-- Controls bar -->
+                <div class="bg-gray-900 border-t border-gray-800 px-4 py-4">
+                    <div class="max-w-lg mx-auto flex items-center justify-between gap-4">
+
+                        <!-- Left — participant count + time -->
+                        <div class="text-xs font-mono text-gray-400 space-y-0.5">
+                            <div>{{ participantCount }} participant{{ participantCount !== 1 ? 's' : '' }}</div>
+                            <div
+                                v-if="timeRemaining !== null"
+                                :class="timeRemaining < 60 ? 'text-red-400 animate-pulse' : 'text-gray-500'"
+                            >
+                                {{ formatTimeRemaining(timeRemaining) }} remaining
+                            </div>
+                        </div>
+
+                        <!-- Centre — mic / camera -->
+                        <div class="flex gap-3">
+                            <button
+                                @click="toggleMute"
+                                :title="isMuted ? 'Unmute' : 'Mute'"
+                                :class="isMuted ? 'bg-red-700 hover:bg-red-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'"
+                                class="p-3 rounded-full transition-colors"
+                            >
+                                <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path v-if="!isMuted" stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"/>
+                                    <path v-else stroke-linecap="round" stroke-linejoin="round" d="M19 19L5 5m5.5 4.5A4 4 0 0 0 12 12v3m-4 2.5c.8.8 2 1.5 4 1.5s3.2-.7 4-1.5m.5-8.5a4 4 0 0 0-8 0v4"/>
+                                </svg>
+                            </button>
+                            <button
+                                @click="toggleCamera"
+                                :title="isCameraOff ? 'Turn camera on' : 'Turn camera off'"
+                                :class="isCameraOff ? 'bg-red-700 hover:bg-red-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'"
+                                class="p-3 rounded-full transition-colors"
+                            >
+                                <svg class="size-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path v-if="!isCameraOff" stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                                    <path v-else stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5 4.72-4.72m0 0a.75.75 0 0 0-1.28.53v11.38a.75.75 0 0 0 1.28.53l4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                                </svg>
+                            </button>
+                        </div>
+
+                        <!-- Right — leave -->
+                        <div class="text-right">
+                            <div v-if="confirmingLeave" class="flex gap-2 items-center">
+                                <span class="text-xs text-gray-400 font-mono">Leave call?</span>
+                                <button @click="cancelLeave" class="text-xs text-gray-400 hover:text-white font-mono border border-gray-700 px-2 py-1 rounded transition-colors">Stay</button>
+                                <button @click="confirmLeave" class="text-xs text-red-400 hover:text-red-300 font-mono border border-red-700 px-2 py-1 rounded transition-colors">Leave call</button>
+                            </div>
+                            <button
+                                v-else
+                                @click="requestLeave"
+                                class="bg-red-800 hover:bg-red-700 text-white font-mono text-sm px-4 py-2 rounded-lg transition-colors"
+                            >
+                                Leave
+                            </button>
+                        </div>
+
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -97,9 +97,21 @@ async function drainPendingCandidates(fromId, pc) {
     delete pendingCandidates[fromId];
 }
 
+function sanitizeSdp(sdpString) {
+    return sdpString.split('\r\n')
+        .map(line => {
+            // Some browsers (Safari, older Chrome) emit a=ssrc lines with a two-token msid value
+            // (stream-id + track-id separated by a space). Chrome's Unified Plan parser rejects the
+            // space inside the msid attribute value. Strip the trailing track-id token.
+            const m = line.match(/^(a=ssrc:\d+ msid:\S+)\s+\S+$/);
+            return m ? m[1] : line;
+        })
+        .join('\r\n');
+}
+
 function createPeerConnection(peerId) {
     console.log('[WebRTC] createPeerConnection', peerId, 'ice_servers:', sessionData.ice_servers);
-    const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
+    const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers, sdpSemantics: 'unified-plan' });
     localStream.value.getTracks().forEach(track => {
         console.log('[WebRTC] addTrack', track.kind, track.label);
         pc.addTrack(track, localStream.value);
@@ -168,7 +180,9 @@ async function processSignal(signal) {
     if (type === 'offer') {
         console.log('[WebRTC] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
-        await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+        const rawSdp = payload.sdp;
+        const cleanSdp = rawSdp?.sdp ? { ...rawSdp, sdp: sanitizeSdp(rawSdp.sdp) } : rawSdp;
+        await pc.setRemoteDescription(new RTCSessionDescription(cleanSdp));
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
@@ -181,7 +195,9 @@ async function processSignal(signal) {
         console.log('[WebRTC] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
-            await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+            const rawSdp = payload.sdp;
+            const cleanSdp = rawSdp?.sdp ? { ...rawSdp, sdp: sanitizeSdp(rawSdp.sdp) } : rawSdp;
+            await pc.setRemoteDescription(new RTCSessionDescription(cleanSdp));
             await drainPendingCandidates(fromId, pc);
         }
         return;
@@ -243,11 +259,16 @@ async function pollParticipants() {
 async function pollSignals() {
     try {
         const { data } = await axios.get(signalPollUrl(signalCursor.value));
-        for (const signal of data.signals) {
-            await processSignal(signal);
-        }
+        // Advance cursor before processing so a failing signal never stalls the queue
         if (data.signals.length > 0) {
             signalCursor.value = data.signals.at(-1).id;
+        }
+        for (const signal of data.signals) {
+            try {
+                await processSignal(signal);
+            } catch (e) {
+                console.error('[WebRTC] processSignal error:', signal.type, e);
+            }
         }
     } catch (e) { console.error('[WebRTC] pollSignals error:', e); }
     signalPollTimer.value = setTimeout(pollSignals, 1500);

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -98,12 +98,11 @@ async function drainPendingCandidates(fromId, pc) {
 }
 
 function sanitizeSdp(sdpString) {
-    // Chrome's Unified Plan SDP parser rejects a=ssrc: msid attributes — they are
-    // Plan B artefacts that Chrome still generates for backwards compatibility but
-    // refuses to accept when parsing received SDP. Remove these lines entirely; the
-    // media-level a=msid: attribute conveys the same MSID information in Unified Plan.
+    // Chrome's Unified Plan parser rejects all a=ssrc: source attributes (cname, msid,
+    // mslabel, label) — they are Plan B artefacts. Remove all of them; Unified Plan
+    // conveys CNAME via RTCP SDES and MSID via the media-level a=msid: attribute.
     return sdpString.split('\r\n')
-        .filter(line => !/^a=ssrc:\d+ msid:/.test(line))
+        .filter(line => !/^a=ssrc:/.test(line))
         .join('\r\n');
 }
 

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -97,21 +97,9 @@ async function drainPendingCandidates(fromId, pc) {
     delete pendingCandidates[fromId];
 }
 
-function sanitizeSdp(sdpString) {
-    return sdpString.split('\r\n')
-        .map(line => {
-            // Some browsers (Safari, older Chrome) emit a=ssrc lines with a two-token msid value
-            // (stream-id + track-id separated by a space). Chrome's Unified Plan parser rejects the
-            // space inside the msid attribute value. Strip the trailing track-id token.
-            const m = line.match(/^(a=ssrc:\d+ msid:\S+)\s+\S+$/);
-            return m ? m[1] : line;
-        })
-        .join('\r\n');
-}
-
 function createPeerConnection(peerId) {
     console.log('[WebRTC] createPeerConnection', peerId, 'ice_servers:', sessionData.ice_servers);
-    const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers, sdpSemantics: 'unified-plan' });
+    const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
     localStream.value.getTracks().forEach(track => {
         console.log('[WebRTC] addTrack', track.kind, track.label);
         pc.addTrack(track, localStream.value);
@@ -180,9 +168,7 @@ async function processSignal(signal) {
     if (type === 'offer') {
         console.log('[WebRTC] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
-        const rawSdp = payload.sdp;
-        const cleanSdp = rawSdp?.sdp ? { ...rawSdp, sdp: sanitizeSdp(rawSdp.sdp) } : rawSdp;
-        await pc.setRemoteDescription(new RTCSessionDescription(cleanSdp));
+        await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
@@ -195,9 +181,7 @@ async function processSignal(signal) {
         console.log('[WebRTC] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
-            const rawSdp = payload.sdp;
-            const cleanSdp = rawSdp?.sdp ? { ...rawSdp, sdp: sanitizeSdp(rawSdp.sdp) } : rawSdp;
-            await pc.setRemoteDescription(new RTCSessionDescription(cleanSdp));
+            await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
             await drainPendingCandidates(fromId, pc);
         }
         return;

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -97,6 +97,16 @@ async function drainPendingCandidates(fromId, pc) {
     delete pendingCandidates[fromId];
 }
 
+function sanitizeSdp(sdpString) {
+    // Chrome's Unified Plan SDP parser rejects a=ssrc: msid attributes — they are
+    // Plan B artefacts that Chrome still generates for backwards compatibility but
+    // refuses to accept when parsing received SDP. Remove these lines entirely; the
+    // media-level a=msid: attribute conveys the same MSID information in Unified Plan.
+    return sdpString.split('\r\n')
+        .filter(line => !/^a=ssrc:\d+ msid:/.test(line))
+        .join('\r\n');
+}
+
 function createPeerConnection(peerId) {
     const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
     localStream.value.getTracks().forEach(track => {
@@ -154,7 +164,10 @@ async function processSignal(signal) {
 
     if (type === 'offer') {
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
-        await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+        const offerSdp = payload.sdp?.sdp
+            ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
+            : payload.sdp;
+        await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
@@ -165,7 +178,10 @@ async function processSignal(signal) {
     if (type === 'answer') {
         const pc = peers.value[fromId]?.pc;
         if (pc) {
-            await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
+            const answerSdp = payload.sdp?.sdp
+                ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
+                : payload.sdp;
+            await pc.setRemoteDescription(new RTCSessionDescription(answerSdp));
             await drainPendingCandidates(fromId, pc);
         }
         return;

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -108,22 +108,33 @@ function sanitizeSdp(sdpString) {
 }
 
 function createPeerConnection(peerId) {
+    console.log('[D] createPeerConnection', peerId, 'iceServers:', JSON.stringify(sessionData.ice_servers));
     const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
     localStream.value.getTracks().forEach(track => {
+        console.log('[D] addTrack', track.kind, track.label);
         pc.addTrack(track, localStream.value);
     });
     pc.onicecandidate = ({ candidate }) => {
+        console.log('[D] icecandidate', candidate ? candidate.type + ' ' + candidate.protocol : 'null (gathering complete)');
         if (candidate) {
             sendSignal(peerId, 'ice-candidate', { candidate });
         }
     };
+    pc.onicegatheringstatechange = () => {
+        console.log('[D] iceGatheringState ->', pc.iceGatheringState);
+    };
+    pc.oniceconnectionstatechange = () => {
+        console.log('[D] iceConnectionState ->', pc.iceConnectionState);
+    };
     pc.onconnectionstatechange = () => {
+        console.log('[D] connectionState ->', pc.connectionState);
         if (pc.connectionState === 'failed') {
             // Spread to a new object so Vue 3 detects the change
             peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
         }
     };
-    pc.ontrack = ({ streams }) => {
+    pc.ontrack = ({ streams, track }) => {
+        console.log('[D] ontrack', track.kind, 'streams:', streams.length);
         if (streams[0]) {
             // Play remote audio via a hidden <audio> element (audio-only call)
             if (!remoteAudioElements[peerId]) {
@@ -135,7 +146,9 @@ function createPeerConnection(peerId) {
             }
             remoteAudioElements[peerId].srcObject = streams[0];
             // Autoplay may be blocked after Inertia client-side navigation; call play() explicitly
-            remoteAudioElements[peerId].play().catch(() => { });
+            remoteAudioElements[peerId].play()
+                .then(() => console.log('[D] audio.play() resolved'))
+                .catch(err => console.log('[D] audio.play() rejected:', err.message));
         }
     };
     // Spread to a new object so Vue 3 detects the key addition
@@ -161,25 +174,30 @@ async function processSignal(signal) {
     }
 
     if (type === 'offer') {
+        console.log('[D] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
         const offerSdp = payload.sdp?.sdp
             ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
             : payload.sdp;
         await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
+        console.log('[D] setRemoteDescription (offer) OK, signalingState:', pc.signalingState);
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
         await sendSignal(fromId, 'answer', { sdp: answer });
+        console.log('[D] answer sent to', fromId);
         return;
     }
 
     if (type === 'answer') {
+        console.log('[D] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
             const answerSdp = payload.sdp?.sdp
                 ? { ...payload.sdp, sdp: sanitizeSdp(payload.sdp.sdp) }
                 : payload.sdp;
             await pc.setRemoteDescription(new RTCSessionDescription(answerSdp));
+            console.log('[D] setRemoteDescription (answer) OK, signalingState:', pc.signalingState);
             await drainPendingCandidates(fromId, pc);
         }
         return;
@@ -212,6 +230,7 @@ async function pollParticipants() {
                 const pc = createPeerConnection(p.id);
                 const offer = await pc.createOffer();
                 await pc.setLocalDescription(offer);
+                console.log('[D] sending offer to', p.id);
                 await sendSignal(p.id, 'offer', { sdp: offer });
 
                 if (p.public_key) {
@@ -233,7 +252,7 @@ async function pollParticipants() {
                 createPeerConnection(p.id);
             }
         }
-    } catch (e) { }
+    } catch (e) { console.log('[D] pollParticipants error:', e.message); }
     participantPollTimer.value = setTimeout(pollParticipants, 3000);
 }
 
@@ -247,9 +266,9 @@ async function pollSignals() {
         for (const signal of data.signals) {
             try {
                 await processSignal(signal);
-            } catch (e) { }
+            } catch (e) { console.log('[D] processSignal error:', signal.type, e.message); }
         }
-    } catch (e) { }
+    } catch (e) { console.log('[D] pollSignals error:', e.message); }
     signalPollTimer.value = setTimeout(pollSignals, 1500);
 }
 

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -42,6 +42,9 @@ const redirectTimer = ref(null);
 // ICE candidate queue — plain object, not reactive
 const pendingCandidates = {};
 
+// Guard against duplicate leave calls (cleanup() fires from both confirmLeave and onUnmounted)
+let hasCalledLeave = false;
+
 // Participant ECDH public key cache — populated during participant polling
 const participantPublicKeys = {};
 
@@ -113,6 +116,8 @@ function createPeerConnection(peerId) {
                 remoteAudioElements[peerId] = audio;
             }
             remoteAudioElements[peerId].srcObject = streams[0];
+            // Autoplay may be blocked after Inertia client-side navigation; call play() explicitly
+            remoteAudioElements[peerId].play().catch(() => {});
         }
     };
     pc.onconnectionstatechange = () => {
@@ -253,7 +258,19 @@ function startExpiryCountdown() {
     }, 1000);
 }
 
+function leaveCall() {
+    if (!sessionData?.participant_id || hasCalledLeave) return;
+    hasCalledLeave = true;
+    fetch(`/api/v1/calls/${props.session.bridge_number}/leave`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participant_id: sessionData.participant_id }),
+        keepalive: true,
+    }).catch(() => {});
+}
+
 function cleanup() {
+    leaveCall();
     clearTimeout(participantPollTimer.value);
     clearTimeout(signalPollTimer.value);
     clearInterval(expiryTimer.value);

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -108,7 +108,12 @@ function createPeerConnection(peerId) {
         if (candidate) {
             console.log('[WebRTC] onicecandidate', candidate.type, candidate.protocol, candidate.address);
             sendSignal(peerId, 'ice-candidate', { candidate });
+        } else {
+            console.log('[WebRTC] ICE gathering complete');
         }
+    };
+    pc.onicegatheringstatechange = () => {
+        console.log('[WebRTC] iceGatheringState →', pc.iceGatheringState);
     };
     pc.oniceconnectionstatechange = () => {
         console.log('[WebRTC] iceConnectionState →', pc.iceConnectionState);
@@ -210,6 +215,7 @@ async function pollParticipants() {
                 const offer = await pc.createOffer();
                 await pc.setLocalDescription(offer);
                 await sendSignal(p.id, 'offer', { sdp: offer });
+                console.log('[WebRTC] offer sent to', p.id);
 
                 if (p.public_key) {
                     const enc = new encryption();
@@ -230,7 +236,7 @@ async function pollParticipants() {
                 createPeerConnection(p.id);
             }
         }
-    } catch (_) { /* swallow poll errors */ }
+    } catch (e) { console.error('[WebRTC] pollParticipants error:', e); }
     participantPollTimer.value = setTimeout(pollParticipants, 3000);
 }
 
@@ -243,7 +249,7 @@ async function pollSignals() {
         if (data.signals.length > 0) {
             signalCursor.value = data.signals.at(-1).id;
         }
-    } catch (_) { /* swallow poll errors */ }
+    } catch (e) { console.error('[WebRTC] pollSignals error:', e); }
     signalPollTimer.value = setTimeout(pollSignals, 1500);
 }
 

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -101,9 +101,12 @@ function sanitizeSdp(sdpString) {
     // Chrome's Unified Plan parser rejects all a=ssrc: source attributes (cname, msid,
     // mslabel, label) — they are Plan B artefacts. Remove all of them; Unified Plan
     // conveys CNAME via RTCP SDES and MSID via the media-level a=msid: attribute.
-    return sdpString.split('\r\n')
-        .filter(line => !/^a=ssrc:/.test(line))
-        .join('\r\n');
+    const lines = sdpString.split('\r\n');
+    const filtered = lines.filter(line => !/^a=ssrc:/.test(line));
+    console.log('[D] sanitizeSdp: lines before:', lines.length, 'after:', filtered.length, '(removed', lines.length - filtered.length, 'a=ssrc: lines)');
+    const result = filtered.join('\r\n');
+    console.log('[D] sanitized SDP dump:\n' + result);
+    return result;
 }
 
 function createPeerConnection(peerId) {

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -98,35 +98,24 @@ async function drainPendingCandidates(fromId, pc) {
 }
 
 function createPeerConnection(peerId) {
-    console.log('[WebRTC] createPeerConnection', peerId, 'ice_servers:', sessionData.ice_servers);
     const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
     localStream.value.getTracks().forEach(track => {
-        console.log('[WebRTC] addTrack', track.kind, track.label);
         pc.addTrack(track, localStream.value);
     });
     pc.onicecandidate = ({ candidate }) => {
         if (candidate) {
-            console.log('[WebRTC] onicecandidate', candidate.type, candidate.protocol, candidate.address);
             sendSignal(peerId, 'ice-candidate', { candidate });
-        } else {
-            console.log('[WebRTC] ICE gathering complete');
         }
     };
-    pc.onicegatheringstatechange = () => {
-        console.log('[WebRTC] iceGatheringState →', pc.iceGatheringState);
-    };
-    pc.oniceconnectionstatechange = () => {
-        console.log('[WebRTC] iceConnectionState →', pc.iceConnectionState);
-    };
+    pc.onicegatheringstatechange = () => { };
+    pc.oniceconnectionstatechange = () => { };
     pc.onconnectionstatechange = () => {
-        console.log('[WebRTC] connectionState →', pc.connectionState);
         if (pc.connectionState === 'failed') {
             // Spread to a new object so Vue 3 detects the change
             peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
         }
     };
-    pc.ontrack = ({ streams, track }) => {
-        console.log('[WebRTC] ontrack', track.kind, 'streams:', streams.length);
+    pc.ontrack = ({ streams }) => {
         if (streams[0]) {
             // Play remote audio via a hidden <audio> element (audio-only call)
             if (!remoteAudioElements[peerId]) {
@@ -138,9 +127,7 @@ function createPeerConnection(peerId) {
             }
             remoteAudioElements[peerId].srcObject = streams[0];
             // Autoplay may be blocked after Inertia client-side navigation; call play() explicitly
-            remoteAudioElements[peerId].play()
-                .then(() => console.log('[WebRTC] audio.play() succeeded'))
-                .catch(err => console.warn('[WebRTC] audio.play() rejected:', err));
+            remoteAudioElements[peerId].play().catch(() => { });
         }
     };
     // Spread to a new object so Vue 3 detects the key addition
@@ -166,19 +153,16 @@ async function processSignal(signal) {
     }
 
     if (type === 'offer') {
-        console.log('[WebRTC] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
         await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
         await sendSignal(fromId, 'answer', { sdp: answer });
-        console.log('[WebRTC] answer sent to', fromId);
         return;
     }
 
     if (type === 'answer') {
-        console.log('[WebRTC] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
             await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
@@ -215,7 +199,6 @@ async function pollParticipants() {
                 const offer = await pc.createOffer();
                 await pc.setLocalDescription(offer);
                 await sendSignal(p.id, 'offer', { sdp: offer });
-                console.log('[WebRTC] offer sent to', p.id);
 
                 if (p.public_key) {
                     const enc = new encryption();
@@ -325,11 +308,8 @@ onMounted(async () => {
         return;
     }
 
-    console.log('[WebRTC] sessionData.ice_servers:', JSON.stringify(sessionData.ice_servers));
-
     try {
         localStream.value = await navigator.mediaDevices.getUserMedia({ audio: true });
-        console.log('[WebRTC] getUserMedia ok, tracks:', localStream.value.getTracks().map(t => t.kind));
     } catch (e) {
         mediaError.value = e.name === 'NotFoundError' ? 'unavailable' : 'denied';
         return;

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -15,9 +15,6 @@ const props = defineProps({
 
 const storageKey = `call_session:${props.session.bridge_number}`;
 const raw = sessionStorage.getItem(storageKey);
-if (!raw) {
-    router.visit(route('calls.join', props.session.bridge_number));
-}
 const sessionData = raw ? JSON.parse(raw) : null;
 
 // Reactive state
@@ -280,7 +277,10 @@ function cancelLeave()   { confirmingLeave.value = false; }
 function confirmLeave()  { cleanup(); router.visit(route('calls.index')); }
 
 onMounted(async () => {
-    if (!sessionData) return;
+    if (!sessionData) {
+        router.visit(route('calls.join', props.session.bridge_number));
+        return;
+    }
 
     try {
         localStream.value = await navigator.mediaDevices.getUserMedia({ audio: true });

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -101,10 +101,14 @@ function sanitizeSdp(sdpString) {
     // Chrome's Unified Plan parser rejects all a=ssrc: source attributes (cname, msid,
     // mslabel, label) — they are Plan B artefacts. Remove all of them; Unified Plan
     // conveys CNAME via RTCP SDES and MSID via the media-level a=msid: attribute.
+    //
+    // After filtering, rejoin and guarantee a trailing \r\n. Chrome's SDP parser
+    // treats the last line as invalid if it is not CRLF-terminated.
     const lines = sdpString.split('\r\n');
     const filtered = lines.filter(line => !/^a=ssrc:/.test(line));
-    console.log('[D] sanitizeSdp: lines before:', lines.length, 'after:', filtered.length, '(removed', lines.length - filtered.length, 'a=ssrc: lines)');
-    const result = filtered.join('\r\n');
+    console.log('[D] sanitizeSdp: lines before:', lines.length, 'after:', filtered.length, '(removed', lines.length - filtered.length, 'a=ssrc: lines)', '| input ends CRLF:', sdpString.endsWith('\r\n'));
+    const joined = filtered.join('\r\n');
+    const result = joined.endsWith('\r\n') ? joined : joined + '\r\n';
     console.log('[D] sanitized SDP dump:\n' + result);
     return result;
 }

--- a/resources/js/Pages/Call/Room.vue
+++ b/resources/js/Pages/Call/Room.vue
@@ -98,14 +98,30 @@ async function drainPendingCandidates(fromId, pc) {
 }
 
 function createPeerConnection(peerId) {
+    console.log('[WebRTC] createPeerConnection', peerId, 'ice_servers:', sessionData.ice_servers);
     const pc = new RTCPeerConnection({ iceServers: sessionData.ice_servers });
-    localStream.value.getTracks().forEach(track => pc.addTrack(track, localStream.value));
+    localStream.value.getTracks().forEach(track => {
+        console.log('[WebRTC] addTrack', track.kind, track.label);
+        pc.addTrack(track, localStream.value);
+    });
     pc.onicecandidate = ({ candidate }) => {
         if (candidate) {
+            console.log('[WebRTC] onicecandidate', candidate.type, candidate.protocol, candidate.address);
             sendSignal(peerId, 'ice-candidate', { candidate });
         }
     };
-    pc.ontrack = ({ streams }) => {
+    pc.oniceconnectionstatechange = () => {
+        console.log('[WebRTC] iceConnectionState →', pc.iceConnectionState);
+    };
+    pc.onconnectionstatechange = () => {
+        console.log('[WebRTC] connectionState →', pc.connectionState);
+        if (pc.connectionState === 'failed') {
+            // Spread to a new object so Vue 3 detects the change
+            peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
+        }
+    };
+    pc.ontrack = ({ streams, track }) => {
+        console.log('[WebRTC] ontrack', track.kind, 'streams:', streams.length);
         if (streams[0]) {
             // Play remote audio via a hidden <audio> element (audio-only call)
             if (!remoteAudioElements[peerId]) {
@@ -117,13 +133,9 @@ function createPeerConnection(peerId) {
             }
             remoteAudioElements[peerId].srcObject = streams[0];
             // Autoplay may be blocked after Inertia client-side navigation; call play() explicitly
-            remoteAudioElements[peerId].play().catch(() => {});
-        }
-    };
-    pc.onconnectionstatechange = () => {
-        if (pc.connectionState === 'failed') {
-            // Spread to a new object so Vue 3 detects the change
-            peers.value = { ...peers.value, [peerId]: { ...peers.value[peerId], connectionFailed: true } };
+            remoteAudioElements[peerId].play()
+                .then(() => console.log('[WebRTC] audio.play() succeeded'))
+                .catch(err => console.warn('[WebRTC] audio.play() rejected:', err));
         }
     };
     // Spread to a new object so Vue 3 detects the key addition
@@ -149,16 +161,19 @@ async function processSignal(signal) {
     }
 
     if (type === 'offer') {
+        console.log('[WebRTC] processSignal: offer from', fromId);
         const pc = peers.value[fromId]?.pc ?? createPeerConnection(fromId);
         await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
         await drainPendingCandidates(fromId, pc);
         const answer = await pc.createAnswer();
         await pc.setLocalDescription(answer);
         await sendSignal(fromId, 'answer', { sdp: answer });
+        console.log('[WebRTC] answer sent to', fromId);
         return;
     }
 
     if (type === 'answer') {
+        console.log('[WebRTC] processSignal: answer from', fromId);
         const pc = peers.value[fromId]?.pc;
         if (pc) {
             await pc.setRemoteDescription(new RTCSessionDescription(payload.sdp));
@@ -299,8 +314,11 @@ onMounted(async () => {
         return;
     }
 
+    console.log('[WebRTC] sessionData.ice_servers:', JSON.stringify(sessionData.ice_servers));
+
     try {
         localStream.value = await navigator.mediaDevices.getUserMedia({ audio: true });
+        console.log('[WebRTC] getUserMedia ok, tracks:', localStream.value.getTracks().map(t => t.kind));
     } catch (e) {
         mediaError.value = e.name === 'NotFoundError' ? 'unavailable' : 'denied';
         return;

--- a/resources/js/encryption.js
+++ b/resources/js/encryption.js
@@ -9,6 +9,7 @@ import {
     deriveKeyFromFile, combineLockerKeyMaterials,
     generateCallEphemeralKeypair, generateCallSessionAesKey,
     wrapCallSessionKey, unwrapCallSessionKey,
+    deriveCallKeyPair, signCallChallenge,
 } from '@pioneer-dynamics/flashview-crypto';
 export { LockerBlobVersionError, LockerDecryptionError } from '@pioneer-dynamics/flashview-crypto';
 
@@ -134,6 +135,14 @@ export class encryption {
 
     async combineLockerKeyMaterials(materials) {
         return combineLockerKeyMaterials(materials);
+    }
+
+    async deriveCallKeyPair(password, saltBase64) {
+        return deriveCallKeyPair(password, saltBase64);
+    }
+
+    signCallChallenge(privateKeyBytes, challengeHex) {
+        return signCallChallenge(privateKeyBytes, challengeHex);
     }
 
     async generateCallEphemeralKeypair() {

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,5 +91,8 @@ Route::prefix('v1')->as('api.v1.')->group(function () {
         Route::get('{callSession}/signal', [CallSignalController::class, 'index'])
             ->name('signal.index')
             ->middleware('throttle:call-signal-poll');
+        Route::post('{callSession}/leave', [CallSignalController::class, 'leave'])
+            ->name('leave')
+            ->middleware('throttle:call-signal-poll');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Admin\AdminPlanController;
 use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\BlogController;
+use App\Http\Controllers\CallPageController;
 use App\Http\Controllers\CallSessionController;
 use App\Http\Controllers\CliAuthController;
 use App\Http\Controllers\CliDeviceController;
@@ -232,6 +233,13 @@ Route::middleware([
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::post('users/{user}/suspend', [AdminUserController::class, 'suspend'])->name('users.suspend');
     Route::delete('users/{user}/suspend', [AdminUserController::class, 'unsuspend'])->name('users.unsuspend');
+});
+
+// Call page routes — Inertia views; no auth required
+Route::prefix('calls')->name('calls.')->group(function () {
+    Route::get('/', [CallPageController::class, 'index'])->name('index');
+    Route::get('/{callSession}', [CallPageController::class, 'show'])->name('join');
+    Route::get('/{callSession}/room', [CallPageController::class, 'room'])->name('room');
 });
 
 // Call session routes — no auth required; Ed25519 challenge-response verifies access

--- a/tests/Feature/Call/CallPageTest.php
+++ b/tests/Feature/Call/CallPageTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Call;
+
+use App\Models\CallSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CallPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_call_index_page_renders(): void
+    {
+        $response = $this->get('/calls');
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page->component('Call/Index'));
+    }
+
+    public function test_call_join_page_renders_for_active_session(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $response = $this->get("/calls/{$session->hash_id}");
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Join')
+                ->where('session.bridge_number', $session->hash_id)
+                ->where('session.is_active', true)
+            );
+    }
+
+    public function test_call_join_page_shows_future_session_as_not_active(): void
+    {
+        $session = CallSession::factory()->notYetStarted()->create();
+
+        $response = $this->get("/calls/{$session->hash_id}");
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Join')
+                ->where('session.is_active', false)
+            );
+    }
+
+    public function test_call_join_page_returns_404_for_invalid_hash(): void
+    {
+        $response = $this->get('/calls/invalidhash');
+
+        $response->assertNotFound();
+    }
+
+    public function test_call_room_page_renders(): void
+    {
+        $session = CallSession::factory()->create();
+
+        $response = $this->get("/calls/{$session->hash_id}/room");
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Room')
+                ->where('session.bridge_number', $session->hash_id)
+            );
+    }
+
+    public function test_call_room_page_returns_404_for_invalid_hash(): void
+    {
+        $response = $this->get('/calls/invalidhash/room');
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/Call/CallSignalTest.php
+++ b/tests/Feature/Call/CallSignalTest.php
@@ -28,6 +28,55 @@ class CallSignalTest extends TestCase
         return CallParticipant::factory()->for($session, 'session')->create();
     }
 
+    // ─── leave ────────────────────────────────────────────────────────────────
+
+    public function test_leave_marks_participant_as_left(): void
+    {
+        $session = $this->activeSession();
+        $participant = $this->participantIn($session);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/leave", [
+            'participant_id' => $participant->id,
+        ]);
+
+        $response->assertOk();
+        $this->assertNotNull($participant->fresh()->left_at);
+    }
+
+    public function test_leave_returns_404_when_participant_not_in_session(): void
+    {
+        $session = $this->activeSession();
+        $otherSession = $this->activeSession();
+        $participant = $this->participantIn($otherSession);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/leave", [
+            'participant_id' => $participant->id,
+        ]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_leave_is_idempotent_when_participant_already_left(): void
+    {
+        $session = $this->activeSession();
+        $participant = CallParticipant::factory()->for($session, 'session')->create(['left_at' => now()->subMinute()]);
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/leave", [
+            'participant_id' => $participant->id,
+        ]);
+
+        $response->assertOk();
+    }
+
+    public function test_leave_returns_422_when_participant_id_is_missing(): void
+    {
+        $session = $this->activeSession();
+
+        $response = $this->postJson("/api/v1/calls/{$session->hash_id}/leave", []);
+
+        $response->assertUnprocessable()->assertJsonValidationErrors(['participant_id']);
+    }
+
     // ─── participants ──────────────────────────────────────────────────────────
 
     public function test_participants_returns_active_participants(): void

--- a/tests/e2e/call-index.spec.ts
+++ b/tests/e2e/call-index.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from './helpers/db';
+import { createActiveCallSession } from './helpers/calls';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+test('navigating to /calls renders the Secure Line index page with a bridge number input', async ({ page }) => {
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Secure Line')).toBeVisible();
+    await expect(page.getByTestId('bridge-number-input')).toBeVisible();
+    await expect(page.getByTestId('join-line-button')).toBeVisible();
+});
+
+test('entering a bridge number and clicking Join Line navigates to the join page', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bridge-number-input').fill(hashId);
+    await page.getByTestId('join-line-button').click();
+
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(`/calls/${hashId}`);
+});
+
+test('pressing Enter in the bridge number input navigates to the join page', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bridge-number-input').fill(hashId);
+    await page.getByTestId('bridge-number-input').press('Enter');
+
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(`/calls/${hashId}`);
+});
+
+test('submitting an empty bridge number does not navigate', async ({ page }) => {
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('join-line-button').click();
+
+    await expect(page).toHaveURL('/calls');
+});
+
+test('the Join Line button is disabled when the bridge number input is empty', async ({ page }) => {
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('join-line-button')).toBeDisabled();
+});
+
+test('the Buy a Line card is visible with a link to plans', async ({ page }) => {
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Buy a Line')).toBeVisible();
+    await expect(page.getByText('Buy a Line →')).toBeVisible();
+});

--- a/tests/e2e/call-index.spec.ts
+++ b/tests/e2e/call-index.spec.ts
@@ -10,7 +10,7 @@ test('navigating to /calls renders the Secure Line index page with a bridge numb
     await page.goto('/calls');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('Encrypted, Ephemeral Video Calls')).toBeVisible();
+    await expect(page.getByText('Encrypted, Ephemeral Audio Calls')).toBeVisible();
     await expect(page.getByTestId('bridge-number-input')).toBeVisible();
     await expect(page.getByTestId('join-line-button')).toBeVisible();
 });

--- a/tests/e2e/call-index.spec.ts
+++ b/tests/e2e/call-index.spec.ts
@@ -10,7 +10,7 @@ test('navigating to /calls renders the Secure Line index page with a bridge numb
     await page.goto('/calls');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('Secure Line')).toBeVisible();
+    await expect(page.getByText('Encrypted, Ephemeral Video Calls')).toBeVisible();
     await expect(page.getByTestId('bridge-number-input')).toBeVisible();
     await expect(page.getByTestId('join-line-button')).toBeVisible();
 });
@@ -45,7 +45,8 @@ test('submitting an empty bridge number does not navigate', async ({ page }) => 
     await page.goto('/calls');
     await page.waitForLoadState('networkidle');
 
-    await page.getByTestId('join-line-button').click();
+    // Button is disabled when input is empty — force-click to verify navigation is blocked
+    await page.getByTestId('join-line-button').click({ force: true });
 
     await expect(page).toHaveURL('/calls');
 });
@@ -61,6 +62,6 @@ test('the Buy a Line card is visible with a link to plans', async ({ page }) => 
     await page.goto('/calls');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('Buy a Line')).toBeVisible();
+    await expect(page.getByText('Buy a Line', { exact: true })).toBeVisible();
     await expect(page.getByText('Buy a Line →')).toBeVisible();
 });

--- a/tests/e2e/call-join.spec.ts
+++ b/tests/e2e/call-join.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from './helpers/db';
+import { createActiveCallSession, createFutureCallSession } from './helpers/calls';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+test('navigating to an active session renders the Join page with the bridge number', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto(`/calls/${hashId}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(hashId)).toBeVisible();
+    await expect(page.getByTestId('call-password-input')).toBeVisible();
+    await expect(page.getByTestId('join-call-button')).toBeVisible();
+});
+
+test('navigating to a future session shows a "not yet started" message and a disabled button', async ({ page }) => {
+    const hashId = createFutureCallSession();
+
+    await page.goto(`/calls/${hashId}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Not Yet Started')).toBeVisible();
+    await expect(page.getByText(/This call starts at/i)).toBeVisible();
+    // The join button should be disabled (shown as a static disabled element for not-yet-started)
+    const disabledBtn = page.locator('button[disabled]:has-text("Join Call")');
+    await expect(disabledBtn).toBeVisible();
+});
+
+test('navigating to an invalid bridge number returns a 404 page', async ({ page }) => {
+    const response = await page.goto('/calls/invalidhash000');
+    expect(response?.status()).toBe(404);
+});
+
+test('the Join Call button is disabled when password input is empty', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto(`/calls/${hashId}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('join-call-button')).toBeDisabled();
+});
+
+test('typing in the password field enables the Join Call button', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto(`/calls/${hashId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('call-password-input').fill('any-password');
+    await expect(page.getByTestId('join-call-button')).toBeEnabled();
+});

--- a/tests/e2e/call-room.spec.ts
+++ b/tests/e2e/call-room.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from './helpers/db';
+import { createActiveCallSession } from './helpers/calls';
+
+/**
+ * Full WebRTC room interaction tests (media tracks, peer connection establishment)
+ * require two concurrent browser contexts with media stream mocking. These are
+ * deferred to a dedicated follow-up E2E ticket.
+ *
+ * This file covers only the guards and expiry-adjacent behaviours that can be
+ * tested without live media or a second participant.
+ */
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+test('navigating directly to /room without sessionStorage redirects to the join page', async ({ page }) => {
+    const hashId = createActiveCallSession();
+
+    await page.goto(`/calls/${hashId}/room`);
+    await page.waitForLoadState('networkidle');
+
+    // Room.vue reads sessionStorage on mount; if missing it immediately redirects
+    await expect(page).toHaveURL(`/calls/${hashId}`);
+    await expect(page.getByTestId('call-password-input')).toBeVisible();
+});
+
+test('navigating to an invalid bridge number on /room returns a 404', async ({ page }) => {
+    const response = await page.goto('/calls/invalidhash000/room');
+    expect(response?.status()).toBe(404);
+});

--- a/tests/e2e/helpers/calls.ts
+++ b/tests/e2e/helpers/calls.ts
@@ -1,0 +1,29 @@
+import { execSync } from 'child_process';
+
+const ARTISAN = process.env.CI ? 'php artisan' : 'vendor/bin/sail artisan';
+
+/**
+ * Create an active call session via tinker and return its hash_id.
+ */
+export function createActiveCallSession(): string {
+    const output = execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="echo json_encode(['hash_id' => App\\\\Models\\\\CallSession::factory()->create()->hash_id]);"`,
+        { stdio: 'pipe' }
+    ).toString().trim();
+    const match = output.match(/\{"hash_id":"([^"]+)"\}/);
+    if (!match) throw new Error(`Could not extract hash_id from tinker output: ${output}`);
+    return match[1];
+}
+
+/**
+ * Create a call session that starts in the future via tinker and return its hash_id.
+ */
+export function createFutureCallSession(): string {
+    const output = execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="echo json_encode(['hash_id' => App\\\\Models\\\\CallSession::factory()->notYetStarted()->create()->hash_id]);"`,
+        { stdio: 'pipe' }
+    ).toString().trim();
+    const match = output.match(/\{"hash_id":"([^"]+)"\}/);
+    if (!match) throw new Error(`Could not extract hash_id from tinker output: ${output}`);
+    return match[1];
+}


### PR DESCRIPTION
## Summary

- Adds the **Secure Line** call UI — three Inertia pages (`Call/Index`, `Call/Join`, `Call/Room`) backed by a stateless `CallPageController`
- Wires Ed25519 challenge-response auth (`deriveCallKeyPair`, `signCallChallenge`) from `flashview-crypto` into `encryption.js` for use in Join.vue
- Adds `Secure Line` nav link to `AppLayout.vue` (desktop + mobile) pointing at `calls.index`
- Full WebRTC peer connection in Room.vue: ICE candidate queuing, deterministic offerer election (lower UUID = offerer), P-256 ECDH group key exchange with AES-GCM, and `setTimeout`-chained signal/participant polling to prevent overlap
- Session data bridged from Join → Room via `sessionStorage`; redirect guard fires in `onMounted` if sessionStorage is absent

## Files Changed

| Layer | Files |
|---|---|
| Backend | `app/Http/Controllers/CallPageController.php`, `routes/web.php` |
| Frontend | `resources/js/Pages/Call/Index.vue`, `Join.vue`, `Room.vue`, `resources/js/Layouts/AppLayout.vue`, `resources/js/encryption.js` |
| Tests | `tests/Feature/Call/CallPageTest.php`, `tests/e2e/call-index.spec.ts`, `tests/e2e/call-join.spec.ts`, `tests/e2e/call-room.spec.ts`, `tests/e2e/helpers/calls.ts` |

## Test plan

- [ ] Run PHPUnit: `php artisan test tests/Feature/Call/CallPageTest.php` — 6 tests must pass
- [ ] Run Playwright (Sail must be running): `npx playwright test tests/e2e/call-index.spec.ts tests/e2e/call-join.spec.ts tests/e2e/call-room.spec.ts` — 13 tests must pass
- [ ] Navigate to `/calls` — verify two equal-weight cards: "Join a Line" and "Buy a Line"
- [ ] Enter a valid bridge number → verify redirect to `/calls/{hashId}`
- [ ] On Join page, leave password empty → Join Call button must be disabled
- [ ] On Join page, enter password → Join Call button enables; submit → verify TURN warning interstitial (if TURN is degraded) or direct Room redirect
- [ ] Navigate directly to `/calls/{hashId}/room` without joining → verify redirect back to Join page
- [ ] Verify `Secure Line` nav link appears in desktop and mobile menus

## Regression risks (informational)

- `calls.join` route name exists in both `web.php` (Inertia page) and `api.php` (`api.v1.calls.join`). Ziggy resolves `route('calls.join')` to the web route correctly — verified via `php artisan route:list --name=calls.join`. No conflict.
- `deriveCallKeyPair` and `signCallChallenge` are consumed from `@pioneer-dynamics/flashview-crypto` (local workspace) — no publish step needed, but verify the workspace symlink is intact after fresh `npm install`.