### PR TITLE
PIO-120: Anonymous Secure Line Purchase

### DIFF
--- a/app/Http/Controllers/SecureLineCheckoutController.php
+++ b/app/Http/Controllers/SecureLineCheckoutController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SecureLine\CheckoutSecureLineRequest;
+use App\Http\Requests\SecureLine\StoreCallSessionRequest;
+use App\Models\CallSession;
+use App\Models\SecureLineCredit;
+use App\Models\SecureLineProduct;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Cashier\Cashier;
+use Stripe\Exception\ApiErrorException;
+
+class SecureLineCheckoutController extends Controller
+{
+    public function buy(): Response
+    {
+        $products = SecureLineProduct::where('is_active', true)
+            ->whereNotNull('stripe_price_id')
+            ->orderBy('amount_cents')
+            ->get();
+
+        return Inertia::render('Call/Buy', ['products' => $products]);
+    }
+
+    public function checkout(CheckoutSecureLineRequest $request): RedirectResponse|HttpResponse
+    {
+        $product = SecureLineProduct::where('id', $request->product_id)
+            ->where('is_active', true)
+            ->whereNotNull('stripe_price_id')
+            ->firstOrFail();
+
+        try {
+            $session = Cashier::stripe()->checkout->sessions->create([
+                'mode' => 'payment',
+                'line_items' => [['price' => $product->stripe_price_id, 'quantity' => 1]],
+                'metadata' => [
+                    'product_type' => 'secure_line',
+                    'secure_line_product_id' => $product->id,
+                ],
+                'success_url' => route('calls.await-credit').'?session={CHECKOUT_SESSION_ID}',
+                'cancel_url' => route('calls.buy'),
+            ]);
+        } catch (ApiErrorException $e) {
+            Log::error('Stripe checkout session creation failed for SecureLine', [
+                'error' => $e->getMessage(),
+                'product_id' => $product->id,
+            ]);
+
+            return redirect()->route('calls.buy')->with('error', 'Payment service unavailable. Please try again.');
+        }
+
+        return Inertia::location($session->url);
+    }
+
+    public function awaitCredit(Request $request): Response
+    {
+        return Inertia::render('Call/AwaitCredit', [
+            'session_id' => $request->query('session'),
+        ]);
+    }
+
+    public function creditStatus(Request $request): JsonResponse
+    {
+        $sessionId = $request->query('session');
+
+        if (! $sessionId) {
+            return response()->json(['error' => 'Missing session parameter.'], 422);
+        }
+
+        $credit = SecureLineCredit::where('stripe_session_id', $sessionId)->first();
+
+        if (! $credit) {
+            return response()->json(['pending' => true]);
+        }
+
+        return response()->json(['token' => $credit->token]);
+    }
+
+    public function create(Request $request): Response
+    {
+        $token = $request->query('token');
+        $credit = SecureLineCredit::with(['secureLineProduct' => fn ($q) => $q->withTrashed()])
+            ->where('token', $token)
+            ->unused()
+            ->first();
+
+        if (! $credit || ! $credit->secureLineProduct) {
+            abort(404);
+        }
+
+        return Inertia::render('Call/Create', [
+            'credit_token' => $credit->token,
+            'product' => [
+                'name' => $credit->secureLineProduct->name,
+                'duration_minutes' => $credit->secureLineProduct->duration_minutes,
+                'max_participants' => $credit->secureLineProduct->max_participants,
+            ],
+        ]);
+    }
+
+    public function store(StoreCallSessionRequest $request): JsonResponse
+    {
+        return DB::transaction(function () use ($request) {
+            $credit = SecureLineCredit::where('token', $request->credit_token)
+                ->whereNull('used_at')
+                ->lockForUpdate()
+                ->with(['secureLineProduct' => fn ($q) => $q->withTrashed()])
+                ->first();
+
+            if (! $credit) {
+                return response()->json(['error' => 'Invalid or used credit token.'], 422);
+            }
+
+            $product = $credit->secureLineProduct;
+
+            if (! $product) {
+                return response()->json(['error' => 'Product not found.'], 422);
+            }
+
+            $session = CallSession::create([
+                'public_key' => $request->public_key,
+                'key_salt' => $request->key_salt,
+                'starts_at' => now(),
+                'ends_at' => now()->addMinutes($product->duration_minutes),
+                'max_participants' => $product->max_participants,
+            ]);
+
+            $credit->update([
+                'call_session_id' => $session->id,
+                'used_at' => now(),
+            ]);
+
+            return response()->json([
+                'bridge_number' => $session->hash_id,
+                'starts_at' => $session->starts_at->toIso8601String(),
+                'ends_at' => $session->ends_at->toIso8601String(),
+            ]);
+        });
+    }
+}

--- a/app/Http/Requests/SecureLine/CheckoutSecureLineRequest.php
+++ b/app/Http/Requests/SecureLine/CheckoutSecureLineRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\SecureLine;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CheckoutSecureLineRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'product_id' => [
+                'required',
+                'integer',
+                Rule::exists('secure_line_products', 'id')
+                    ->where('is_active', true)
+                    ->whereNotNull('stripe_price_id')
+                    ->whereNull('deleted_at'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/SecureLine/StoreCallSessionRequest.php
+++ b/app/Http/Requests/SecureLine/StoreCallSessionRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\SecureLine;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCallSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'credit_token' => ['required', 'string', 'max:64'],
+            'public_key' => ['required', 'string', 'regex:/^[A-Za-z0-9+\/]+=*$/'],
+            'key_salt' => ['required', 'string', 'max:64', 'regex:/^[A-Za-z0-9+\/]+=*$/'],
+        ];
+    }
+}

--- a/app/Listeners/HandleSecureLineStripeWebhook.php
+++ b/app/Listeners/HandleSecureLineStripeWebhook.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\SecureLineCredit;
+use Illuminate\Support\Facades\Log;
+use Laravel\Cashier\Events\WebhookReceived;
+
+class HandleSecureLineStripeWebhook
+{
+    public function handle(WebhookReceived $event): void
+    {
+        $payload = $event->payload;
+
+        if ($payload['type'] !== 'checkout.session.completed') {
+            return;
+        }
+
+        $session = $payload['data']['object'];
+
+        if (($session['metadata']['product_type'] ?? null) !== 'secure_line') {
+            return;
+        }
+
+        // Guard: async payment methods (SEPA, BACS) fire completed before money clears.
+        if (($session['payment_status'] ?? null) !== 'paid') {
+            Log::info('SecureLine webhook: skipping non-paid session', [
+                'stripe_session_id' => $session['id'],
+                'payment_status' => $session['payment_status'] ?? null,
+            ]);
+
+            return;
+        }
+
+        if (SecureLineCredit::where('stripe_session_id', $session['id'])->exists()) {
+            return;
+        }
+
+        $productId = $session['metadata']['secure_line_product_id'] ?? null;
+
+        if (! $productId) {
+            Log::warning('SecureLine webhook: missing secure_line_product_id', [
+                'stripe_session_id' => $session['id'],
+            ]);
+
+            return;
+        }
+
+        SecureLineCredit::create([
+            'token' => bin2hex(random_bytes(32)),
+            'stripe_session_id' => $session['id'],
+            'secure_line_product_id' => $productId,
+        ]);
+    }
+}

--- a/app/Models/SecureLineCredit.php
+++ b/app/Models/SecureLineCredit.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\SecureLineCreditFactory;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SecureLineCredit extends Model
+{
+    /** @use HasFactory<SecureLineCreditFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'token',
+        'stripe_session_id',
+        'secure_line_product_id',
+        'call_session_id',
+        'used_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'used_at' => 'datetime',
+        ];
+    }
+
+    public function secureLineProduct(): BelongsTo
+    {
+        return $this->belongsTo(SecureLineProduct::class);
+    }
+
+    public function callSession(): BelongsTo
+    {
+        return $this->belongsTo(CallSession::class);
+    }
+
+    public function isUsed(): bool
+    {
+        return filled($this->used_at);
+    }
+
+    #[Scope]
+    protected function unused($query): void
+    {
+        $query->whereNull('used_at');
+    }
+}

--- a/app/Models/SecureLineProduct.php
+++ b/app/Models/SecureLineProduct.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Database\Factories\SecureLineProductFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class SecureLineProduct extends Model
@@ -29,6 +30,11 @@ class SecureLineProduct extends Model
             'max_participants' => 'integer',
             'amount_cents' => 'integer',
         ];
+    }
+
+    public function secureLineCredits(): HasMany
+    {
+        return $this->hasMany(SecureLineCredit::class);
     }
 
     public function amountDollars(): float

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Features\SupportFeature;
 use App\Features\ThrottlingFeature;
 use App\Features\WebhookNotificationFeature;
 use App\Listeners\HandleLockerStripeWebhook;
+use App\Listeners\HandleSecureLineStripeWebhook;
 use App\Models\PersonalAccessToken;
 use App\Models\User;
 use App\Observers\SubscriptionObserver;
@@ -66,6 +67,7 @@ class AppServiceProvider extends ServiceProvider
         Subscription::observe(SubscriptionObserver::class);
 
         Event::listen(WebhookReceived::class, HandleLockerStripeWebhook::class);
+        Event::listen(WebhookReceived::class, HandleSecureLineStripeWebhook::class);
 
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
 

--- a/database/factories/SecureLineCreditFactory.php
+++ b/database/factories/SecureLineCreditFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SecureLineCredit;
+use App\Models\SecureLineProduct;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SecureLineCredit>
+ */
+class SecureLineCreditFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'token' => bin2hex(random_bytes(32)),
+            'stripe_session_id' => 'cs_test_'.$this->faker->uuid(),
+            'secure_line_product_id' => SecureLineProduct::factory(),
+            'call_session_id' => null,
+            'used_at' => null,
+        ];
+    }
+
+    public function used(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'used_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_06_20_121141_create_secure_line_credits_table.php
+++ b/database/migrations/2026_06_20_121141_create_secure_line_credits_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('secure_line_credits', function (Blueprint $table) {
+            $table->id();
+            $table->string('token', 64)->unique();
+            $table->string('stripe_session_id')->unique();
+            $table->foreignId('secure_line_product_id')
+                ->constrained()
+                ->restrictOnDelete();
+            $table->foreignId('call_session_id')
+                ->nullable()
+                ->constrained()
+                ->nullOnDelete();
+            $table->timestamp('used_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('secure_line_credits');
+    }
+};

--- a/resources/js/Pages/Call/AwaitCredit.vue
+++ b/resources/js/Pages/Call/AwaitCredit.vue
@@ -47,7 +47,7 @@ onUnmounted(() => clearInterval(pollInterval));
 
 <template>
     <AppLayout title="Confirming Payment — Secure Line">
-        <div class="dark min-h-screen bg-gray-950 flex items-center justify-center px-4 py-16">
+        <div class="dark min-h-screen bg-gray-900 flex items-center justify-center px-4 py-16">
             <div class="max-w-lg w-full">
 
                 <div class="bg-gray-900 border border-gray-700 rounded-xl p-8">
@@ -56,7 +56,7 @@ onUnmounted(() => clearInterval(pollInterval));
                     <p class="text-gray-400 text-sm mb-6">Your Secure Line credit will appear here automatically once Stripe confirms payment.</p>
 
                     <!-- Payment reference -->
-                    <div class="bg-gray-950 border border-gamboge-300/30 rounded-lg p-4 mb-6">
+                    <div class="bg-gray-800 border border-gamboge-300/30 rounded-lg p-4 mb-6">
                         <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Payment Reference</div>
                         <div class="font-mono text-xs text-white break-all">{{ session_id }}</div>
                         <p class="text-gray-400 text-xs mt-2">

--- a/resources/js/Pages/Call/AwaitCredit.vue
+++ b/resources/js/Pages/Call/AwaitCredit.vue
@@ -1,0 +1,97 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { router } from '@inertiajs/vue3';
+import { ref, onMounted, onUnmounted } from 'vue';
+
+const props = defineProps({
+    session_id: String,
+});
+
+const timedOut = ref(false);
+let pollInterval = null;
+let elapsed = 0;
+
+const poll = async () => {
+    if (!props.session_id) return;
+    try {
+        const res = await fetch(route('calls.credit-status') + '?session=' + encodeURIComponent(props.session_id));
+        const data = await res.json();
+        if (data.token) {
+            clearInterval(pollInterval);
+            localStorage.setItem('secure_line_pending_token', data.token);
+            router.visit(route('calls.create') + '?token=' + encodeURIComponent(data.token));
+        }
+    } catch {
+        // network error — keep polling
+    }
+};
+
+const startPolling = () => {
+    elapsed = 0;
+    timedOut.value = false;
+    pollInterval = setInterval(() => {
+        elapsed += 2;
+        if (elapsed >= 60) {
+            clearInterval(pollInterval);
+            timedOut.value = true;
+            return;
+        }
+        poll();
+    }, 2000);
+    poll();
+};
+
+onMounted(startPolling);
+onUnmounted(() => clearInterval(pollInterval));
+</script>
+
+<template>
+    <AppLayout title="Confirming Payment — Secure Line">
+        <div class="dark min-h-screen bg-gray-950 flex items-center justify-center px-4 py-16">
+            <div class="max-w-lg w-full">
+
+                <div class="bg-gray-900 border border-gray-700 rounded-xl p-8">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Secure Line</div>
+                    <h1 class="text-2xl font-bold text-white mb-2">Confirming your payment…</h1>
+                    <p class="text-gray-400 text-sm mb-6">Your Secure Line credit will appear here automatically once Stripe confirms payment.</p>
+
+                    <!-- Payment reference -->
+                    <div class="bg-gray-950 border border-gamboge-300/30 rounded-lg p-4 mb-6">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Payment Reference</div>
+                        <div class="font-mono text-xs text-white break-all">{{ session_id }}</div>
+                        <p class="text-gray-400 text-xs mt-2">
+                            Bookmark this page — if anything goes wrong, returning here will resume automatically.
+                        </p>
+                    </div>
+
+                    <!-- Shimmer while polling -->
+                    <div v-if="!timedOut" class="space-y-3">
+                        <div class="relative h-1.5 w-full rounded-sm bg-gray-700 border border-gamboge-300/20 overflow-hidden">
+                            <div class="absolute inset-y-0 w-1/3 bg-gradient-to-r from-transparent via-gamboge-300 to-transparent animate-shimmer" />
+                        </div>
+                        <p class="text-gray-500 text-sm text-center">Waiting for Stripe confirmation…</p>
+                    </div>
+
+                    <!-- Timeout state -->
+                    <div v-else class="space-y-4">
+                        <div class="bg-yellow-900/20 border border-yellow-600/30 rounded-lg p-4 text-yellow-300 text-sm">
+                            <p class="font-semibold mb-2">Payment is taking longer than expected.</p>
+                            <ul class="list-disc list-inside space-y-1 text-yellow-300/80">
+                                <li>If you've completed payment, wait a moment and click <strong>Try again</strong> below.</li>
+                                <li>Quote your payment reference above when contacting support — no account is needed.</li>
+                            </ul>
+                            <p class="mt-2 text-yellow-300/70">Bank transfers may take 1–3 business days. Keep this page reference handy and check back later.</p>
+                        </div>
+                        <button
+                            @click="startPolling"
+                            class="w-full text-center border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-sm py-2.5 rounded-lg transition-colors"
+                        >
+                            Try again
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Buy.vue
+++ b/resources/js/Pages/Call/Buy.vue
@@ -87,7 +87,7 @@ const formatDuration = (minutes) => minutes >= 60 ? `${minutes / 60} hour${minut
                     >
                         <div>
                             <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">{{ product.name }}</div>
-                            <div class="text-3xl font-bold text-white">{{ formatPrice(product.amount_cents) }}</div>
+                            <div class="text-3xl font-bold text-white" data-testid="product-price">{{ formatPrice(product.amount_cents) }}</div>
                             <div class="text-gray-400 text-xs mt-1">one-time payment</div>
                         </div>
                         <ul class="space-y-1 text-sm text-gray-300">

--- a/resources/js/Pages/Call/Buy.vue
+++ b/resources/js/Pages/Call/Buy.vue
@@ -1,0 +1,127 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Link, router } from '@inertiajs/vue3';
+import { ref, onMounted } from 'vue';
+
+const props = defineProps({
+    products: Array,
+});
+
+const pendingToken = ref(null);
+
+onMounted(() => {
+    pendingToken.value = localStorage.getItem('secure_line_pending_token') || null;
+});
+
+const resumeSetup = () => {
+    router.visit(route('calls.create') + '?token=' + encodeURIComponent(pendingToken.value));
+};
+
+const dismissPending = () => {
+    localStorage.removeItem('secure_line_pending_token');
+    pendingToken.value = null;
+};
+
+const formatPrice = (cents) => `$${(cents / 100).toFixed(0)}`;
+const formatDuration = (minutes) => minutes >= 60 ? `${minutes / 60} hour${minutes / 60 !== 1 ? 's' : ''}` : `${minutes} minutes`;
+</script>
+
+<template>
+    <AppLayout title="Buy a Secure Line">
+        <div class="dark min-h-screen bg-gray-950 py-16 px-4">
+            <div class="max-w-3xl mx-auto space-y-10">
+
+                <!-- Pending token recovery banner -->
+                <div v-if="pendingToken" class="bg-gamboge-300/10 border border-gamboge-300/50 rounded-xl p-5 flex flex-col sm:flex-row sm:items-center gap-4 shadow-neon-cyan-sm">
+                    <div class="flex-1">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Unused Secure Line Credit</div>
+                        <p class="text-white text-sm">You have an unused Secure Line setup from a previous purchase. Continue where you left off.</p>
+                    </div>
+                    <div class="flex gap-2 shrink-0">
+                        <button @click="resumeSetup" class="bg-gamboge-300 hover:bg-gamboge-400 text-gray-900 font-semibold py-2 px-4 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm">
+                            Continue →
+                        </button>
+                        <button @click="dismissPending" class="border border-gray-600 text-gray-400 hover:text-white hover:border-gray-500 py-2 px-3 rounded-lg text-sm transition-colors">
+                            Dismiss
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Hero -->
+                <div class="text-center">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Secure Line</div>
+                    <h1 class="text-3xl font-bold text-white mb-3">Buy a Secure Line</h1>
+                    <p class="text-gray-400 text-sm max-w-lg mx-auto">
+                        One-off payment. No account. No subscription. A time-limited, end-to-end encrypted call window you share with your participant.
+                    </p>
+                </div>
+
+                <!-- How it works -->
+                <div class="bg-gray-900 border border-gray-700 rounded-xl p-6">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-4">How it works</div>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <div class="flex gap-3">
+                            <div class="shrink-0 w-6 h-6 rounded-full bg-gamboge-300/20 text-gamboge-300 font-mono text-xs flex items-center justify-center">1</div>
+                            <p class="text-gray-300 text-sm">Pay once — no account, no subscription.</p>
+                        </div>
+                        <div class="flex gap-3">
+                            <div class="shrink-0 w-6 h-6 rounded-full bg-gamboge-300/20 text-gamboge-300 font-mono text-xs flex items-center justify-center">2</div>
+                            <p class="text-gray-300 text-sm">Receive a bridge number and a call password.</p>
+                        </div>
+                        <div class="flex gap-3">
+                            <div class="shrink-0 w-6 h-6 rounded-full bg-gamboge-300/20 text-gamboge-300 font-mono text-xs flex items-center justify-center">3</div>
+                            <p class="text-gray-300 text-sm">Share both with your participant — they join at <span class="font-mono text-gamboge-300/80">/calls</span>.</p>
+                        </div>
+                    </div>
+                    <div class="mt-4 bg-yellow-900/20 border border-yellow-600/30 rounded-lg px-4 py-3 text-yellow-300/90 text-xs">
+                        Your call window starts the moment you generate your credentials — share them promptly.
+                    </div>
+                </div>
+
+                <!-- Product grid -->
+                <div v-if="products.length > 0" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div
+                        v-for="product in products"
+                        :key="product.id"
+                        class="bg-gray-900 border border-gray-700 rounded-xl p-6 flex flex-col gap-4 hover:border-gamboge-300 hover:shadow-neon-cyan transition-all duration-200"
+                    >
+                        <div>
+                            <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">{{ product.name }}</div>
+                            <div class="text-3xl font-bold text-white">{{ formatPrice(product.amount_cents) }}</div>
+                            <div class="text-gray-400 text-xs mt-1">one-time payment</div>
+                        </div>
+                        <ul class="space-y-1 text-sm text-gray-300">
+                            <li>
+                                <span class="text-gamboge-300 font-mono mr-1">✓</span>
+                                {{ formatDuration(product.duration_minutes) }} call window
+                            </li>
+                            <li>
+                                <span class="text-gamboge-300 font-mono mr-1">✓</span>
+                                Up to {{ product.max_participants }} participants
+                            </li>
+                            <li>
+                                <span class="text-gamboge-300 font-mono mr-1">✓</span>
+                                End-to-end encrypted
+                            </li>
+                        </ul>
+                        <Link
+                            :href="route('calls.checkout')"
+                            method="post"
+                            :data="{ product_id: product.id }"
+                            as="button"
+                            class="mt-auto w-full text-center bg-gamboge-300 hover:bg-gamboge-400 text-gray-900 font-semibold py-2.5 px-4 rounded-lg font-mono text-sm transition-colors duration-150 shadow-neon-cyan-sm hover:shadow-neon-cyan"
+                            data-testid="purchase-button"
+                        >
+                            Purchase — {{ formatPrice(product.amount_cents) }}
+                        </Link>
+                    </div>
+                </div>
+
+                <div v-else class="text-center text-gray-500 text-sm">
+                    No Secure Line products are currently available. Please check back soon.
+                </div>
+
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Buy.vue
+++ b/resources/js/Pages/Call/Buy.vue
@@ -28,7 +28,7 @@ const formatDuration = (minutes) => minutes >= 60 ? `${minutes / 60} hour${minut
 
 <template>
     <AppLayout title="Buy a Secure Line">
-        <div class="dark min-h-screen bg-gray-950 py-16 px-4">
+        <div class="dark min-h-screen bg-gray-900 py-16 px-4">
             <div class="max-w-3xl mx-auto space-y-10">
 
                 <!-- Pending token recovery banner -->

--- a/resources/js/Pages/Call/Create.vue
+++ b/resources/js/Pages/Call/Create.vue
@@ -96,7 +96,7 @@ onMounted(async () => {
 
 <template>
     <AppLayout title="Your Secure Line">
-        <div class="dark min-h-screen bg-gray-950 flex items-center justify-center py-16 px-4">
+        <div class="dark min-h-screen bg-gray-900 flex items-center justify-center py-16 px-4">
             <div class="max-w-xl w-full">
 
                 <!-- Creating / shimmer state -->
@@ -141,7 +141,7 @@ onMounted(async () => {
                     </div>
 
                     <!-- Bridge Number -->
-                    <div class="bg-gray-950 rounded-lg p-4">
+                    <div class="bg-gray-800 rounded-lg p-4">
                         <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Bridge Number</div>
                         <div class="flex items-center gap-3">
                             <code class="text-white text-lg flex-1 font-mono" data-testid="bridge-number">{{ bridgeNumber }}</code>
@@ -154,7 +154,7 @@ onMounted(async () => {
                     </div>
 
                     <!-- Call Password -->
-                    <div class="bg-gray-950 rounded-lg p-4">
+                    <div class="bg-gray-800 rounded-lg p-4">
                         <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Call Password</div>
                         <div class="flex items-center gap-3">
                             <code class="text-white text-sm flex-1 break-all font-mono" data-testid="call-password">{{ callPassword }}</code>
@@ -168,13 +168,13 @@ onMounted(async () => {
 
                     <!-- Session expiry -->
                     <div class="bg-yellow-900/20 border border-yellow-600/40 rounded-lg p-4">
-                        <div class="text-yellow-400 font-mono text-xs uppercase tracking-widest mb-1">Session Closes</div>
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Session Closes</div>
                         <p class="text-yellow-200 text-sm font-semibold" data-testid="session-expiry">{{ formattedExpiry }}</p>
                         <p class="text-yellow-300/70 text-xs mt-0.5">{{ minutesRemaining }}</p>
                     </div>
 
                     <!-- Participant instructions -->
-                    <div class="bg-gray-950 rounded-lg p-4">
+                    <div class="bg-gray-800 rounded-lg p-4">
                         <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Participant Instructions</div>
                         <p class="text-gray-300 text-sm">
                             Your participant visits

--- a/resources/js/Pages/Call/Create.vue
+++ b/resources/js/Pages/Call/Create.vue
@@ -2,7 +2,7 @@
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { router } from '@inertiajs/vue3';
 import { ref, onMounted, computed } from 'vue';
-import { generatePassphrase, deriveCallKeyPair } from '@pioneer-dynamics/flashview-crypto';
+import { generatePassphrase, deriveCallKeyPair, generateCallKeySalt } from '@pioneer-dynamics/flashview-crypto';
 
 const props = defineProps({
     credit_token: String,
@@ -57,8 +57,7 @@ const downloadCredentials = () => {
 onMounted(async () => {
     try {
         const password = generatePassphrase();
-        const saltBytes = crypto.getRandomValues(new Uint8Array(32));
-        const keySalt = btoa(String.fromCharCode(...saltBytes));
+        const keySalt = generateCallKeySalt();
         const { publicKeyBase64 } = await deriveCallKeyPair(password, keySalt);
 
         const res = await fetch(route('calls.store'), {

--- a/resources/js/Pages/Call/Create.vue
+++ b/resources/js/Pages/Call/Create.vue
@@ -1,0 +1,222 @@
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { router } from '@inertiajs/vue3';
+import { ref, onMounted, computed } from 'vue';
+import { generatePassphrase, deriveCallKeyPair } from '@pioneer-dynamics/flashview-crypto';
+
+const props = defineProps({
+    credit_token: String,
+    product: Object,
+});
+
+const step = ref('creating'); // 'creating' | 'done' | 'error'
+const errorMessage = ref(null);
+const bridgeNumber = ref(null);
+const callPassword = ref(null);
+const endsAt = ref(null);
+const savedConfirmed = ref(false);
+
+const xsrfToken = () => decodeURIComponent(document.cookie.match(/XSRF-TOKEN=([^;]+)/)?.[1] ?? '');
+
+const formattedExpiry = computed(() => {
+    if (!endsAt.value) return '';
+    return new Date(endsAt.value).toLocaleString();
+});
+
+const minutesRemaining = computed(() => {
+    if (!endsAt.value) return '';
+    const diff = Math.round((new Date(endsAt.value) - Date.now()) / 60000);
+    return diff > 0 ? `${diff} minutes from now` : 'soon';
+});
+
+const copyToClipboard = async (text) => {
+    await navigator.clipboard.writeText(text);
+};
+
+const downloadCredentials = () => {
+    const callsUrl = route('calls.index');
+    const lines = [
+        'Secure Line Credentials',
+        '=======================',
+        `Bridge Number: ${bridgeNumber.value}`,
+        `Call Password: ${callPassword.value}`,
+        `Session Closes: ${formattedExpiry.value}`,
+        '',
+        'Your participant visits ' + callsUrl + ', enters the bridge number under',
+        '"Join a Line", and uses the call password when prompted.',
+    ];
+    const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `secure-line-${bridgeNumber.value}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+};
+
+onMounted(async () => {
+    try {
+        const password = generatePassphrase();
+        const saltBytes = crypto.getRandomValues(new Uint8Array(32));
+        const keySalt = btoa(String.fromCharCode(...saltBytes));
+        const { publicKeyBase64 } = await deriveCallKeyPair(password, keySalt);
+
+        const res = await fetch(route('calls.store'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-XSRF-TOKEN': xsrfToken(),
+            },
+            body: JSON.stringify({
+                credit_token: props.credit_token,
+                public_key: publicKeyBase64,
+                key_salt: keySalt,
+            }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+            errorMessage.value = data.error ?? 'An error occurred while setting up your Secure Line.';
+            step.value = 'error';
+            return;
+        }
+
+        callPassword.value = password;
+        bridgeNumber.value = data.bridge_number;
+        endsAt.value = data.ends_at;
+        localStorage.removeItem('secure_line_pending_token');
+        step.value = 'done';
+    } catch {
+        errorMessage.value = 'An unexpected error occurred. Please try again.';
+        step.value = 'error';
+    }
+});
+</script>
+
+<template>
+    <AppLayout title="Your Secure Line">
+        <div class="dark min-h-screen bg-gray-950 flex items-center justify-center py-16 px-4">
+            <div class="max-w-xl w-full">
+
+                <!-- Creating / shimmer state -->
+                <div v-if="step === 'creating'" class="bg-gray-900 border border-gray-700 rounded-xl p-8 space-y-4">
+                    <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest">Secure Line</div>
+                    <h1 class="text-2xl font-bold text-white">Setting up your Secure Line…</h1>
+                    <p class="text-gray-400 text-sm">Generating encryption keys and creating your session. This only takes a moment.</p>
+                    <div class="relative h-1.5 w-full rounded-sm bg-gray-700 border border-gamboge-300/20 overflow-hidden mt-4">
+                        <div class="absolute inset-y-0 w-1/3 bg-gradient-to-r from-transparent via-gamboge-300 to-transparent animate-shimmer" />
+                    </div>
+                    <!-- Skeleton placeholders -->
+                    <div class="space-y-3 mt-4 animate-pulse">
+                        <div class="h-4 bg-gray-800 rounded w-3/4" />
+                        <div class="h-4 bg-gray-800 rounded w-1/2" />
+                        <div class="h-10 bg-gray-800 rounded" />
+                    </div>
+                </div>
+
+                <!-- Error state -->
+                <div v-else-if="step === 'error'" class="bg-gray-900 border border-red-500/40 rounded-xl p-8">
+                    <div class="text-red-400 font-mono text-xs uppercase tracking-widest mb-2">Error</div>
+                    <h1 class="text-2xl font-bold text-white mb-3">Setup failed</h1>
+                    <p class="text-red-300 text-sm mb-6">{{ errorMessage }}</p>
+                    <button
+                        @click="router.visit(route('calls.buy'))"
+                        class="w-full border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-sm py-2.5 rounded-lg transition-colors"
+                    >
+                        ← Back to Buy
+                    </button>
+                </div>
+
+                <!-- Credentials panel -->
+                <div v-else class="bg-gray-900 border border-gamboge-300 rounded-xl p-8 shadow-neon-cyan space-y-6">
+                    <div>
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-1">Secure Line — Ready</div>
+                        <h1 class="text-2xl font-bold text-white">Your Secure Line is set up</h1>
+                    </div>
+
+                    <div class="bg-red-900/20 border border-red-500/40 rounded-lg p-4 text-red-300 text-sm">
+                        <p class="font-semibold text-red-200 mb-1">Save these credentials now — they cannot be recovered.</p>
+                        Share both the bridge number and password with your participant before the session closes.
+                    </div>
+
+                    <!-- Bridge Number -->
+                    <div class="bg-gray-950 rounded-lg p-4">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Bridge Number</div>
+                        <div class="flex items-center gap-3">
+                            <code class="text-white text-lg flex-1 font-mono" data-testid="bridge-number">{{ bridgeNumber }}</code>
+                            <button
+                                @click="copyToClipboard(bridgeNumber)"
+                                class="shrink-0 text-gray-400 hover:text-gamboge-300 transition-colors text-xs border border-gray-700 hover:border-gamboge-300 rounded px-2 py-1 font-mono"
+                                data-testid="copy-bridge-number"
+                            >Copy</button>
+                        </div>
+                    </div>
+
+                    <!-- Call Password -->
+                    <div class="bg-gray-950 rounded-lg p-4">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Call Password</div>
+                        <div class="flex items-center gap-3">
+                            <code class="text-white text-sm flex-1 break-all font-mono" data-testid="call-password">{{ callPassword }}</code>
+                            <button
+                                @click="copyToClipboard(callPassword)"
+                                class="shrink-0 text-gray-400 hover:text-gamboge-300 transition-colors text-xs border border-gray-700 hover:border-gamboge-300 rounded px-2 py-1 font-mono"
+                                data-testid="copy-call-password"
+                            >Copy</button>
+                        </div>
+                    </div>
+
+                    <!-- Session expiry -->
+                    <div class="bg-yellow-900/20 border border-yellow-600/40 rounded-lg p-4">
+                        <div class="text-yellow-400 font-mono text-xs uppercase tracking-widest mb-1">Session Closes</div>
+                        <p class="text-yellow-200 text-sm font-semibold" data-testid="session-expiry">{{ formattedExpiry }}</p>
+                        <p class="text-yellow-300/70 text-xs mt-0.5">{{ minutesRemaining }}</p>
+                    </div>
+
+                    <!-- Participant instructions -->
+                    <div class="bg-gray-950 rounded-lg p-4">
+                        <div class="text-gamboge-300 font-mono text-xs uppercase tracking-widest mb-2">Participant Instructions</div>
+                        <p class="text-gray-300 text-sm">
+                            Your participant visits
+                            <a :href="route('calls.index')" class="font-mono text-gamboge-300 hover:underline">{{ route('calls.index') }}</a>,
+                            enters the bridge number under <span class="font-mono text-white">Join a Line</span>,
+                            and enters the call password when prompted.
+                        </p>
+                    </div>
+
+                    <!-- Download button -->
+                    <button
+                        @click="downloadCredentials"
+                        class="w-full border border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10 font-mono text-sm py-2.5 rounded-lg transition-colors"
+                        data-testid="download-credentials"
+                    >
+                        Download credentials as text file
+                    </button>
+
+                    <!-- Save confirmation -->
+                    <label class="flex items-center gap-2 text-gray-300 text-sm cursor-pointer">
+                        <input
+                            type="checkbox"
+                            v-model="savedConfirmed"
+                            class="rounded border-gray-600 bg-gray-700 text-gamboge-300"
+                            data-testid="saved-confirmed-checkbox"
+                        />
+                        I have saved the bridge number and call password
+                    </label>
+
+                    <!-- Done button -->
+                    <button
+                        :disabled="!savedConfirmed"
+                        @click="router.visit(route('calls.index'))"
+                        class="w-full bg-gamboge-300 hover:bg-gamboge-400 disabled:opacity-40 disabled:cursor-not-allowed text-gray-900 font-semibold py-2.5 px-4 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm"
+                        data-testid="done-button"
+                    >
+                        Done — Go to Calls
+                    </button>
+                </div>
+
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Call/Index.vue
+++ b/resources/js/Pages/Call/Index.vue
@@ -14,7 +14,7 @@ function joinLine() {
 
 <template>
     <AppLayout title="Secure Line">
-        <div class="dark min-h-screen bg-gray-950 py-16 px-4">
+        <div class="dark min-h-screen bg-gray-900 py-16 px-4">
             <div class="max-w-3xl mx-auto space-y-10">
 
                 <!-- Hero -->
@@ -39,7 +39,7 @@ function joinLine() {
                             placeholder="Bridge number"
                             @keydown.enter="joinLine"
                             data-testid="bridge-number-input"
-                            class="w-full bg-gray-950 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none"
+                            class="w-full bg-gray-800 border border-gray-700 text-white font-mono rounded-lg px-3 py-2.5 text-sm focus:border-gamboge-300 focus:outline-none"
                         />
                         <button
                             @click="joinLine"

--- a/resources/js/Pages/Call/Index.vue
+++ b/resources/js/Pages/Call/Index.vue
@@ -58,8 +58,7 @@ function joinLine() {
                             Host your own encrypted call window. Time-limited, zero-knowledge, no account needed for participants.
                         </p>
                         <Link
-                            :href="route('plans.index')"
-                            prefetch
+                            :href="route('calls.buy')"
                             class="block w-full text-center bg-gamboge-300 hover:bg-gamboge-400 text-gray-900 font-semibold py-2.5 rounded-lg font-mono text-sm transition-colors shadow-neon-cyan-sm hover:shadow-neon-cyan"
                         >
                             Buy a Line →

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\NotificationSettingsController;
 use App\Http\Controllers\PaymentConfirmingController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SecretController;
+use App\Http\Controllers\SecureLineCheckoutController;
 use App\Http\Controllers\SenderIdentityController;
 use App\Http\Controllers\WebhookSettingsController;
 use App\Http\Middleware\EnsurePlanHasApiAccess;
@@ -240,6 +241,17 @@ Route::middleware([
 // Call page routes — Inertia views; no auth required
 Route::prefix('calls')->name('calls.')->group(function () {
     Route::get('/', [CallPageController::class, 'index'])->name('index');
+
+    // Anonymous purchase flow — static routes must precede /{callSession} wildcard
+    Route::get('/buy', [SecureLineCheckoutController::class, 'buy'])->name('buy');
+    Route::post('/checkout', [SecureLineCheckoutController::class, 'checkout'])->name('checkout');
+    Route::get('/await-credit', [SecureLineCheckoutController::class, 'awaitCredit'])->name('await-credit');
+    Route::get('/credit-status', [SecureLineCheckoutController::class, 'creditStatus'])
+        ->middleware('throttle:30,1')->name('credit-status');
+    Route::get('/create', [SecureLineCheckoutController::class, 'create'])->name('create');
+    Route::post('/', [SecureLineCheckoutController::class, 'store'])
+        ->middleware('throttle:6,1')->name('store');
+
     Route::get('/{callSession}', [CallPageController::class, 'show'])->name('join');
     Route::get('/{callSession}/room', [CallPageController::class, 'room'])->name('room');
 });

--- a/tests/Feature/SecureLine/AnonymousCheckoutTest.php
+++ b/tests/Feature/SecureLine/AnonymousCheckoutTest.php
@@ -1,0 +1,400 @@
+<?php
+
+namespace Tests\Feature\SecureLine;
+
+use App\Listeners\HandleSecureLineStripeWebhook;
+use App\Models\CallSession;
+use App\Models\SecureLineCredit;
+use App\Models\SecureLineProduct;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Events\WebhookReceived;
+use Tests\TestCase;
+
+class AnonymousCheckoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Buy page ────────────────────────────────────────────────────────────
+
+    public function test_buy_page_shows_active_products_with_stripe_price_id(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create(['is_active' => true]);
+
+        $response = $this->get(route('calls.buy'));
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Buy')
+                ->has('products', 1)
+                ->where('products.0.id', $product->id)
+            );
+    }
+
+    public function test_buy_page_excludes_inactive_products(): void
+    {
+        SecureLineProduct::factory()->withStripePrice()->inactive()->create();
+
+        $response = $this->get(route('calls.buy'));
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Buy')
+                ->has('products', 0)
+            );
+    }
+
+    public function test_buy_page_excludes_products_without_stripe_price_id(): void
+    {
+        SecureLineProduct::factory()->create(['is_active' => true, 'stripe_price_id' => null]);
+
+        $response = $this->get(route('calls.buy'));
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Buy')
+                ->has('products', 0)
+            );
+    }
+
+    // ── Checkout ─────────────────────────────────────────────────────────────
+
+    public function test_checkout_rejects_inactive_product(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->inactive()->create();
+
+        $response = $this->post(route('calls.checkout'), ['product_id' => $product->id]);
+
+        $response->assertSessionHasErrors('product_id');
+    }
+
+    public function test_checkout_rejects_product_without_stripe_price_id(): void
+    {
+        $product = SecureLineProduct::factory()->create(['is_active' => true, 'stripe_price_id' => null]);
+
+        $response = $this->post(route('calls.checkout'), ['product_id' => $product->id]);
+
+        $response->assertSessionHasErrors('product_id');
+    }
+
+    // ── Credit Status ─────────────────────────────────────────────────────────
+
+    public function test_credit_status_returns_missing_session_error_without_param(): void
+    {
+        $response = $this->getJson(route('calls.credit-status'));
+
+        $response->assertStatus(422)->assertJson(['error' => 'Missing session parameter.']);
+    }
+
+    public function test_credit_status_returns_pending_when_no_credit(): void
+    {
+        $response = $this->getJson(route('calls.credit-status').'?session=nonexistent_session');
+
+        $response->assertStatus(200)->assertJson(['pending' => true]);
+    }
+
+    public function test_credit_status_returns_token_when_credit_exists(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        $credit = SecureLineCredit::factory()->create([
+            'stripe_session_id' => 'cs_test_abc123',
+            'secure_line_product_id' => $product->id,
+            'token' => 'sometoken',
+        ]);
+
+        $response = $this->getJson(route('calls.credit-status').'?session=cs_test_abc123');
+
+        $response->assertStatus(200)->assertJson(['token' => 'sometoken']);
+    }
+
+    // ── Create page ──────────────────────────────────────────────────────────
+
+    public function test_create_page_requires_valid_unused_token(): void
+    {
+        $response = $this->get(route('calls.create').'?token=invalid');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_create_page_rejects_invalid_token(): void
+    {
+        $response = $this->get(route('calls.create'));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_create_page_rejects_used_token(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        SecureLineCredit::factory()->used()->create([
+            'token' => 'usedtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+
+        $response = $this->get(route('calls.create').'?token=usedtoken');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_create_page_loads_with_valid_unused_token(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create([
+            'name' => 'Test Product',
+            'duration_minutes' => 30,
+            'max_participants' => 5,
+        ]);
+        SecureLineCredit::factory()->create([
+            'token' => 'validtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+
+        $response = $this->get(route('calls.create').'?token=validtoken');
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('Call/Create')
+                ->where('credit_token', 'validtoken')
+                ->where('product.name', 'Test Product')
+                ->where('product.duration_minutes', 30)
+                ->where('product.max_participants', 5)
+            );
+    }
+
+    public function test_create_page_handles_soft_deleted_product(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        SecureLineCredit::factory()->create([
+            'token' => 'validtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+        $product->delete(); // soft delete
+
+        $response = $this->get(route('calls.create').'?token=validtoken');
+
+        // Should still work — controller loads product with withTrashed()
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page->component('Call/Create'));
+    }
+
+    // ── Store ─────────────────────────────────────────────────────────────────
+
+    public function test_store_rejects_invalid_token(): void
+    {
+        $response = $this->postJson(route('calls.store'), [
+            'credit_token' => 'notavalidtoken',
+            'public_key' => base64_encode(random_bytes(32)),
+            'key_salt' => base64_encode(random_bytes(32)),
+        ]);
+
+        $response->assertStatus(422)->assertJson(['error' => 'Invalid or used credit token.']);
+    }
+
+    public function test_store_rejects_used_credit_token(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        SecureLineCredit::factory()->used()->create([
+            'token' => 'usedtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+
+        $response = $this->postJson(route('calls.store'), [
+            'credit_token' => 'usedtoken',
+            'public_key' => base64_encode(random_bytes(32)),
+            'key_salt' => base64_encode(random_bytes(32)),
+        ]);
+
+        $response->assertStatus(422)->assertJson(['error' => 'Invalid or used credit token.']);
+    }
+
+    public function test_store_creates_call_session_and_marks_credit_used(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create([
+            'duration_minutes' => 30,
+            'max_participants' => 4,
+        ]);
+        SecureLineCredit::factory()->create([
+            'token' => 'freshtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+
+        $publicKey = base64_encode(random_bytes(32));
+        $keySalt = base64_encode(random_bytes(32));
+
+        $response = $this->postJson(route('calls.store'), [
+            'credit_token' => 'freshtoken',
+            'public_key' => $publicKey,
+            'key_salt' => $keySalt,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['bridge_number', 'starts_at', 'ends_at']);
+
+        $this->assertDatabaseHas('call_sessions', ['public_key' => $publicKey]);
+
+        $credit = SecureLineCredit::where('token', 'freshtoken')->first();
+        $this->assertNotNull($credit->used_at);
+        $this->assertNotNull($credit->call_session_id);
+    }
+
+    public function test_store_sets_correct_session_duration_from_product(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create(['duration_minutes' => 45]);
+        SecureLineCredit::factory()->create([
+            'token' => 'durationtoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+
+        $response = $this->postJson(route('calls.store'), [
+            'credit_token' => 'durationtoken',
+            'public_key' => base64_encode(random_bytes(32)),
+            'key_salt' => base64_encode(random_bytes(32)),
+        ]);
+
+        $response->assertStatus(200);
+
+        $bridgeNumber = $response->json('bridge_number');
+        $session = CallSession::whereNotNull('public_key')->latest()->first();
+        $this->assertEquals(45, $session->starts_at->diffInMinutes($session->ends_at));
+    }
+
+    public function test_store_loads_soft_deleted_product_correctly(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create(['duration_minutes' => 60]);
+        SecureLineCredit::factory()->create([
+            'token' => 'softdeltoken',
+            'secure_line_product_id' => $product->id,
+        ]);
+        $product->delete(); // soft delete
+
+        $response = $this->postJson(route('calls.store'), [
+            'credit_token' => 'softdeltoken',
+            'public_key' => base64_encode(random_bytes(32)),
+            'key_salt' => base64_encode(random_bytes(32)),
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['bridge_number']);
+    }
+
+    // ── Webhook ───────────────────────────────────────────────────────────────
+
+    public function test_webhook_creates_credit_for_secure_line_product(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_webhook001',
+                    'payment_status' => 'paid',
+                    'metadata' => [
+                        'product_type' => 'secure_line',
+                        'secure_line_product_id' => $product->id,
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseHas('secure_line_credits', [
+            'stripe_session_id' => 'cs_test_webhook001',
+            'secure_line_product_id' => $product->id,
+        ]);
+    }
+
+    public function test_webhook_is_idempotent_on_duplicate_stripe_session_id(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $payload = [
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_duplicate',
+                    'payment_status' => 'paid',
+                    'metadata' => [
+                        'product_type' => 'secure_line',
+                        'secure_line_product_id' => $product->id,
+                    ],
+                ],
+            ],
+        ];
+
+        $listener->handle(new WebhookReceived($payload));
+        $listener->handle(new WebhookReceived($payload));
+
+        $this->assertDatabaseCount('secure_line_credits', 1);
+    }
+
+    public function test_webhook_ignores_non_secure_line_events(): void
+    {
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_other',
+                    'payment_status' => 'paid',
+                    'metadata' => [
+                        'product_type' => 'something_else',
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseCount('secure_line_credits', 0);
+    }
+
+    public function test_webhook_ignores_locker_events(): void
+    {
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_locker',
+                    'payment_status' => 'paid',
+                    'metadata' => [
+                        'action' => 'create',
+                        'tier' => 'text',
+                        'years' => '1',
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseCount('secure_line_credits', 0);
+    }
+
+    public function test_webhook_ignores_processing_payment_status(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_processing',
+                    'payment_status' => 'unpaid',
+                    'metadata' => [
+                        'product_type' => 'secure_line',
+                        'secure_line_product_id' => $product->id,
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseCount('secure_line_credits', 0);
+    }
+}

--- a/tests/e2e/helpers/calls.ts
+++ b/tests/e2e/helpers/calls.ts
@@ -8,10 +8,7 @@ const ARTISAN = process.env.CI ? 'php artisan' : 'vendor/bin/sail artisan';
  */
 export function createSecureLineCredit(token: string, used: boolean = false): void {
     const usedAt = used ? `'used_at' => now()` : `'used_at' => null`;
-    const script = [
-        `$p = App\\\\Models\\\\SecureLineProduct::factory()->withStripePrice()->create(['duration_minutes' => 30, 'max_participants' => 5]);`,
-        `App\\\\Models\\\\SecureLineCredit::create(['token' => '${token}', 'stripe_session_id' => 'cs_test_e2e_${token}', 'secure_line_product_id' => $p->id, ${usedAt}]);`,
-    ].join(' ');
+    const script = `App\\\\Models\\\\SecureLineCredit::create(['token' => '${token}', 'stripe_session_id' => 'cs_test_e2e_${token}', 'secure_line_product_id' => App\\\\Models\\\\SecureLineProduct::factory()->withStripePrice()->create(['duration_minutes' => 30, 'max_participants' => 5])->id, ${usedAt}]);`;
     execSync(
         `${ARTISAN} tinker --no-interaction --env=testing --execute="${script}"`,
         { stdio: 'pipe' }

--- a/tests/e2e/helpers/calls.ts
+++ b/tests/e2e/helpers/calls.ts
@@ -3,6 +3,22 @@ import { execSync } from 'child_process';
 const ARTISAN = process.env.CI ? 'php artisan' : 'vendor/bin/sail artisan';
 
 /**
+ * Create a SecureLineCredit with a known token via tinker.
+ * Creates a product with a stripe_price_id automatically.
+ */
+export function createSecureLineCredit(token: string, used: boolean = false): void {
+    const usedAt = used ? `'used_at' => now()` : `'used_at' => null`;
+    const script = [
+        `$p = App\\\\Models\\\\SecureLineProduct::factory()->withStripePrice()->create(['duration_minutes' => 30, 'max_participants' => 5]);`,
+        `App\\\\Models\\\\SecureLineCredit::create(['token' => '${token}', 'stripe_session_id' => 'cs_test_e2e_${token}', 'secure_line_product_id' => $p->id, ${usedAt}]);`,
+    ].join(' ');
+    execSync(
+        `${ARTISAN} tinker --no-interaction --env=testing --execute="${script}"`,
+        { stdio: 'pipe' }
+    );
+}
+
+/**
  * Create an active call session via tinker and return its hash_id.
  */
 export function createActiveCallSession(): string {

--- a/tests/e2e/secure-line-purchase.spec.ts
+++ b/tests/e2e/secure-line-purchase.spec.ts
@@ -36,7 +36,7 @@ test('buy page shows "How it works" block and active products', async ({ page })
     await expect(page.getByText(/Your call window starts the moment/)).toBeVisible();
 
     await expect(page.getByText('Quick Call')).toBeVisible();
-    await expect(page.getByText('$20')).toBeVisible();
+    await expect(page.getByTestId('product-price')).toContainText('$20');
     await expect(page.getByTestId('purchase-button')).toBeVisible();
 });
 
@@ -114,8 +114,10 @@ test('await-credit shows retry button after timeout', async ({ page }) => {
     await page.goto('/calls/await-credit?session=cs_test_timeout');
     await page.waitForLoadState('networkidle');
 
-    // Fast-forward 60 seconds to trigger the timeout
-    await page.clock.fastForward(62000);
+    // Step through 32 intervals of 2s each so Vue flushes reactivity between ticks
+    for (let i = 0; i < 32; i++) {
+        await page.clock.tick(2000);
+    }
 
     await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Bank transfers may take 1–3 business days')).toBeVisible();

--- a/tests/e2e/secure-line-purchase.spec.ts
+++ b/tests/e2e/secure-line-purchase.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from './helpers/db';
+import { createSecureLineProduct } from './helpers/db';
+import { createSecureLineCredit } from './helpers/calls';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+// ── Call/Index buy button ────────────────────────────────────────────────────
+
+test('Buy a Line card links to /calls/buy', async ({ page }) => {
+    await page.goto('/calls');
+    await page.waitForLoadState('networkidle');
+
+    const buyLink = page.getByText('Buy a Line →');
+    await expect(buyLink).toBeVisible();
+
+    await buyLink.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL('/calls/buy');
+});
+
+// ── Buy page ─────────────────────────────────────────────────────────────────
+
+test('buy page shows "How it works" block and active products', async ({ page }) => {
+    createSecureLineProduct({ name: 'Quick Call', amount_cents: 2000, stripe_price_id: 'price_test_e2e' });
+
+    await page.goto('/calls/buy');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('How it works')).toBeVisible();
+    await expect(page.getByText('Pay once — no account, no subscription.')).toBeVisible();
+    await expect(page.getByText('Receive a bridge number and a call password.')).toBeVisible();
+    await expect(page.getByText(/Your call window starts the moment/)).toBeVisible();
+
+    await expect(page.getByText('Quick Call')).toBeVisible();
+    await expect(page.getByText('$20')).toBeVisible();
+    await expect(page.getByTestId('purchase-button')).toBeVisible();
+});
+
+test('buy page shows empty state when no products', async ({ page }) => {
+    await page.goto('/calls/buy');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('No Secure Line products are currently available.')).toBeVisible();
+});
+
+test('buy page excludes inactive products', async ({ page }) => {
+    createSecureLineProduct({ name: 'Hidden Product', stripe_price_id: 'price_test_e2e', is_active: false });
+
+    await page.goto('/calls/buy');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Hidden Product')).not.toBeVisible();
+});
+
+// ── Pending token recovery banner ────────────────────────────────────────────
+
+test('buy page shows recovery banner when pending token in localStorage', async ({ page }) => {
+    // Navigate first to set localStorage, then revisit
+    await page.goto('/calls/buy');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => {
+        localStorage.setItem('secure_line_pending_token', 'recovery-test-token');
+    });
+
+    // Reload to trigger the onMounted check
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Unused Secure Line Credit')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Continue →' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Dismiss' })).toBeVisible();
+});
+
+test('dismissing the recovery banner removes it', async ({ page }) => {
+    await page.goto('/calls/buy');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => {
+        localStorage.setItem('secure_line_pending_token', 'dismiss-test-token');
+    });
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    await expect(page.getByText('Unused Secure Line Credit')).not.toBeVisible();
+});
+
+// ── AwaitCredit page ─────────────────────────────────────────────────────────
+
+test('await-credit page shows shimmer and payment reference initially', async ({ page }) => {
+    await page.goto('/calls/await-credit?session=cs_test_e2e_fake');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Confirming your payment…')).toBeVisible();
+    await expect(page.getByText('cs_test_e2e_fake')).toBeVisible();
+    await expect(page.getByText('Waiting for Stripe confirmation…')).toBeVisible();
+});
+
+test('await-credit shows retry button after timeout', async ({ page }) => {
+    // Block the credit-status endpoint so it never resolves
+    await page.route('**/calls/credit-status**', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ pending: true }) })
+    );
+
+    // Install fake clock before navigation so setInterval is captured
+    await page.clock.install();
+    await page.goto('/calls/await-credit?session=cs_test_timeout');
+    await page.waitForLoadState('networkidle');
+
+    // Fast-forward 60 seconds to trigger the timeout
+    await page.clock.fastForward(62000);
+
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Bank transfers may take 1–3 business days')).toBeVisible();
+});
+
+// ── Create page ───────────────────────────────────────────────────────────────
+
+test('create page shows 404 for invalid token', async ({ page }) => {
+    const response = await page.request.get('/calls/create?token=notexists');
+    expect(response.status()).toBe(404);
+});
+
+test('create page shows 404 for used credit token', async ({ page }) => {
+    createSecureLineCredit('usedtoken123', true);
+
+    const response = await page.request.get('/calls/create?token=usedtoken123');
+    expect(response.status()).toBe(404);
+});
+
+test('full happy path: create page generates credentials and shows them', async ({ page }) => {
+    createSecureLineCredit('e2etoken123');
+
+    await page.goto('/calls/create?token=e2etoken123');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for credentials panel to appear (crypto + API call)
+    await expect(page.getByTestId('bridge-number')).toBeVisible({ timeout: 15000 });
+
+    // Bridge number and password are shown
+    const bridgeNumber = await page.getByTestId('bridge-number').textContent();
+    expect(bridgeNumber?.trim().length).toBeGreaterThan(0);
+
+    await expect(page.getByTestId('call-password')).toBeVisible();
+    const password = await page.getByTestId('call-password').textContent();
+    expect(password?.trim().length).toBeGreaterThan(0);
+
+    // Session expiry is shown
+    await expect(page.getByTestId('session-expiry')).toBeVisible();
+
+    // Copy buttons present
+    await expect(page.getByTestId('copy-bridge-number')).toBeVisible();
+    await expect(page.getByTestId('copy-call-password')).toBeVisible();
+
+    // Download button present
+    await expect(page.getByTestId('download-credentials')).toBeVisible();
+
+    // Done button is disabled until checkbox is checked
+    await expect(page.getByTestId('done-button')).toBeDisabled();
+
+    // Check the "I have saved" checkbox
+    await page.getByTestId('saved-confirmed-checkbox').check();
+
+    // Done button is now enabled
+    await expect(page.getByTestId('done-button')).toBeEnabled();
+});
+
+test('done button navigates to /calls after confirming credentials saved', async ({ page }) => {
+    createSecureLineCredit('e2etoken456');
+
+    await page.goto('/calls/create?token=e2etoken456');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('bridge-number')).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('saved-confirmed-checkbox').check();
+    await page.getByTestId('done-button').click();
+
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL('/calls');
+});
+
+test('create page removes pending token from localStorage on success', async ({ page }) => {
+    createSecureLineCredit('e2etoken789');
+
+    // Pre-set the pending token
+    await page.goto('/calls');
+    await page.evaluate(() => {
+        localStorage.setItem('secure_line_pending_token', 'e2etoken789');
+    });
+
+    await page.goto('/calls/create?token=e2etoken789');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('bridge-number')).toBeVisible({ timeout: 15000 });
+
+    const pendingToken = await page.evaluate(() => localStorage.getItem('secure_line_pending_token'));
+    expect(pendingToken).toBeNull();
+});
+
+test('participant instructions are shown on credentials page', async ({ page }) => {
+    createSecureLineCredit('e2etoken_instruct');
+
+    await page.goto('/calls/create?token=e2etoken_instruct');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('bridge-number')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/Join a Line/)).toBeVisible();
+});

--- a/tests/e2e/secure-line-purchase.spec.ts
+++ b/tests/e2e/secure-line-purchase.spec.ts
@@ -116,7 +116,7 @@ test('await-credit shows retry button after timeout', async ({ page }) => {
 
     // Step through 32 intervals of 2s each so Vue flushes reactivity between ticks
     for (let i = 0; i < 32; i++) {
-        await page.clock.tick(2000);
+        await page.clock.runFor(2000);
     }
 
     await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible({ timeout: 5000 });

--- a/tools/flashview-crypto/src/index.js
+++ b/tools/flashview-crypto/src/index.js
@@ -903,6 +903,18 @@ export async function decryptMessage(ciphertextString, passphrase) {
 // ─── Call Session Auth ────────────────────────────────────────────────────────
 
 /**
+ * Generate a cryptographically random 32-byte PBKDF2 salt for call key derivation (base64-encoded).
+ * Used as the key_salt stored in CallSession and passed to deriveCallKeyPair.
+ *
+ * @returns {string} base64-encoded 32-byte salt
+ */
+export function generateCallKeySalt() {
+    const salt = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(salt);
+    return uint8ArrayToBase64(salt);
+}
+
+/**
  * Derives a deterministic Ed25519 key pair from a password and PBKDF2 salt.
  *
  * SHA-256 is used here (not SHA-512 like other PBKDF2 derivations in this module)


### PR DESCRIPTION
## Summary

- Adds a full anonymous, one-off Stripe checkout flow for Secure Line sessions — no account or subscription required
- Introduces the `SecureLineCredit` model (analogous to `LockerCredit`) as a one-time consumable token issued after Stripe payment confirmation
- Browser-side key generation: `generateCallKeySalt()` added to `flashview-crypto`; `Create.vue` derives an Ed25519 key pair in-browser and POSTs only the public key and salt to the server

## What's included

**Backend**
- `SecureLineCredit` model + migration + factory
- `HandleSecureLineStripeWebhook` listener — idempotent, guards against async payment methods (SEPA/BACS via `payment_status !== 'paid'`)
- `SecureLineCheckoutController` — buy, checkout (Stripe redirect), await-credit (polling page), credit-status (JSON), create, store
- `CheckoutSecureLineRequest` + `StoreCallSessionRequest` form requests
- TOCTOU prevention: `DB::transaction()` + `lockForUpdate()` in `store()`
- Soft-delete safety: `withTrashed()` on product eager-load; `restrictOnDelete` FK prevents hard-deletes of products with credits
- 6 new routes under `/calls/` prefix, all ordered before the `/{callSession}` wildcard

**Frontend**
- `Call/Buy.vue` — product grid, "How it works" block, localStorage recovery banner
- `Call/AwaitCredit.vue` — polls `/calls/credit-status` every 2s; shimmer progress bar; 60s timeout with bank-transfer guidance
- `Call/Create.vue` — auto-generates passphrase + key pair on mount, POSTs to store, shows credentials panel with copy/download/done gate
- `Call/Index.vue` — "Buy a Line" button now links to `calls.buy`

**Crypto**
- `generateCallKeySalt()` added to `tools/flashview-crypto/src/index.js` (centralises all random salt generation)

**Tests**
- 23 PHPUnit feature tests covering happy path, TOCTOU, used tokens, duration, soft-deleted products, webhook idempotency
- 14 Playwright E2E tests covering full purchase flow, recovery banner, 60s timeout, 404 for invalid/used tokens, localStorage lifecycle

## Regression risks (from regression-detector)

- `HandleLockerStripeWebhook` now shares the `WebhookReceived` event with the new listener — SecureLine events reach it but safely fall through via `default => null` in the existing `match($action)` block. No locker credits can be created by a SecureLine webhook.
- `Call/Index.vue`, `Call/Join.vue`, `Call/Room.vue` still use `bg-gray-950` (undefined in the custom Tailwind palette) — pre-existing on those files, not introduced by this PR. Recommend a follow-up style pass.

## Test plan

- [ ] Visit `/calls`, click "Buy a Line →" — should navigate to `/calls/buy`
- [ ] Buy page shows product grid with price, duration, max participants, and Purchase button
- [ ] Clicking Purchase redirects to Stripe Checkout (use test card `4242 4242 4242 4242`)
- [ ] After payment, `/calls/await-credit` shows shimmer and payment reference; auto-redirects to `/calls/create?token=...` once webhook fires
- [ ] `/calls/create` auto-generates credentials — bridge number, call password, session expiry shown
- [ ] Copy buttons, download as `.txt`, and "I have saved" checkbox gate work correctly
- [ ] Revisiting `/calls/buy` with a pending token in localStorage shows the recovery banner
- [ ] Used or invalid token at `/calls/create` returns 404
- [ ] PHPUnit: `php artisan test tests/Feature/SecureLine/AnonymousCheckoutTest.php`
- [ ] E2E: `npx playwright test tests/e2e/secure-line-purchase.spec.ts`