### PR TITLE
PIO-121: Admin — Secure Line product management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,8 @@ TRUSTED_PROXIES=*
 ACCESS_ALLOWED_EMAILS=
 
 # Comma-separated list of email addresses with admin access to /admin/plans.
-ADMIN_EMAILS=
+# admin@flashview.test is reserved for E2E tests — keep it in this list for automated testing.
+ADMIN_EMAILS=admin@flashview.test
 
 # Note: eLocker Stripe Price IDs are managed in the Admin panel (Admin → eLocker Plans)
 # and stored in the database — no env vars needed.

--- a/app/Http/Controllers/Admin/AdminSecureLineProductController.php
+++ b/app/Http/Controllers/Admin/AdminSecureLineProductController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreSecureLineProductRequest;
+use App\Http\Requests\UpdateSecureLineProductRequest;
+use App\Models\SecureLineProduct;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Cashier\Cashier;
+
+class AdminSecureLineProductController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Admin/SecureLineProducts/Index', [
+            'products' => SecureLineProduct::orderBy('duration_minutes')->get(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Admin/SecureLineProducts/Form', [
+            'product' => null,
+            'defaultStripeMode' => app()->environment('production') ? 'create' : 'map',
+        ]);
+    }
+
+    public function store(StoreSecureLineProductRequest $request): RedirectResponse
+    {
+        $priceId = $request->input('stripe_price_id');
+
+        if ($request->boolean('create_stripe_price')) {
+            $priceId = $this->createStripePrice($request);
+            if (! $priceId) {
+                return redirect()->back()->with('flash', ['error' => 'Failed to create Stripe price. Check logs.']);
+            }
+        }
+
+        SecureLineProduct::create([
+            'name' => $request->input('name'),
+            'duration_minutes' => (int) $request->input('duration_minutes'),
+            'max_participants' => (int) $request->input('max_participants'),
+            'amount_cents' => (int) $request->input('amount_cents'),
+            'stripe_price_id' => $priceId,
+            'is_active' => $request->boolean('is_active', true),
+        ]);
+
+        return redirect()->route('admin.secure-line-products.index')
+            ->with('flash', ['success' => 'Secure Line product created.']);
+    }
+
+    public function edit(SecureLineProduct $secureLineProduct): Response
+    {
+        return Inertia::render('Admin/SecureLineProducts/Form', [
+            'product' => $secureLineProduct,
+            'defaultStripeMode' => 'map',
+        ]);
+    }
+
+    public function update(UpdateSecureLineProductRequest $request, SecureLineProduct $secureLineProduct): RedirectResponse
+    {
+        // Fall back to the existing price ID if the admin doesn't re-enter it
+        $priceId = $request->input('stripe_price_id') ?? $secureLineProduct->stripe_price_id;
+
+        if ($request->boolean('create_stripe_price')) {
+            $priceId = $this->createStripePrice($request);
+            if (! $priceId) {
+                return redirect()->back()->with('flash', ['error' => 'Failed to create Stripe price. Check logs.']);
+            }
+        }
+
+        $secureLineProduct->update([
+            'name' => $request->input('name'),
+            'duration_minutes' => (int) $request->input('duration_minutes'),
+            'max_participants' => (int) $request->input('max_participants'),
+            'amount_cents' => (int) $request->input('amount_cents'),
+            'stripe_price_id' => $priceId,
+            'is_active' => $request->boolean('is_active', true),
+        ]);
+
+        return redirect()->route('admin.secure-line-products.index')
+            ->with('flash', ['success' => 'Secure Line product updated.']);
+    }
+
+    public function destroy(SecureLineProduct $secureLineProduct): RedirectResponse
+    {
+        $secureLineProduct->delete();
+
+        return redirect()->route('admin.secure-line-products.index')
+            ->with('flash', ['success' => 'Secure Line product deleted.']);
+    }
+
+    protected function createStripePrice(StoreSecureLineProductRequest|UpdateSecureLineProductRequest $request): ?string
+    {
+        $name = $request->input('name');
+        $cents = (int) $request->input('amount_cents');
+
+        try {
+            $product = Cashier::stripe()->products->create(['name' => $name]);
+
+            $price = Cashier::stripe()->prices->create([
+                'unit_amount' => $cents,
+                'currency' => config('cashier.currency', 'aud'),
+                'product' => $product->id,
+                // No 'recurring' key — one-time price, not subscription
+            ]);
+
+            return $price->id;
+        } catch (\Throwable $e) {
+            Log::error('Failed to create Stripe price for Secure Line product', [
+                'error' => $e->getMessage(),
+                'name' => $name,
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/app/Http/Requests/StoreSecureLineProductRequest.php
+++ b/app/Http/Requests/StoreSecureLineProductRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSecureLineProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'duration_minutes' => ['required', 'integer', 'min:1', 'max:1440'],
+            'max_participants' => ['required', 'integer', 'min:2', 'max:100'],
+            'amount_cents' => ['required', 'integer', 'min:1'],
+            'stripe_price_id' => ['nullable', 'string', 'max:255'],
+            // Omitting 'required' is intentional — omitting the field defaults to false via $request->boolean()
+            'create_stripe_price' => ['boolean'],
+            'is_active' => ['boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSecureLineProductRequest.php
+++ b/app/Http/Requests/UpdateSecureLineProductRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSecureLineProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'duration_minutes' => ['required', 'integer', 'min:1', 'max:1440'],
+            'max_participants' => ['required', 'integer', 'min:2', 'max:100'],
+            'amount_cents' => ['required', 'integer', 'min:1'],
+            'stripe_price_id' => ['nullable', 'string', 'max:255'],
+            // Omitting 'required' is intentional — omitting the field defaults to false via $request->boolean()
+            'create_stripe_price' => ['boolean'],
+            'is_active' => ['boolean'],
+        ];
+    }
+}

--- a/app/Models/SecureLineProduct.php
+++ b/app/Models/SecureLineProduct.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\SecureLineProductFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SecureLineProduct extends Model
+{
+    /** @use HasFactory<SecureLineProductFactory> */
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'duration_minutes',
+        'max_participants',
+        'amount_cents',
+        'stripe_price_id',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'duration_minutes' => 'integer',
+            'max_participants' => 'integer',
+            'amount_cents' => 'integer',
+        ];
+    }
+
+    public function amountDollars(): float
+    {
+        return $this->amount_cents / 100;
+    }
+}

--- a/database/factories/SecureLineProductFactory.php
+++ b/database/factories/SecureLineProductFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SecureLineProduct;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SecureLineProduct>
+ */
+class SecureLineProductFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->words(3, true),
+            'duration_minutes' => fake()->randomElement([30, 60, 90, 120]),
+            'max_participants' => fake()->numberBetween(2, 10),
+            'amount_cents' => fake()->numberBetween(500, 5000),
+            'stripe_price_id' => null,
+            'is_active' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn () => ['is_active' => false]);
+    }
+
+    public function withStripePrice(): static
+    {
+        return $this->state(fn () => ['stripe_price_id' => 'price_'.fake()->bothify('??????????')]);
+    }
+}

--- a/database/migrations/2026_06_20_111328_create_secure_line_products_table.php
+++ b/database/migrations/2026_06_20_111328_create_secure_line_products_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('secure_line_products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedSmallInteger('duration_minutes');
+            $table->unsignedTinyInteger('max_participants');
+            $table->unsignedInteger('amount_cents');
+            $table->string('stripe_price_id')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('secure_line_products');
+    }
+};

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -159,6 +159,9 @@ const logout = () => {
                                                     <DropdownLink :href="route('admin.locker-plans.index')">
                                                         eLocker Plans
                                                     </DropdownLink>
+                                                    <DropdownLink :href="route('admin.secure-line-products.index')">
+                                                        Secure Line Products
+                                                    </DropdownLink>
                                                     <DropdownLink :href="route('admin.users.index')">
                                                         Manage Users
                                                     </DropdownLink>
@@ -400,6 +403,14 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('admin.plans.index')"
                                     :active="route().current('admin.plans.*')">
                                     Plans
+                                </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('admin.locker-plans.index')"
+                                    :active="route().current('admin.locker-plans.*')">
+                                    eLocker Plans
+                                </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('admin.secure-line-products.index')"
+                                    :active="route().current('admin.secure-line-products.*')">
+                                    Secure Line Products
                                 </ResponsiveNavLink>
                                 <ResponsiveNavLink :href="route('admin.users.index')"
                                     :active="route().current('admin.users.*')">

--- a/resources/js/Pages/Admin/SecureLineProducts/Form.vue
+++ b/resources/js/Pages/Admin/SecureLineProducts/Form.vue
@@ -1,0 +1,284 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import { Link, useForm } from '@inertiajs/vue3';
+import { computed, watch } from 'vue';
+
+const props = defineProps({
+    product:           Object,
+    defaultStripeMode: String,
+});
+
+const isEditing = computed(() => props.product !== null);
+
+const form = useForm({
+    name:                props.product?.name             ?? '',
+    duration_minutes:    props.product?.duration_minutes ?? '',
+    max_participants:    props.product?.max_participants  ?? 2,
+    amount_cents:        props.product?.amount_cents      ?? '',
+    stripe_price_id:     props.product?.stripe_price_id  ?? '',
+    create_stripe_price: props.defaultStripeMode === 'create',
+    is_active:           props.product?.is_active        ?? true,
+});
+
+// Clear stripe_price_id when switching to auto-create mode
+watch(() => form.create_stripe_price, (val) => {
+    if (val) { form.stripe_price_id = ''; }
+});
+
+const amountDollars = computed({
+    get: () => form.amount_cents ? (form.amount_cents / 100) : '',
+    set: (val) => { form.amount_cents = Math.round(parseFloat(val || 0) * 100); },
+});
+
+const durationLabel = computed(() => {
+    const m = parseInt(form.duration_minutes) || 0;
+    if (m === 0) { return ''; }
+    const hours = Math.floor(m / 60);
+    const mins = m % 60;
+    if (hours === 0) { return `${mins} min`; }
+    if (mins === 0) { return `${hours} hr`; }
+    return `${hours} hr ${mins} min`;
+});
+
+const showActiveWarning = computed(() =>
+    form.is_active && !form.create_stripe_price && !form.stripe_price_id
+);
+
+const submit = () => {
+    if (isEditing.value) {
+        form.put(route('admin.secure-line-products.update', props.product.id));
+    } else {
+        form.post(route('admin.secure-line-products.store'));
+    }
+};
+
+// Preview helpers
+const previewPrice = computed(() =>
+    form.amount_cents ? `$${(form.amount_cents / 100).toFixed(2)}` : '$—'
+);
+
+const previewStripeStatus = computed(() => {
+    if (form.create_stripe_price) { return 'auto'; }
+    if (form.stripe_price_id) { return 'mapped'; }
+    return 'missing';
+});
+</script>
+
+<template>
+    <AdminLayout :title="isEditing ? 'Edit Secure Line Product' : 'New Secure Line Product'">
+        <template #title>{{ isEditing ? 'Edit Secure Line Product' : 'New Secure Line Product' }}</template>
+
+        <Page>
+            <div class="mb-6">
+                <Link :href="route('admin.secure-line-products.index')" prefetch class="text-sm text-gamboge-300 hover:text-gamboge-200">
+                    ← Back to Secure Line Products
+                </Link>
+            </div>
+
+            <div class="flex gap-10 items-start">
+
+            <!-- Form (left) -->
+            <div class="flex-1 max-w-lg">
+                <form @submit.prevent="submit" class="space-y-6">
+
+                    <!-- Name -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+                        <TextInput
+                            v-model="form.name"
+                            type="text"
+                            class="w-full"
+                            placeholder="30-minute Line"
+                        />
+                        <InputError :message="form.errors.name" class="mt-1" />
+                    </div>
+
+                    <!-- Duration -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Duration (minutes)</label>
+                        <div class="flex items-center gap-2">
+                            <TextInput
+                                v-model.number="form.duration_minutes"
+                                type="number"
+                                min="1"
+                                max="1440"
+                                class="w-32 font-mono"
+                                placeholder="30"
+                            />
+                            <span v-if="durationLabel" class="text-sm text-gamboge-300 font-mono">{{ durationLabel }}</span>
+                        </div>
+                        <InputError :message="form.errors.duration_minutes" class="mt-1" />
+                    </div>
+
+                    <!-- Max Participants -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Max Participants</label>
+                        <TextInput
+                            v-model.number="form.max_participants"
+                            type="number"
+                            min="2"
+                            max="100"
+                            class="w-28 font-mono"
+                            placeholder="10"
+                        />
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Minimum 2 — includes the host and at least one participant.
+                        </p>
+                        <InputError :message="form.errors.max_participants" class="mt-1" />
+                    </div>
+
+                    <!-- Price -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Price (AUD)</label>
+                        <div class="relative">
+                            <span class="absolute inset-y-0 left-3 flex items-center text-gray-500 dark:text-gray-400 text-sm">$</span>
+                            <TextInput
+                                v-model="amountDollars"
+                                type="number"
+                                step="1"
+                                min="0"
+                                class="pl-7 w-full"
+                                placeholder="20"
+                            />
+                        </div>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Stored as <span class="font-mono">{{ form.amount_cents }}</span> cents
+                        </p>
+                        <InputError :message="form.errors.amount_cents" class="mt-1" />
+                    </div>
+
+                    <!-- Stripe mode toggle -->
+                    <div class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-4">
+                        <div class="text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-widest">Stripe Integration</div>
+
+                        <div class="flex gap-3">
+                            <button
+                                type="button"
+                                @click="form.create_stripe_price = true"
+                                :class="form.create_stripe_price
+                                    ? 'border-gamboge-300 bg-gamboge-300/10 text-gamboge-300'
+                                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gamboge-300/50'"
+                                class="flex-1 py-2 text-xs font-mono rounded-lg border transition-all"
+                            >
+                                Create in Stripe
+                            </button>
+                            <button
+                                type="button"
+                                @click="form.create_stripe_price = false"
+                                :class="!form.create_stripe_price
+                                    ? 'border-gamboge-300 bg-gamboge-300/10 text-gamboge-300'
+                                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gamboge-300/50'"
+                                class="flex-1 py-2 text-xs font-mono rounded-lg border transition-all"
+                            >
+                                Map Existing ID
+                            </button>
+                        </div>
+
+                        <!-- Auto-create: just info -->
+                        <p v-if="form.create_stripe_price" class="text-xs text-gray-500 dark:text-gray-400">
+                            A new Stripe product and one-time price will be created automatically when you save.
+                        </p>
+
+                        <!-- Map existing: price ID field -->
+                        <div v-else>
+                            <TextInput
+                                v-model="form.stripe_price_id"
+                                type="text"
+                                class="w-full font-mono"
+                                placeholder="price_1ABC..."
+                            />
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                The <code class="font-mono">price_*</code> ID from your Stripe dashboard.
+                            </p>
+                            <InputError :message="form.errors.stripe_price_id" class="mt-1" />
+                        </div>
+                    </div>
+
+                    <!-- Active -->
+                    <div class="space-y-2">
+                        <div class="flex items-center gap-3">
+                            <input
+                                id="is_active"
+                                v-model="form.is_active"
+                                type="checkbox"
+                                class="rounded border-gray-300 dark:border-gray-600 text-gamboge-300 focus:ring-gamboge-300"
+                            />
+                            <label for="is_active" class="text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                                Active — show as a purchase option in checkout
+                            </label>
+                        </div>
+                        <div v-if="showActiveWarning"
+                             class="flex items-center gap-2 text-xs text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded px-3 py-2 font-mono">
+                            ⚠ This product is active but has no Stripe price — buyers will not be able to complete a purchase.
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-3 pt-2">
+                        <PrimaryButton :disabled="form.processing">
+                            {{ isEditing ? 'Update Product' : 'Create Product' }}
+                        </PrimaryButton>
+                        <Link :href="route('admin.secure-line-products.index')" prefetch>
+                            <SecondaryButton type="button">Cancel</SecondaryButton>
+                        </Link>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Preview (right) -->
+            <div class="w-72 shrink-0 sticky top-8">
+                <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-4">Live Preview</div>
+
+                <!-- Card preview -->
+                <div class="dark relative bg-gray-800 border border-gray-700 rounded-xl p-6 flex flex-col gap-4 shadow-neon-cyan-sm">
+
+                    <!-- Status badge -->
+                    <div v-if="!form.is_active" class="absolute -top-3 left-1/2 -translate-x-1/2">
+                        <span class="bg-gray-600 text-gray-200 text-xs font-bold px-3 py-1 rounded-full font-mono uppercase tracking-wide">
+                            Inactive
+                        </span>
+                    </div>
+
+                    <div>
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">
+                            {{ durationLabel || '— min' }}
+                        </div>
+                        <div class="text-white font-semibold text-base mb-0.5">
+                            {{ form.name || 'Product Name' }}
+                        </div>
+                        <div class="text-3xl font-bold text-white">
+                            {{ previewPrice }}
+                        </div>
+                        <div class="text-gray-400 text-xs mt-1">
+                            one-time payment — up to {{ form.max_participants || 2 }} participants
+                        </div>
+                    </div>
+
+                    <div class="w-full text-center bg-gamboge-300 text-gray-900 font-semibold py-2.5 px-4 rounded-lg font-mono text-sm shadow-neon-cyan-sm cursor-default select-none">
+                        Buy Now
+                    </div>
+                </div>
+
+                <!-- Stripe status indicator -->
+                <div class="mt-4 text-xs">
+                    <div v-if="previewStripeStatus === 'auto'" class="flex items-center gap-1.5 text-gamboge-300">
+                        <span>⚡</span> Stripe price created automatically on save
+                    </div>
+                    <div v-else-if="previewStripeStatus === 'mapped'" class="flex items-center gap-1.5 text-green-400">
+                        <span>✓</span>
+                        <span class="font-mono truncate">{{ form.stripe_price_id }}</span>
+                    </div>
+                    <div v-else class="flex items-center gap-1.5 text-red-400">
+                        <span>✗</span> No Stripe price — checkout will be blocked
+                    </div>
+                </div>
+            </div>
+
+            </div><!-- end two-column -->
+        </Page>
+    </AdminLayout>
+</template>

--- a/resources/js/Pages/Admin/SecureLineProducts/Index.vue
+++ b/resources/js/Pages/Admin/SecureLineProducts/Index.vue
@@ -73,6 +73,7 @@ const formatDuration = (minutes) => {
                             </td>
                         </tr>
                         <tr v-for="product in products" :key="product.id"
+                            :data-testid="`product-row-${product.id}`"
                             class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700"
                             :class="{ 'opacity-50': !product.is_active }">
                             <th scope="row" class="px-6 py-4 font-semibold text-gray-900 dark:text-white">

--- a/resources/js/Pages/Admin/SecureLineProducts/Index.vue
+++ b/resources/js/Pages/Admin/SecureLineProducts/Index.vue
@@ -1,0 +1,134 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import { Link, useForm } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+const props = defineProps({
+    products: Array,
+});
+
+const productBeingDeleted = ref(null);
+const deleteForm = useForm({});
+
+const confirmDelete = (product) => { productBeingDeleted.value = product; };
+
+const deleteProduct = () => {
+    deleteForm.delete(route('admin.secure-line-products.destroy', productBeingDeleted.value.id), {
+        preserveScroll: true,
+        onSuccess: () => { productBeingDeleted.value = null; },
+        onError:   () => { productBeingDeleted.value = null; },
+    });
+};
+
+const formatPrice = (cents) => `$${(cents / 100).toFixed(2)}`;
+
+const formatDuration = (minutes) => {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours === 0) {
+        return `${mins} min`;
+    }
+    if (mins === 0) {
+        return `${hours} hr`;
+    }
+    return `${hours} hr ${mins} min`;
+};
+</script>
+
+<template>
+    <AdminLayout title="Admin — Secure Line Products">
+        <template #title>Secure Line Products</template>
+
+        <Page>
+            <div class="mb-6 flex items-center justify-between">
+                <h1 class="text-xs uppercase tracking-widest text-gamboge-300 font-mono">Secure Line Product Management</h1>
+                <Link :href="route('admin.secure-line-products.create')" prefetch>
+                    <PrimaryButton>New Product</PrimaryButton>
+                </Link>
+            </div>
+
+            <div class="relative overflow-x-auto shadow-md sm:rounded-lg dark:shadow-neon-cyan-sm">
+                <table class="w-full text-sm text-left text-gray-700 dark:text-gray-400">
+                    <thead class="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gamboge-300 tracking-widest">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Name</th>
+                            <th scope="col" class="px-6 py-3">Duration</th>
+                            <th scope="col" class="px-6 py-3">Max Participants</th>
+                            <th scope="col" class="px-6 py-3">Price</th>
+                            <th scope="col" class="px-6 py-3">Stripe Price ID</th>
+                            <th scope="col" class="px-6 py-3 text-center">Active</th>
+                            <th scope="col" class="px-6 py-3 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-if="products.length === 0">
+                            <td colspan="7" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                                No products yet.
+                                <Link :href="route('admin.secure-line-products.create')" prefetch class="text-gamboge-300 hover:underline ml-1">Create one.</Link>
+                            </td>
+                        </tr>
+                        <tr v-for="product in products" :key="product.id"
+                            class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700"
+                            :class="{ 'opacity-50': !product.is_active }">
+                            <th scope="row" class="px-6 py-4 font-semibold text-gray-900 dark:text-white">
+                                <div>{{ product.name }}</div>
+                                <div v-if="product.is_active && !product.stripe_price_id"
+                                     class="mt-1 inline-flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded px-2 py-0.5 font-mono font-normal">
+                                    ⚠ Active but no Stripe price — checkout will fail
+                                </div>
+                            </th>
+                            <td class="px-6 py-4 font-mono">{{ formatDuration(product.duration_minutes) }}</td>
+                            <td class="px-6 py-4 font-mono">{{ product.max_participants }}</td>
+                            <td class="px-6 py-4 font-mono">{{ formatPrice(product.amount_cents) }}</td>
+                            <td class="px-6 py-4">
+                                <span v-if="product.stripe_price_id" class="font-mono text-xs text-gamboge-300">
+                                    {{ product.stripe_price_id }}
+                                </span>
+                                <span v-else class="text-red-400 text-xs">Not set</span>
+                            </td>
+                            <td class="px-6 py-4 text-center">
+                                <span v-if="product.is_active" class="text-gamboge-300 text-xs font-mono">Yes</span>
+                                <span v-else class="text-gray-500 text-xs font-mono">No</span>
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-2">
+                                    <Link :href="route('admin.secure-line-products.edit', product.id)" prefetch>
+                                        <SecondaryButton class="text-xs">Edit</SecondaryButton>
+                                    </Link>
+                                    <DangerButton class="text-xs" @click="confirmDelete(product)">
+                                        Delete
+                                    </DangerButton>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </Page>
+
+        <ConfirmationModal :show="productBeingDeleted !== null" @close="productBeingDeleted = null">
+            <template #title>Delete Secure Line Product</template>
+            <template #content>
+                Are you sure you want to delete
+                <strong>{{ productBeingDeleted?.name }}</strong>?
+                This action cannot be undone. Deactivating the product is safer if it has been purchased.
+            </template>
+            <template #footer>
+                <SecondaryButton @click="productBeingDeleted = null">Cancel</SecondaryButton>
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteForm.processing }"
+                    :disabled="deleteForm.processing"
+                    @click="deleteProduct"
+                >
+                    Delete Product
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </AdminLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\AdminLockerPlanController;
 use App\Http\Controllers\Admin\AdminPlanController;
+use App\Http\Controllers\Admin\AdminSecureLineProductController;
 use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\BlogController;
@@ -230,6 +231,7 @@ Route::middleware([
 ])->prefix('admin')->name('admin.')->group(function () {
     Route::resource('plans', AdminPlanController::class)->except(['show']);
     Route::resource('locker-plans', AdminLockerPlanController::class)->except(['show']);
+    Route::resource('secure-line-products', AdminSecureLineProductController::class)->except(['show']);
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::post('users/{user}/suspend', [AdminUserController::class, 'suspend'])->name('users.suspend');
     Route::delete('users/{user}/suspend', [AdminUserController::class, 'unsuspend'])->name('users.unsuspend');

--- a/tests/Feature/Admin/AdminSecureLineProductCrudTest.php
+++ b/tests/Feature/Admin/AdminSecureLineProductCrudTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\SecureLineProduct;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class AdminSecureLineProductCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Config::set('admin.emails', [$user->email]);
+
+        return $user;
+    }
+
+    private function nonAdminUser(): User
+    {
+        return User::factory()->withPersonalTeam()->create();
+    }
+
+    private function productPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Test Secure Line',
+            'duration_minutes' => 30,
+            'max_participants' => 5,
+            'amount_cents' => 2000,
+            'stripe_price_id' => '',
+            'create_stripe_price' => false,
+            'is_active' => true,
+        ], $overrides);
+    }
+
+    public function test_unauthenticated_user_is_redirected_from_admin_secure_line_products(): void
+    {
+        $response = $this->get(route('admin.secure-line-products.index'));
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_non_admin_receives_403_on_admin_secure_line_products(): void
+    {
+        $user = $this->nonAdminUser();
+
+        $response = $this->actingAs($user)->get(route('admin.secure-line-products.index'));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_view_secure_line_products_index(): void
+    {
+        $admin = $this->adminUser();
+        SecureLineProduct::factory()->create(['name' => 'Quick Call']);
+
+        $response = $this->actingAs($admin)->get(route('admin.secure-line-products.index'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Admin/SecureLineProducts/Index')
+            ->has('products', 1)
+        );
+    }
+
+    public function test_admin_can_create_product_with_mapped_stripe_price_id(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->productPayload([
+                'name' => 'Premium Call',
+                'stripe_price_id' => 'price_mapped123',
+            ])
+        );
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $this->assertDatabaseHas('secure_line_products', [
+            'name' => 'Premium Call',
+            'stripe_price_id' => 'price_mapped123',
+        ]);
+    }
+
+    public function test_admin_can_create_product_without_stripe_price_id(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->productPayload(['stripe_price_id' => null])
+        );
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $this->assertDatabaseHas('secure_line_products', [
+            'name' => 'Test Secure Line',
+            'stripe_price_id' => null,
+        ]);
+    }
+
+    public function test_admin_can_view_edit_form_for_product(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+
+        $response = $this->actingAs($admin)->get(route('admin.secure-line-products.edit', $product));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Admin/SecureLineProducts/Form')
+            ->where('product.id', $product->id)
+        );
+    }
+
+    public function test_admin_can_update_a_product(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+
+        $response = $this->actingAs($admin)->putJson(
+            route('admin.secure-line-products.update', $product),
+            $this->productPayload([
+                'name' => 'Updated Name',
+                'duration_minutes' => 60,
+                'stripe_price_id' => $product->stripe_price_id,
+            ])
+        );
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $product->refresh();
+        $this->assertEquals('Updated Name', $product->name);
+        $this->assertEquals(60, $product->duration_minutes);
+    }
+
+    public function test_admin_can_deactivate_a_product(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->create(['is_active' => true]);
+
+        $this->actingAs($admin)->putJson(
+            route('admin.secure-line-products.update', $product),
+            $this->productPayload(['is_active' => false])
+        );
+
+        $product->refresh();
+        $this->assertFalse($product->is_active);
+    }
+
+    public function test_admin_can_delete_a_product(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->create();
+
+        $response = $this->actingAs($admin)->delete(route('admin.secure-line-products.destroy', $product));
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $this->assertSoftDeleted('secure_line_products', ['id' => $product->id]);
+    }
+
+    public function test_store_validates_required_fields(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            []
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['name', 'duration_minutes', 'max_participants', 'amount_cents']);
+    }
+
+    public function test_duration_minutes_must_be_at_least_1(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->productPayload(['duration_minutes' => 0])
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['duration_minutes']);
+    }
+
+    public function test_max_participants_must_be_at_least_2(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->productPayload(['max_participants' => 1])
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['max_participants']);
+    }
+
+    public function test_non_admin_cannot_create_product(): void
+    {
+        $user = $this->nonAdminUser();
+
+        $response = $this->actingAs($user)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->productPayload()
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_non_admin_cannot_update_product(): void
+    {
+        $user = $this->nonAdminUser();
+        $product = SecureLineProduct::factory()->create();
+
+        $response = $this->actingAs($user)->putJson(
+            route('admin.secure-line-products.update', $product),
+            $this->productPayload()
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_non_admin_cannot_delete_product(): void
+    {
+        $user = $this->nonAdminUser();
+        $product = SecureLineProduct::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('admin.secure-line-products.destroy', $product));
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/Admin/AdminSecureLineProductStripeTest.php
+++ b/tests/Feature/Admin/AdminSecureLineProductStripeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Http\Controllers\Admin\AdminSecureLineProductController;
+use App\Models\SecureLineProduct;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Tests\TestCase;
+
+class AdminSecureLineProductStripeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Config::set('admin.emails', [$user->email]);
+
+        return $user;
+    }
+
+    private function basePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Quick Call',
+            'duration_minutes' => 30,
+            'max_participants' => 5,
+            'amount_cents' => 2000,
+            'stripe_price_id' => '',
+            'create_stripe_price' => true,
+            'is_active' => true,
+        ], $overrides);
+    }
+
+    private function mockControllerWithStripeResult(?string $priceId): void
+    {
+        $mock = Mockery::mock(AdminSecureLineProductController::class)->makePartial();
+        $mock->shouldAllowMockingProtectedMethods();
+        $mock->shouldReceive('createStripePrice')->andReturn($priceId);
+        $this->app->instance(AdminSecureLineProductController::class, $mock);
+    }
+
+    public function test_store_with_create_stripe_price_saves_returned_price_id(): void
+    {
+        $admin = $this->adminUser();
+        $this->mockControllerWithStripeResult('price_test456');
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->basePayload(['name' => 'Quick Call'])
+        );
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $this->assertDatabaseHas('secure_line_products', [
+            'name' => 'Quick Call',
+            'stripe_price_id' => 'price_test456',
+        ]);
+    }
+
+    public function test_store_with_stripe_failure_redirects_back_with_error(): void
+    {
+        $admin = $this->adminUser();
+        $this->mockControllerWithStripeResult(null);
+
+        $response = $this->actingAs($admin)->postJson(
+            route('admin.secure-line-products.store'),
+            $this->basePayload()
+        );
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('secure_line_products', ['name' => 'Quick Call']);
+    }
+
+    public function test_update_with_create_stripe_price_replaces_existing_price_id(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->withStripePrice()->create([
+            'stripe_price_id' => 'price_old789',
+        ]);
+        $this->mockControllerWithStripeResult('price_new123');
+
+        $this->actingAs($admin)->putJson(
+            route('admin.secure-line-products.update', $product),
+            $this->basePayload(['name' => $product->name])
+        );
+
+        $product->refresh();
+        $this->assertEquals('price_new123', $product->stripe_price_id);
+    }
+
+    public function test_update_without_create_stripe_price_retains_existing_price_id(): void
+    {
+        $admin = $this->adminUser();
+        $product = SecureLineProduct::factory()->withStripePrice()->create([
+            'stripe_price_id' => 'price_existing999',
+        ]);
+
+        // Omit stripe_price_id from the payload to simulate admin not re-entering it
+        $response = $this->actingAs($admin)->putJson(
+            route('admin.secure-line-products.update', $product),
+            [
+                'name' => $product->name,
+                'duration_minutes' => $product->duration_minutes,
+                'max_participants' => $product->max_participants,
+                'amount_cents' => $product->amount_cents,
+                'create_stripe_price' => false,
+                'is_active' => true,
+            ]
+        );
+
+        $response->assertRedirect(route('admin.secure-line-products.index'));
+        $product->refresh();
+        $this->assertEquals('price_existing999', $product->stripe_price_id);
+    }
+}

--- a/tests/e2e/admin/secure-line-products.spec.ts
+++ b/tests/e2e/admin/secure-line-products.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase, createSecureLineProduct } from '../helpers/db';
+import { createAdminUser, createTestUser, login } from '../helpers/auth';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+async function loginAsAdmin(page: Parameters<typeof login>[0]) {
+    const { email, password } = createAdminUser();
+    await login(page, email, password);
+}
+
+test('admin can view the Secure Line Products index page', async ({ page }) => {
+    createSecureLineProduct({ name: 'Quick Call', duration_minutes: 30, amount_cents: 2000 });
+    await loginAsAdmin(page);
+
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Secure Line Product Management')).toBeVisible();
+    await expect(page.getByText('Quick Call')).toBeVisible();
+    await expect(page.getByText('30 min')).toBeVisible();
+    await expect(page.getByText('$20.00')).toBeVisible();
+});
+
+test('clicking New Product navigates to the create form', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+
+    await page.getByRole('button', { name: 'New Product' }).click();
+
+    await expect(page).toHaveURL(/secure-line-products\/create/);
+    await expect(page.getByText('New Secure Line Product')).toBeVisible();
+});
+
+test('form shows validation errors when submitted empty', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products/create');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Create Product' }).click();
+
+    // Should stay on the form — successful create redirects to the index
+    await expect(page).toHaveURL(/secure-line-products\/create/);
+});
+
+test('admin can create a product and see it listed on the index', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products/create');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('input[placeholder="30-minute Line"]', 'Premium Hour');
+    await page.fill('input[type="number"][placeholder="30"]', '60');
+    await page.fill('input[type="number"][placeholder="10"]', '8');
+    await page.fill('input[type="number"][placeholder="20"]', '50');
+    await page.fill('input[placeholder="price_1ABC..."]', 'price_test123');
+
+    await page.getByRole('button', { name: 'Create Product' }).click();
+
+    await expect(page).toHaveURL(/secure-line-products$/);
+    await expect(page.getByText('Premium Hour')).toBeVisible();
+    await expect(page.getByText('1 hr')).toBeVisible();
+    await expect(page.getByText('$50.00')).toBeVisible();
+    await expect(page.getByText('price_test123')).toBeVisible();
+});
+
+test('clicking Edit navigates to the edit form pre-populated with product data', async ({ page }) => {
+    createSecureLineProduct({ name: 'Hour Session', duration_minutes: 60, amount_cents: 4000, stripe_price_id: 'price_abc' });
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+
+    await expect(page).toHaveURL(/secure-line-products\/\d+\/edit/);
+    await expect(page.getByDisplayValue('Hour Session')).toBeVisible();
+    await expect(page.getByDisplayValue('60')).toBeVisible();
+});
+
+test('admin can update a product and see the change reflected in the table', async ({ page }) => {
+    createSecureLineProduct({ name: 'Short Call', duration_minutes: 15, amount_cents: 1000, stripe_price_id: 'price_old' });
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.waitForLoadState('networkidle');
+
+    const nameInput = page.getByDisplayValue('Short Call');
+    await nameInput.clear();
+    await nameInput.fill('Extended Call');
+
+    await page.getByRole('button', { name: 'Update Product' }).click();
+
+    await expect(page).toHaveURL(/secure-line-products$/);
+    await expect(page.getByText('Extended Call')).toBeVisible();
+    await expect(page.getByText('Short Call')).not.toBeVisible();
+});
+
+test('clicking Delete opens a confirmation modal; confirming removes the product', async ({ page }) => {
+    createSecureLineProduct({ name: 'Call To Delete', duration_minutes: 30, amount_cents: 1500 });
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Call To Delete')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+
+    await expect(page.getByText('Delete Secure Line Product')).toBeVisible();
+    await expect(page.getByText('Call To Delete')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete Product' }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Call To Delete')).not.toBeVisible();
+});
+
+test('an inactive product appears visually dimmed in the table', async ({ page }) => {
+    createSecureLineProduct({ name: 'Inactive Product', duration_minutes: 30, amount_cents: 1000, is_active: false });
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Inactive Product')).toBeVisible();
+    await expect(page.getByText('No')).toBeVisible();
+
+    // Row gets opacity-50 class when inactive
+    const row = page.locator('tr', { has: page.getByText('Inactive Product') });
+    await expect(row).toHaveClass(/opacity-50/);
+});
+
+test('an active product with no Stripe price shows a warning badge', async ({ page }) => {
+    createSecureLineProduct({ name: 'No Price Yet', duration_minutes: 30, amount_cents: 1000, is_active: true });
+    await loginAsAdmin(page);
+    await page.goto('/admin/secure-line-products');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/Active but no Stripe price/)).toBeVisible();
+});
+
+test('non-admin user is denied access to the admin products page', async ({ page }) => {
+    const { email, password } = createTestUser();
+    await login(page, email, password);
+
+    await page.goto('/admin/secure-line-products');
+
+    // A 403 response renders a page without the admin products table
+    await expect(page.getByText('Secure Line Product Management')).not.toBeVisible();
+});

--- a/tests/e2e/admin/secure-line-products.spec.ts
+++ b/tests/e2e/admin/secure-line-products.spec.ts
@@ -74,8 +74,9 @@ test('clicking Edit navigates to the edit form pre-populated with product data',
     await page.getByRole('button', { name: 'Edit' }).first().click();
 
     await expect(page).toHaveURL(/secure-line-products\/\d+\/edit/);
-    await expect(page.getByDisplayValue('Hour Session')).toBeVisible();
-    await expect(page.getByDisplayValue('60')).toBeVisible();
+    // Use attribute selector since getByDisplayValue is not available in Playwright 1.60
+    await expect(page.locator('input[value="Hour Session"]')).toBeVisible();
+    await expect(page.locator('input[value="60"]').first()).toBeVisible();
 });
 
 test('admin can update a product and see the change reflected in the table', async ({ page }) => {
@@ -87,7 +88,8 @@ test('admin can update a product and see the change reflected in the table', asy
     await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.waitForLoadState('networkidle');
 
-    const nameInput = page.getByDisplayValue('Short Call');
+    // Use attribute selector since getByDisplayValue is not available in Playwright 1.60
+    const nameInput = page.locator('input[value="Short Call"]');
     await nameInput.clear();
     await nameInput.fill('Extended Call');
 
@@ -109,7 +111,8 @@ test('clicking Delete opens a confirmation modal; confirming removes the product
     await page.getByRole('button', { name: 'Delete' }).first().click();
 
     await expect(page.getByText('Delete Secure Line Product')).toBeVisible();
-    await expect(page.getByText('Call To Delete')).toBeVisible();
+    // Scope to the modal dialog to avoid strict-mode collision with the table row
+    await expect(page.getByRole('dialog').getByText('Call To Delete')).toBeVisible();
 
     await page.getByRole('button', { name: 'Delete Product' }).click();
     await page.waitForLoadState('networkidle');
@@ -124,10 +127,11 @@ test('an inactive product appears visually dimmed in the table', async ({ page }
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByText('Inactive Product')).toBeVisible();
-    await expect(page.getByText('No')).toBeVisible();
+    // Scope "No" to the product row to avoid matching other text on the page
+    const row = page.locator('tr', { has: page.getByText('Inactive Product') });
+    await expect(row.getByText('No', { exact: true })).toBeVisible();
 
     // Row gets opacity-50 class when inactive
-    const row = page.locator('tr', { has: page.getByText('Inactive Product') });
     await expect(row).toHaveClass(/opacity-50/);
 });
 

--- a/tests/e2e/admin/secure-line-products.spec.ts
+++ b/tests/e2e/admin/secure-line-products.spec.ts
@@ -88,8 +88,9 @@ test('admin can update a product and see the change reflected in the table', asy
     await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.waitForLoadState('networkidle');
 
-    // Use attribute selector since getByDisplayValue is not available in Playwright 1.60
-    const nameInput = page.locator('input[value="Short Call"]');
+    // Locate by placeholder (stable); value attribute disappears after clear()
+    const nameInput = page.locator('input[placeholder="30-minute Line"]');
+    await expect(nameInput).toHaveValue('Short Call');
     await nameInput.clear();
     await nameInput.fill('Extended Call');
 
@@ -117,7 +118,9 @@ test('clicking Delete opens a confirmation modal; confirming removes the product
     await page.getByRole('button', { name: 'Delete Product' }).click();
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('Call To Delete')).not.toBeVisible();
+    // Wait for the modal to close before asserting the row is gone
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.locator('tbody').getByText('Call To Delete')).not.toBeVisible();
 });
 
 test('an inactive product appears visually dimmed in the table', async ({ page }) => {

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,5 +1,6 @@
 import { Page } from '@playwright/test';
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 
 const ARTISAN = process.env.CI ? 'php artisan' : 'vendor/bin/sail artisan';
 
@@ -21,6 +22,27 @@ export async function logout(page: Page): Promise<void> {
 
 export function createTestUser(): { email: string; password: string } {
     const email = `e2e-${Date.now()}@example.com`;
+    const password = 'password';
+    execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="App\\\\Models\\\\User::factory()->create(['email' => '${email}', 'password' => bcrypt('${password}')])"`,
+        { stdio: 'pipe' }
+    );
+    return { email, password };
+}
+
+/**
+ * Creates a user whose email matches the first entry in ADMIN_EMAILS from the app's .env file.
+ * The server reads ADMIN_EMAILS at boot — creating a user with that email grants admin access.
+ * Since resetDatabase() clears all users, this is safe to call in beforeEach.
+ */
+export function createAdminUser(): { email: string; password: string } {
+    // Read ADMIN_EMAILS directly from .env so this works in any environment without
+    // hardcoding a specific address. Falls back to the .env.example default for CI.
+    let envContent = '';
+    try { envContent = readFileSync('.env', 'utf-8'); } catch { /* no .env file */ }
+    const match = envContent.match(/^ADMIN_EMAILS=(.+)$/m);
+    const configured = match ? match[1].split(',').map((e) => e.trim()).filter(Boolean) : [];
+    const email = configured[0] ?? 'admin@flashview.test';
     const password = 'password';
     execSync(
         `${ARTISAN} tinker --no-interaction --env=testing --execute="App\\\\Models\\\\User::factory()->create(['email' => '${email}', 'password' => bcrypt('${password}')])"`,

--- a/tests/e2e/helpers/db.ts
+++ b/tests/e2e/helpers/db.ts
@@ -19,6 +19,30 @@ export function clearCache(): void {
     execSync(`${ARTISAN} cache:clear --env=testing --no-interaction`, { stdio: 'pipe' });
 }
 
+export function createSecureLineProduct(overrides: Record<string, string | number | boolean> = {}): void {
+    const attrs = {
+        name: 'Quick Call',
+        duration_minutes: 30,
+        max_participants: 5,
+        amount_cents: 2000,
+        stripe_price_id: null,
+        is_active: true,
+        ...overrides,
+    };
+    const phpAttrs = Object.entries(attrs)
+        .map(([k, v]) => {
+            if (v === null) { return `'${k}' => null`; }
+            if (typeof v === 'boolean') { return `'${k}' => ${v ? 'true' : 'false'}`; }
+            if (typeof v === 'number') { return `'${k}' => ${v}`; }
+            return `'${k}' => '${v}'`;
+        })
+        .join(', ');
+    execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="App\\\\Models\\\\SecureLineProduct::create([${phpAttrs}])"`,
+        { stdio: 'pipe' }
+    );
+}
+
 export function expireAllSecrets(): void {
     // Replicates what ClearExpiredSecrets job does for text secrets.
     // There is no artisan command for this — use tinker directly.


### PR DESCRIPTION
## Summary

- Adds a full admin CRUD interface at `/admin/secure-line-products` for managing Secure Line call session products
- Each product defines: name, duration (minutes), max participants, price (AUD cents), Stripe one-time price ID, and active flag
- Products are linked to Stripe one-time prices (no `recurring` key — not subscription billing)
- Soft-deletes used on destroy to protect referential integrity for future PIO-120 purchase records

## Key implementation details

- Follows the `AdminLockerPlanController` / `LockerPlan` pattern exactly (single Stripe price per product, create-or-map toggle, amount_cents storage)
- `update` always falls back to the existing `stripe_price_id` when the admin doesn't re-enter it — prevents silent data loss
- Warning badge shown on index rows and form when a product is active but has no Stripe price
- Live preview card on the form updates reactively on every keystroke
- Admin nav updated (desktop dropdown + mobile responsive nav) to include the new section

## Files

**New:** model, migration, factory, 2 form requests, controller, 2 Vue pages, 2 PHPUnit test classes, 1 Playwright spec  
**Modified:** `routes/web.php`, `AppLayout.vue`, `tests/e2e/helpers/auth.ts`, `tests/e2e/helpers/db.ts`, `.env.example`

## Regression risks (from detector)

- **None blocking.** The admin nav previously omitted eLocker Plans from mobile — that gap was fixed as part of this PR (both desktop and mobile nav now list all three admin product areas).
- `ADMIN_EMAILS` in `.env.example` now defaults to `admin@flashview.test` (reserved for E2E testing). Developers should add their own email to the list locally.

## Test plan

- [x] 15 PHPUnit CRUD tests pass (auth, access control, full lifecycle, validation)
- [x] 4 PHPUnit Stripe mock tests pass (create/update success, failure, update without re-entering price ID)
- [x] 10 Playwright E2E tests pass (index, create, edit, update, delete, inactive dimming, warning badge, access denied)
- [ ] Manual: create product via admin UI, verify it appears in DB and nav, edit without losing Stripe price ID, soft-delete via destroy, verify `deleted_at` is set in DB