### PR TITLE
PIO-122: Admin — Stripe Coupon/Promotion Code Management + Enable at eLocker & Secure Line Checkout

### DIFF
--- a/app/Http/Controllers/Admin/AdminCouponController.php
+++ b/app/Http/Controllers/Admin/AdminCouponController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreCouponRequest;
+use App\Http\Requests\TogglePromoCodeRequest;
 use App\Models\LockerPlan;
 use App\Models\SecureLineProduct;
 use App\Services\StripePromotionService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -95,7 +95,7 @@ class AdminCouponController extends Controller
             ->with('flash', ['success' => 'Coupon deleted.']);
     }
 
-    public function togglePromoCode(Request $request, string $couponId, string $promoCodeId): RedirectResponse
+    public function togglePromoCode(TogglePromoCodeRequest $request, string $couponId, string $promoCodeId): RedirectResponse
     {
         $active = $request->boolean('active');
         $this->stripePromotion->updatePromotionCode($promoCodeId, $active);

--- a/app/Http/Controllers/Admin/AdminCouponController.php
+++ b/app/Http/Controllers/Admin/AdminCouponController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreCouponRequest;
 use App\Http\Requests\TogglePromoCodeRequest;
 use App\Models\LockerPlan;
+use App\Models\Plan;
 use App\Models\SecureLineProduct;
 use App\Services\StripePromotionService;
 use Illuminate\Http\RedirectResponse;
@@ -188,6 +189,17 @@ class AdminCouponController extends Controller
         foreach ($priceIds as $priceId) {
             $price = Cashier::stripe()->prices->retrieve($priceId);
             $productIds[] = $price->product;
+        }
+
+        // Plans store stripe_product_id directly — no extra Stripe API call needed.
+        if ($appliesTo === 'subscription') {
+            $subscriptionProductIds = Plan::whereNotNull('stripe_product_id')
+                ->get()
+                ->filter(fn (Plan $plan) => $plan->isCurrentlyAvailable())
+                ->pluck('stripe_product_id')
+                ->toArray();
+
+            $productIds = array_merge($productIds, $subscriptionProductIds);
         }
 
         return array_unique($productIds);

--- a/app/Http/Controllers/Admin/AdminCouponController.php
+++ b/app/Http/Controllers/Admin/AdminCouponController.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCouponRequest;
+use App\Models\LockerPlan;
+use App\Models\SecureLineProduct;
+use App\Services\StripePromotionService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Cashier\Cashier;
+use Stripe\Exception\InvalidRequestException;
+
+class AdminCouponController extends Controller
+{
+    public function __construct(private StripePromotionService $stripePromotion) {}
+
+    public function index(): Response
+    {
+        $coupons = $this->stripePromotion->listCoupons();
+
+        return Inertia::render('Admin/Coupons/Index', ['coupons' => $coupons]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Admin/Coupons/Form');
+    }
+
+    public function store(StoreCouponRequest $request): RedirectResponse
+    {
+        $coupon = null;
+
+        try {
+            $couponData = $this->buildCouponData($request);
+            $coupon = $this->stripePromotion->createCoupon($couponData);
+
+            $promoData = $this->buildPromoCodeData($request);
+            $this->stripePromotion->createPromotionCode($coupon->id, strtoupper($request->input('promo_code')), $promoData);
+
+            return redirect()->route('admin.coupons.show', $coupon->id)
+                ->with('flash', ['success' => 'Coupon and promotion code '.$request->input('promo_code').' created.']);
+        } catch (\Throwable $e) {
+            if ($coupon !== null) {
+                try {
+                    $this->stripePromotion->deleteCoupon($coupon->id);
+                } catch (\Throwable) {
+                }
+            }
+
+            Log::error('Failed to create coupon/promo code', ['error' => $e->getMessage()]);
+
+            return redirect()->back()->with('flash', ['error' => $e->getMessage() ?: 'Failed to create coupon. Check logs.']);
+        }
+    }
+
+    public function show(string $id): Response|RedirectResponse
+    {
+        try {
+            $coupon = $this->stripePromotion->retrieveCoupon($id);
+            $promoCodes = $this->stripePromotion->getPromotionCodesForCoupon($id);
+
+            return Inertia::render('Admin/Coupons/Show', [
+                'coupon' => $coupon,
+                'promoCodes' => $promoCodes,
+            ]);
+        } catch (InvalidRequestException $e) {
+            if ($e->getHttpStatus() === 404) {
+                return redirect()->route('admin.coupons.index')
+                    ->with('flash', ['error' => 'Coupon not found. It may have been deleted.']);
+            }
+
+            throw $e;
+        }
+    }
+
+    public function destroy(string $id): RedirectResponse
+    {
+        try {
+            $this->stripePromotion->deleteCoupon($id);
+        } catch (InvalidRequestException $e) {
+            if ($e->getHttpStatus() === 404) {
+                return redirect()->route('admin.coupons.index')
+                    ->with('flash', ['error' => 'Coupon not found. It may have already been deleted.']);
+            }
+
+            throw $e;
+        }
+
+        return redirect()->route('admin.coupons.index')
+            ->with('flash', ['success' => 'Coupon deleted.']);
+    }
+
+    public function togglePromoCode(Request $request, string $couponId, string $promoCodeId): RedirectResponse
+    {
+        $active = $request->boolean('active');
+        $this->stripePromotion->updatePromotionCode($promoCodeId, $active);
+
+        return redirect()->route('admin.coupons.show', $couponId)
+            ->with('flash', ['success' => $active ? 'Promotion code activated.' : 'Promotion code deactivated.']);
+    }
+
+    private function buildCouponData(StoreCouponRequest $request): array
+    {
+        $data = [
+            'name' => $request->input('name'),
+            'duration' => $request->input('duration'),
+        ];
+
+        if ($request->input('duration') === 'repeating') {
+            $data['duration_in_months'] = (int) $request->input('duration_in_months');
+        }
+
+        if ($request->input('discount_type') === 'percent') {
+            $data['percent_off'] = (float) $request->input('discount_value');
+        } else {
+            $data['amount_off'] = (int) round($request->input('discount_value') * 100);
+            $data['currency'] = strtolower($request->input('currency'));
+        }
+
+        if ($request->filled('max_redemptions')) {
+            $data['max_redemptions'] = (int) $request->input('max_redemptions');
+        }
+
+        if ($request->filled('expires_at')) {
+            $data['redeem_by'] = strtotime($request->input('expires_at'));
+        }
+
+        if ($request->filled('applies_to')) {
+            $productIds = $this->resolveProductIds($request->input('applies_to'));
+
+            if (empty($productIds)) {
+                throw new \RuntimeException('No active Stripe products found for the selected restriction. Add active products first or choose "All Products".');
+            }
+
+            $data['applies_to'] = ['products' => $productIds];
+        }
+
+        return $data;
+    }
+
+    private function buildPromoCodeData(StoreCouponRequest $request): array
+    {
+        $data = [];
+
+        if ($request->filled('max_redemptions_per_user')) {
+            $data['max_redemptions'] = (int) $request->input('max_redemptions_per_user');
+        }
+
+        $restrictions = [];
+
+        if ($request->filled('minimum_amount')) {
+            $restrictions['minimum_amount'] = (int) round($request->input('minimum_amount') * 100);
+            $restrictions['minimum_amount_currency'] = strtolower($request->input('currency', config('cashier.currency', 'aud')));
+        }
+
+        if (! empty($restrictions)) {
+            $data['restrictions'] = $restrictions;
+        }
+
+        return $data;
+    }
+
+    private function resolveProductIds(string $appliesTo): array
+    {
+        $priceIds = [];
+
+        if (in_array($appliesTo, ['locker', 'both'])) {
+            $priceIds = array_merge(
+                $priceIds,
+                LockerPlan::where('is_active', true)->whereNotNull('stripe_price_id')->pluck('stripe_price_id')->toArray()
+            );
+        }
+
+        if (in_array($appliesTo, ['secure_line', 'both'])) {
+            $priceIds = array_merge(
+                $priceIds,
+                SecureLineProduct::where('is_active', true)->whereNotNull('stripe_price_id')->pluck('stripe_price_id')->toArray()
+            );
+        }
+
+        $productIds = [];
+
+        foreach ($priceIds as $priceId) {
+            $price = Cashier::stripe()->prices->retrieve($priceId);
+            $productIds[] = $price->product;
+        }
+
+        return array_unique($productIds);
+    }
+}

--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -67,6 +67,7 @@ class LockerController extends Controller
         try {
             $session = Cashier::stripe()->checkout->sessions->create([
                 'mode' => 'payment',
+                'allow_promotion_codes' => true,
                 'line_items' => [['price' => $priceId, 'quantity' => 1]],
                 'metadata' => ['action' => 'create', 'years' => $years, 'tier' => $tier],
                 'success_url' => route('lockers.await-credit').'?session={CHECKOUT_SESSION_ID}',
@@ -628,6 +629,7 @@ class LockerController extends Controller
         try {
             $session = Cashier::stripe()->checkout->sessions->create([
                 'mode' => 'payment',
+                'allow_promotion_codes' => true,
                 'line_items' => [['price' => $priceId, 'quantity' => 1]],
                 'metadata' => [
                     'action' => 'renewal',

--- a/app/Http/Controllers/SecureLineCheckoutController.php
+++ b/app/Http/Controllers/SecureLineCheckoutController.php
@@ -40,6 +40,7 @@ class SecureLineCheckoutController extends Controller
         try {
             $session = Cashier::stripe()->checkout->sessions->create([
                 'mode' => 'payment',
+                'allow_promotion_codes' => true,
                 'line_items' => [['price' => $product->stripe_price_id, 'quantity' => 1]],
                 'metadata' => [
                     'product_type' => 'secure_line',

--- a/app/Http/Requests/StoreCouponRequest.php
+++ b/app/Http/Requests/StoreCouponRequest.php
@@ -25,7 +25,7 @@ class StoreCouponRequest extends FormRequest
             'duration' => ['required', 'in:once,forever,repeating'],
             'duration_in_months' => ['required_if:duration,repeating', 'nullable', 'integer', 'min:1', 'max:36'],
             'currency' => ['required_if:discount_type,amount', 'nullable', 'string', 'size:3'],
-            'applies_to' => ['nullable', 'in:locker,secure_line,both'],
+            'applies_to' => ['nullable', 'in:locker,secure_line,subscription,both'],
             'max_redemptions' => ['nullable', 'integer', 'min:1'],
             'max_redemptions_per_user' => ['nullable', 'integer', 'min:1'],
             'minimum_amount' => ['nullable', 'numeric', 'min:0'],

--- a/app/Http/Requests/StoreCouponRequest.php
+++ b/app/Http/Requests/StoreCouponRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreCouponRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'discount_type' => ['required', 'in:percent,amount'],
+            'discount_value' => ['required', 'numeric', 'min:1', Rule::when($this->input('discount_type') === 'percent', ['max:100'])],
+            'duration' => ['required', 'in:once,forever,repeating'],
+            'duration_in_months' => ['required_if:duration,repeating', 'nullable', 'integer', 'min:1', 'max:36'],
+            'currency' => ['required_if:discount_type,amount', 'nullable', 'string', 'size:3'],
+            'applies_to' => ['nullable', 'in:locker,secure_line,both'],
+            'max_redemptions' => ['nullable', 'integer', 'min:1'],
+            'max_redemptions_per_user' => ['nullable', 'integer', 'min:1'],
+            'minimum_amount' => ['nullable', 'numeric', 'min:0'],
+            'expires_at' => ['nullable', 'date', 'after:today'],
+            'promo_code' => ['required', 'string', 'regex:/^[A-Z0-9_-]+$/i', 'min:3', 'max:20'],
+        ];
+    }
+}

--- a/app/Http/Requests/TogglePromoCodeRequest.php
+++ b/app/Http/Requests/TogglePromoCodeRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TogglePromoCodeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'active' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Listeners/HandleLockerStripeWebhook.php
+++ b/app/Listeners/HandleLockerStripeWebhook.php
@@ -32,6 +32,16 @@ class HandleLockerStripeWebhook
 
     private function handleCreate(array $session): void
     {
+        // Guard: async payment methods and 100%-off coupons can produce non-paid sessions.
+        if (($session['payment_status'] ?? null) !== 'paid' && ($session['payment_status'] ?? null) !== 'no_payment_required') {
+            Log::info('Locker create webhook: skipping non-paid session', [
+                'stripe_session_id' => $session['id'],
+                'payment_status' => $session['payment_status'] ?? null,
+            ]);
+
+            return;
+        }
+
         if (LockerCredit::where('stripe_session_id', $session['id'])->exists()) {
             return;
         }

--- a/app/Listeners/HandleSecureLineStripeWebhook.php
+++ b/app/Listeners/HandleSecureLineStripeWebhook.php
@@ -3,6 +3,7 @@
 namespace App\Listeners;
 
 use App\Models\SecureLineCredit;
+use App\Models\SecureLineProduct;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Events\WebhookReceived;
 
@@ -22,11 +23,13 @@ class HandleSecureLineStripeWebhook
             return;
         }
 
-        // Guard: async payment methods (SEPA, BACS) fire completed before money clears.
-        if (($session['payment_status'] ?? null) !== 'paid') {
+        // Guard: accept paid (normal) and no_payment_required (100%-off coupon); reject unpaid (async methods).
+        $paymentStatus = $session['payment_status'] ?? null;
+
+        if ($paymentStatus !== 'paid' && $paymentStatus !== 'no_payment_required') {
             Log::info('SecureLine webhook: skipping non-paid session', [
                 'stripe_session_id' => $session['id'],
-                'payment_status' => $session['payment_status'] ?? null,
+                'payment_status' => $paymentStatus,
             ]);
 
             return;
@@ -41,6 +44,15 @@ class HandleSecureLineStripeWebhook
         if (! $productId) {
             Log::warning('SecureLine webhook: missing secure_line_product_id', [
                 'stripe_session_id' => $session['id'],
+            ]);
+
+            return;
+        }
+
+        if (! SecureLineProduct::where('id', $productId)->exists()) {
+            Log::warning('SecureLine webhook: secure_line_product_id not found in database', [
+                'stripe_session_id' => $session['id'],
+                'secure_line_product_id' => $productId,
             ]);
 
             return;

--- a/app/Services/StripePromotionService.php
+++ b/app/Services/StripePromotionService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services;
+
+use Laravel\Cashier\Cashier;
+use Stripe\Coupon;
+use Stripe\PromotionCode;
+
+class StripePromotionService
+{
+    public function listCoupons(): array
+    {
+        return Cashier::stripe()->coupons->all(['limit' => 100])->data;
+    }
+
+    public function createCoupon(array $data): Coupon
+    {
+        return Cashier::stripe()->coupons->create($data);
+    }
+
+    public function retrieveCoupon(string $id): Coupon
+    {
+        return Cashier::stripe()->coupons->retrieve($id);
+    }
+
+    public function deleteCoupon(string $id): void
+    {
+        Cashier::stripe()->coupons->delete($id);
+    }
+
+    public function getPromotionCodesForCoupon(string $couponId): array
+    {
+        return Cashier::stripe()->promotionCodes->all([
+            'coupon' => $couponId,
+            'limit' => 100,
+        ])->data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    public function createPromotionCode(string $couponId, string $code, array $extra = []): PromotionCode
+    {
+        return Cashier::stripe()->promotionCodes->create(array_merge([
+            'coupon' => $couponId,
+            'code' => $code,
+        ], $extra));
+    }
+
+    public function updatePromotionCode(string $id, bool $active): void
+    {
+        Cashier::stripe()->promotionCodes->update($id, ['active' => $active]);
+    }
+}

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -162,6 +162,9 @@ const logout = () => {
                                                     <DropdownLink :href="route('admin.secure-line-products.index')">
                                                         Secure Line Products
                                                     </DropdownLink>
+                                                    <DropdownLink :href="route('admin.coupons.index')">
+                                                        Coupons
+                                                    </DropdownLink>
                                                     <DropdownLink :href="route('admin.users.index')">
                                                         Manage Users
                                                     </DropdownLink>
@@ -411,6 +414,10 @@ const logout = () => {
                                 <ResponsiveNavLink :href="route('admin.secure-line-products.index')"
                                     :active="route().current('admin.secure-line-products.*')">
                                     Secure Line Products
+                                </ResponsiveNavLink>
+                                <ResponsiveNavLink :href="route('admin.coupons.index')"
+                                    :active="route().current('admin.coupons.*')">
+                                    Coupons
                                 </ResponsiveNavLink>
                                 <ResponsiveNavLink :href="route('admin.users.index')"
                                     :active="route().current('admin.users.*')">

--- a/resources/js/Pages/Admin/Coupons/Form.vue
+++ b/resources/js/Pages/Admin/Coupons/Form.vue
@@ -172,6 +172,7 @@ const submit = () => {
                             <option value="">All Products</option>
                             <option value="locker">eLocker only</option>
                             <option value="secure_line">Secure Line only</option>
+                            <option value="subscription">Subscriptions only</option>
                             <option value="both">Both (eLocker &amp; Secure Line)</option>
                         </select>
                         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">

--- a/resources/js/Pages/Admin/Coupons/Form.vue
+++ b/resources/js/Pages/Admin/Coupons/Form.vue
@@ -1,0 +1,283 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import { Link, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const form = useForm({
+    name:                     '',
+    discount_type:            'percent',
+    discount_value:           '',
+    currency:                 'AUD',
+    duration:                 'once',
+    duration_in_months:       '',
+    applies_to:               '',
+    promo_code:               '',
+    max_redemptions:          '',
+    max_redemptions_per_user: '',
+    minimum_amount:           '',
+    expires_at:               '',
+});
+
+const discountValueLabel = computed(() =>
+    form.discount_type === 'percent' ? '%' : '$ (AUD)'
+);
+
+const showCurrencyField = computed(() => form.discount_type === 'amount');
+const showDurationMonths = computed(() => form.duration === 'repeating');
+const showMinAmountCurrencyHint = computed(() =>
+    form.discount_type === 'percent' && form.minimum_amount !== ''
+);
+
+const submit = () => {
+    form.post(route('admin.coupons.store'));
+};
+</script>
+
+<template>
+    <AdminLayout title="Admin — New Coupon">
+        <template #title>New Coupon</template>
+
+        <Page>
+            <div class="mb-6">
+                <Link :href="route('admin.coupons.index')" prefetch class="text-sm text-gamboge-300 hover:text-gamboge-200">
+                    ← Back to Coupons
+                </Link>
+            </div>
+
+            <div class="max-w-lg">
+                <form @submit.prevent="submit" class="space-y-6">
+
+                    <!-- Name -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+                        <TextInput
+                            v-model="form.name"
+                            type="text"
+                            class="w-full"
+                            placeholder="Summer Sale"
+                            data-testid="coupon-name"
+                        />
+                        <InputError :message="form.errors.name" class="mt-1" />
+                    </div>
+
+                    <!-- Discount Type -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">Discount Type</label>
+                        <div class="flex gap-3">
+                            <button
+                                type="button"
+                                @click="form.discount_type = 'percent'"
+                                :class="form.discount_type === 'percent'
+                                    ? 'border-gamboge-300 bg-gamboge-300/10 text-gamboge-300'
+                                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gamboge-300/50'"
+                                class="flex-1 py-2 text-xs font-mono rounded-lg border transition-all"
+                                data-testid="discount-type-percent"
+                            >
+                                Percent Off
+                            </button>
+                            <button
+                                type="button"
+                                @click="form.discount_type = 'amount'"
+                                :class="form.discount_type === 'amount'
+                                    ? 'border-gamboge-300 bg-gamboge-300/10 text-gamboge-300'
+                                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gamboge-300/50'"
+                                class="flex-1 py-2 text-xs font-mono rounded-lg border transition-all"
+                                data-testid="discount-type-amount"
+                            >
+                                Fixed Amount Off
+                            </button>
+                        </div>
+                        <InputError :message="form.errors.discount_type" class="mt-1" />
+                    </div>
+
+                    <!-- Discount Value -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Discount Value ({{ discountValueLabel }})
+                        </label>
+                        <TextInput
+                            v-model="form.discount_value"
+                            type="number"
+                            step="0.01"
+                            min="1"
+                            :max="form.discount_type === 'percent' ? 100 : undefined"
+                            class="w-full font-mono"
+                            placeholder="20"
+                            data-testid="discount-value"
+                        />
+                        <InputError :message="form.errors.discount_value" class="mt-1" />
+                    </div>
+
+                    <!-- Currency (only when fixed amount) -->
+                    <div v-if="showCurrencyField">
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Currency (3-letter code, e.g. AUD)
+                        </label>
+                        <TextInput
+                            v-model="form.currency"
+                            type="text"
+                            class="w-28 font-mono uppercase"
+                            maxlength="3"
+                            placeholder="AUD"
+                            data-testid="currency"
+                        />
+                        <InputError :message="form.errors.currency" class="mt-1" />
+                    </div>
+
+                    <!-- Duration -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Duration</label>
+                        <select
+                            v-model="form.duration"
+                            class="w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:ring-gamboge-300 focus:border-gamboge-300 text-sm"
+                            data-testid="duration"
+                        >
+                            <option value="once">Once (recommended for one-time purchases)</option>
+                            <option value="forever">Forever</option>
+                            <option value="repeating">Repeating</option>
+                        </select>
+                        <InputError :message="form.errors.duration" class="mt-1" />
+                    </div>
+
+                    <!-- Duration in months (only when repeating) -->
+                    <div v-if="showDurationMonths">
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Duration in Months
+                        </label>
+                        <TextInput
+                            v-model.number="form.duration_in_months"
+                            type="number"
+                            min="1"
+                            max="36"
+                            class="w-28 font-mono"
+                            placeholder="3"
+                            data-testid="duration-in-months"
+                        />
+                        <InputError :message="form.errors.duration_in_months" class="mt-1" />
+                    </div>
+
+                    <!-- Applies To -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Applies To</label>
+                        <select
+                            v-model="form.applies_to"
+                            class="w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:ring-gamboge-300 focus:border-gamboge-300 text-sm"
+                            data-testid="applies-to"
+                        >
+                            <option value="">All Products</option>
+                            <option value="locker">eLocker only</option>
+                            <option value="secure_line">Secure Line only</option>
+                            <option value="both">Both (eLocker &amp; Secure Line)</option>
+                        </select>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Restricts which products this coupon applies to. Requires active products with Stripe price IDs.
+                        </p>
+                        <InputError :message="form.errors.applies_to" class="mt-1" />
+                    </div>
+
+                    <!-- Promotion Code -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Promotion Code</label>
+                        <TextInput
+                            v-model="form.promo_code"
+                            type="text"
+                            class="w-full font-mono uppercase"
+                            placeholder="LAUNCH20"
+                            data-testid="promo-code"
+                        />
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Letters, numbers, hyphens, underscores — e.g. LAUNCH20, SUMMER-20
+                        </p>
+                        <InputError :message="form.errors.promo_code" class="mt-1" />
+                    </div>
+
+                    <!-- Max Redemptions (coupon-level) -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Max Redemptions <span class="text-gray-400 font-normal">(optional — leave blank for unlimited)</span>
+                        </label>
+                        <TextInput
+                            v-model.number="form.max_redemptions"
+                            type="number"
+                            min="1"
+                            class="w-32 font-mono"
+                            placeholder="Unlimited"
+                            data-testid="max-redemptions"
+                        />
+                        <InputError :message="form.errors.max_redemptions" class="mt-1" />
+                    </div>
+
+                    <!-- Per-User Limit -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Per-User Limit <span class="text-gray-400 font-normal">(optional)</span>
+                        </label>
+                        <TextInput
+                            v-model.number="form.max_redemptions_per_user"
+                            type="number"
+                            min="1"
+                            class="w-32 font-mono"
+                            placeholder="1"
+                            data-testid="max-redemptions-per-user"
+                        />
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            How many times a single customer can redeem this code.
+                        </p>
+                        <InputError :message="form.errors.max_redemptions_per_user" class="mt-1" />
+                    </div>
+
+                    <!-- Minimum Order Amount -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Minimum Order Amount (AUD) <span class="text-gray-400 font-normal">(optional)</span>
+                        </label>
+                        <div class="relative w-40">
+                            <span class="absolute inset-y-0 left-3 flex items-center text-gray-500 dark:text-gray-400 text-sm">$</span>
+                            <TextInput
+                                v-model="form.minimum_amount"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="pl-7 w-full font-mono"
+                                placeholder="0.00"
+                                data-testid="minimum-amount"
+                            />
+                        </div>
+                        <p v-if="showMinAmountCurrencyHint" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Amounts are interpreted in AUD.
+                        </p>
+                        <InputError :message="form.errors.minimum_amount" class="mt-1" />
+                    </div>
+
+                    <!-- Expiry Date -->
+                    <div>
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Expiry Date <span class="text-gray-400 font-normal">(optional)</span>
+                        </label>
+                        <TextInput
+                            v-model="form.expires_at"
+                            type="date"
+                            class="w-48"
+                            data-testid="expires-at"
+                        />
+                        <InputError :message="form.errors.expires_at" class="mt-1" />
+                    </div>
+
+                    <div class="flex items-center gap-3 pt-2">
+                        <PrimaryButton :disabled="form.processing" data-testid="submit-coupon">
+                            Create Coupon
+                        </PrimaryButton>
+                        <Link :href="route('admin.coupons.index')" prefetch>
+                            <SecondaryButton type="button">Cancel</SecondaryButton>
+                        </Link>
+                    </div>
+                </form>
+            </div>
+        </Page>
+    </AdminLayout>
+</template>

--- a/resources/js/Pages/Admin/Coupons/Index.vue
+++ b/resources/js/Pages/Admin/Coupons/Index.vue
@@ -1,0 +1,148 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import { Link, useForm } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+const props = defineProps({
+    coupons: Array,
+});
+
+const couponBeingDeleted = ref(null);
+const deleteForm = useForm({});
+
+const confirmDelete = (coupon) => { couponBeingDeleted.value = coupon; };
+
+const deleteCoupon = () => {
+    deleteForm.delete(route('admin.coupons.destroy', couponBeingDeleted.value.id), {
+        preserveScroll: true,
+        onSuccess: () => { couponBeingDeleted.value = null; },
+        onError:   () => { couponBeingDeleted.value = null; },
+    });
+};
+
+const formatDiscount = (coupon) => {
+    if (coupon.percent_off) {
+        return `${coupon.percent_off}% off`;
+    }
+    if (coupon.amount_off) {
+        const amount = (coupon.amount_off / 100).toFixed(2);
+        const currency = (coupon.currency ?? 'aud').toUpperCase();
+        return `$${amount} ${currency} off`;
+    }
+    return '—';
+};
+
+const formatExpiry = (redeemBy) => {
+    if (!redeemBy) { return 'No expiry'; }
+    return new Date(redeemBy * 1000).toLocaleDateString('en-AU');
+};
+
+const formatRedemptions = (coupon) => {
+    const used = coupon.times_redeemed ?? 0;
+    const limit = coupon.max_redemptions;
+    return limit ? `${used} / ${limit}` : `${used} / Unlimited`;
+};
+</script>
+
+<template>
+    <AdminLayout title="Admin — Coupons">
+        <template #title>Coupons</template>
+
+        <Page>
+            <div class="mb-6 flex items-center justify-between">
+                <h1 class="text-xs uppercase tracking-widest text-gamboge-300 font-mono">Coupon &amp; Promotion Code Management</h1>
+                <Link :href="route('admin.coupons.create')" prefetch>
+                    <PrimaryButton>New Coupon</PrimaryButton>
+                </Link>
+            </div>
+
+            <div class="relative overflow-x-auto shadow-md sm:rounded-lg dark:shadow-neon-cyan-sm">
+                <table class="w-full text-sm text-left text-gray-700 dark:text-gray-400">
+                    <thead class="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gamboge-300 tracking-widest">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Name</th>
+                            <th scope="col" class="px-6 py-3">Discount</th>
+                            <th scope="col" class="px-6 py-3">Duration</th>
+                            <th scope="col" class="px-6 py-3">Redemptions</th>
+                            <th scope="col" class="px-6 py-3">Expiry</th>
+                            <th scope="col" class="px-6 py-3 text-center">Status</th>
+                            <th scope="col" class="px-6 py-3 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-if="coupons.length === 0">
+                            <td colspan="7" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                                No coupons yet.
+                                <Link :href="route('admin.coupons.create')" prefetch class="text-gamboge-300 hover:underline ml-1">Create one.</Link>
+                            </td>
+                        </tr>
+                        <tr
+                            v-for="coupon in coupons"
+                            :key="coupon.id"
+                            :data-testid="`coupon-row-${coupon.id}`"
+                            class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700"
+                            :class="{ 'opacity-50': !coupon.valid }"
+                        >
+                            <th scope="row" class="px-6 py-4 font-semibold text-gray-900 dark:text-white font-mono">
+                                {{ coupon.name ?? coupon.id }}
+                            </th>
+                            <td class="px-6 py-4 font-mono">{{ formatDiscount(coupon) }}</td>
+                            <td class="px-6 py-4 capitalize">{{ coupon.duration }}</td>
+                            <td class="px-6 py-4 font-mono">{{ formatRedemptions(coupon) }}</td>
+                            <td class="px-6 py-4">{{ formatExpiry(coupon.redeem_by) }}</td>
+                            <td class="px-6 py-4 text-center">
+                                <span
+                                    v-if="coupon.valid"
+                                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                                >
+                                    Valid
+                                </span>
+                                <span
+                                    v-else
+                                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                                >
+                                    Archived
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-2">
+                                    <Link :href="route('admin.coupons.show', coupon.id)" prefetch>
+                                        <SecondaryButton class="text-xs">View</SecondaryButton>
+                                    </Link>
+                                    <DangerButton class="text-xs" @click="confirmDelete(coupon)">
+                                        Delete
+                                    </DangerButton>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </Page>
+
+        <ConfirmationModal :show="couponBeingDeleted !== null" @close="couponBeingDeleted = null">
+            <template #title>Delete Coupon</template>
+            <template #content>
+                Are you sure you want to delete the coupon
+                <strong>{{ couponBeingDeleted?.name ?? couponBeingDeleted?.id }}</strong>?
+                Deleting this coupon will permanently prevent ALL linked promotion codes from being redeemed, even active ones. This cannot be undone.
+            </template>
+            <template #footer>
+                <SecondaryButton @click="couponBeingDeleted = null">Cancel</SecondaryButton>
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteForm.processing }"
+                    :disabled="deleteForm.processing"
+                    @click="deleteCoupon"
+                >
+                    Delete Coupon
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </AdminLayout>
+</template>

--- a/resources/js/Pages/Admin/Coupons/Show.vue
+++ b/resources/js/Pages/Admin/Coupons/Show.vue
@@ -142,7 +142,7 @@ const durationLabel = (coupon) => {
                 </div>
 
                 <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
-                    Customers can enter promotion codes at the eLocker or Secure Line checkout page.
+                    Customers can enter promotion codes at the eLocker, Secure Line, or subscription checkout page.
                 </p>
             </div>
 

--- a/resources/js/Pages/Admin/Coupons/Show.vue
+++ b/resources/js/Pages/Admin/Coupons/Show.vue
@@ -1,0 +1,232 @@
+<script setup>
+import AdminLayout from '@/Layouts/AdminLayout.vue';
+import Page from '@/Pages/Page.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import { Link, useForm, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+const props = defineProps({
+    coupon:     Object,
+    promoCodes: Array,
+});
+
+const showDeleteModal = ref(false);
+const deleteForm = useForm({});
+
+const deleteCoupon = () => {
+    deleteForm.delete(route('admin.coupons.destroy', props.coupon.id), {
+        onSuccess: () => { showDeleteModal.value = false; },
+        onError:   () => { showDeleteModal.value = false; },
+    });
+};
+
+const togglePromoCode = (code) => {
+    router.patch(
+        route('admin.coupons.promo-codes.toggle', [props.coupon.id, code.id]),
+        { active: !code.active },
+        { preserveScroll: true }
+    );
+};
+
+const formatDiscount = (coupon) => {
+    if (coupon.percent_off) {
+        return `${coupon.percent_off}% off`;
+    }
+    if (coupon.amount_off) {
+        const amount = (coupon.amount_off / 100).toFixed(2);
+        const currency = (coupon.currency ?? 'aud').toUpperCase();
+        return `$${amount} ${currency} off`;
+    }
+    return '—';
+};
+
+const formatExpiry = (redeemBy) => {
+    if (!redeemBy) { return 'No expiry'; }
+    return new Date(redeemBy * 1000).toLocaleDateString('en-AU');
+};
+
+const formatCreated = (timestamp) => {
+    if (!timestamp) { return '—'; }
+    return new Date(timestamp * 1000).toLocaleDateString('en-AU');
+};
+
+const formatMinAmount = (code) => {
+    const amount = code.restrictions?.minimum_amount;
+    if (!amount) { return '—'; }
+    const currency = (code.restrictions?.minimum_amount_currency ?? 'aud').toUpperCase();
+    return `$${(amount / 100).toFixed(2)} ${currency}`;
+};
+
+const formatRedemptions = (code) => {
+    const used = code.times_redeemed ?? 0;
+    const limit = code.max_redemptions;
+    return limit ? `${used} / ${limit}` : `${used} / Unlimited`;
+};
+
+const couponRedemptions = () => {
+    const used = props.coupon.times_redeemed ?? 0;
+    const limit = props.coupon.max_redemptions;
+    return limit ? `${used} / ${limit}` : `${used} / Unlimited`;
+};
+
+const durationLabel = (coupon) => {
+    if (coupon.duration === 'repeating') {
+        return `Repeating — ${coupon.duration_in_months} month(s)`;
+    }
+    return coupon.duration ? coupon.duration.charAt(0).toUpperCase() + coupon.duration.slice(1) : '—';
+};
+</script>
+
+<template>
+    <AdminLayout title="Admin — Coupon">
+        <template #title>Coupon Details</template>
+
+        <Page>
+            <div class="mb-6 flex items-center justify-between">
+                <Link :href="route('admin.coupons.index')" prefetch class="text-sm text-gamboge-300 hover:text-gamboge-200">
+                    ← Back to Coupons
+                </Link>
+                <DangerButton @click="showDeleteModal = true" data-testid="delete-coupon-btn">
+                    Delete Coupon
+                </DangerButton>
+            </div>
+
+            <!-- Coupon summary card -->
+            <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-8 shadow-sm dark:shadow-neon-cyan-sm">
+                <div class="flex items-start justify-between mb-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-900 dark:text-white font-mono">
+                            {{ coupon.name ?? coupon.id }}
+                        </h2>
+                        <div class="text-xs text-gray-400 font-mono mt-0.5">{{ coupon.id }}</div>
+                    </div>
+                    <span
+                        v-if="coupon.valid"
+                        class="inline-flex items-center px-2.5 py-1 rounded text-xs font-mono font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                    >
+                        Valid
+                    </span>
+                    <span
+                        v-else
+                        class="inline-flex items-center px-2.5 py-1 rounded text-xs font-mono font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                    >
+                        Archived
+                    </span>
+                </div>
+
+                <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Discount</div>
+                        <div class="text-sm text-gray-900 dark:text-gray-200 font-mono">{{ formatDiscount(coupon) }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Duration</div>
+                        <div class="text-sm text-gray-900 dark:text-gray-200">{{ durationLabel(coupon) }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Redemptions</div>
+                        <div class="text-sm text-gray-900 dark:text-gray-200 font-mono">{{ couponRedemptions() }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Expiry</div>
+                        <div class="text-sm text-gray-900 dark:text-gray-200">{{ formatExpiry(coupon.redeem_by) }}</div>
+                    </div>
+                    <div v-if="coupon.applies_to">
+                        <div class="text-xs uppercase tracking-widest text-gamboge-300 font-mono mb-1">Applies To</div>
+                        <div class="text-sm text-gray-900 dark:text-gray-200 font-mono break-all">
+                            {{ coupon.applies_to.products?.join(', ') ?? '—' }}
+                        </div>
+                    </div>
+                </div>
+
+                <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+                    Customers can enter promotion codes at the eLocker or Secure Line checkout page.
+                </p>
+            </div>
+
+            <!-- Promotion Codes table -->
+            <div class="mb-4">
+                <h3 class="text-xs uppercase tracking-widest text-gamboge-300 font-mono">Promotion Codes</h3>
+            </div>
+
+            <div class="relative overflow-x-auto shadow-md sm:rounded-lg dark:shadow-neon-cyan-sm">
+                <table class="w-full text-sm text-left text-gray-700 dark:text-gray-400">
+                    <thead class="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gamboge-300 tracking-widest">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Code</th>
+                            <th scope="col" class="px-6 py-3 text-center">Active</th>
+                            <th scope="col" class="px-6 py-3">Redemptions</th>
+                            <th scope="col" class="px-6 py-3">Per-User Limit</th>
+                            <th scope="col" class="px-6 py-3">Min. Amount</th>
+                            <th scope="col" class="px-6 py-3">Created</th>
+                            <th scope="col" class="px-6 py-3 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-if="promoCodes.length === 0">
+                            <td colspan="7" class="px-6 py-8 text-center text-gray-400 dark:text-gray-500">
+                                No promotion codes found.
+                            </td>
+                        </tr>
+                        <tr
+                            v-for="code in promoCodes"
+                            :key="code.id"
+                            :data-testid="`promo-code-row-${code.id}`"
+                            class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700"
+                            :class="{ 'opacity-50': !code.active }"
+                        >
+                            <th scope="row" class="px-6 py-4 font-mono font-semibold text-gray-900 dark:text-white">
+                                {{ code.code }}
+                            </th>
+                            <td class="px-6 py-4 text-center">
+                                <span v-if="code.active" class="text-gamboge-300 text-xs font-mono">Yes</span>
+                                <span v-else class="text-gray-500 text-xs font-mono">No</span>
+                            </td>
+                            <td class="px-6 py-4 font-mono">{{ formatRedemptions(code) }}</td>
+                            <td class="px-6 py-4 font-mono">{{ code.max_redemptions ?? '—' }}</td>
+                            <td class="px-6 py-4 font-mono">{{ formatMinAmount(code) }}</td>
+                            <td class="px-6 py-4">{{ formatCreated(code.created) }}</td>
+                            <td class="px-6 py-4 text-right">
+                                <button
+                                    type="button"
+                                    @click="togglePromoCode(code)"
+                                    class="text-xs font-mono px-3 py-1 rounded border transition-all"
+                                    :class="code.active
+                                        ? 'border-red-400 text-red-400 hover:bg-red-400/10'
+                                        : 'border-gamboge-300 text-gamboge-300 hover:bg-gamboge-300/10'"
+                                    :data-testid="`toggle-promo-code-${code.id}`"
+                                >
+                                    {{ code.active ? 'Deactivate' : 'Activate' }}
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </Page>
+
+        <!-- Delete confirmation modal -->
+        <ConfirmationModal :show="showDeleteModal" @close="showDeleteModal = false">
+            <template #title>Delete Coupon</template>
+            <template #content>
+                Are you sure you want to delete the coupon
+                <strong>{{ coupon.name ?? coupon.id }}</strong>?
+                Deleting this coupon will permanently prevent ALL linked promotion codes from being redeemed, even active ones. This cannot be undone.
+            </template>
+            <template #footer>
+                <SecondaryButton @click="showDeleteModal = false">Cancel</SecondaryButton>
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteForm.processing }"
+                    :disabled="deleteForm.processing"
+                    @click="deleteCoupon"
+                    data-testid="confirm-delete-coupon"
+                >
+                    Delete Coupon
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </AdminLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\AdminCouponController;
 use App\Http\Controllers\Admin\AdminLockerPlanController;
 use App\Http\Controllers\Admin\AdminPlanController;
 use App\Http\Controllers\Admin\AdminSecureLineProductController;
@@ -233,6 +234,9 @@ Route::middleware([
     Route::resource('plans', AdminPlanController::class)->except(['show']);
     Route::resource('locker-plans', AdminLockerPlanController::class)->except(['show']);
     Route::resource('secure-line-products', AdminSecureLineProductController::class)->except(['show']);
+    Route::resource('coupons', AdminCouponController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
+    Route::patch('coupons/{coupon}/promotion-codes/{promoCode}', [AdminCouponController::class, 'togglePromoCode'])
+        ->name('coupons.promo-codes.toggle');
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::post('users/{user}/suspend', [AdminUserController::class, 'suspend'])->name('users.suspend');
     Route::delete('users/{user}/suspend', [AdminUserController::class, 'unsuspend'])->name('users.unsuspend');

--- a/tests/Feature/Admin/AdminCouponTest.php
+++ b/tests/Feature/Admin/AdminCouponTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Models\Plan;
 use App\Models\User;
 use App\Services\StripePromotionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -253,6 +254,31 @@ class AdminCouponTest extends TestCase
                 'active' => true,
             ])
             ->assertRedirect(route('admin.coupons.show', 'coupon_test123'));
+    }
+
+    public function test_admin_can_create_coupon_applies_to_subscription(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $plan = Plan::factory()->create(['stripe_product_id' => 'prod_sub_test']);
+        $capturedCouponData = null;
+
+        $mock->shouldReceive('createCoupon')
+            ->once()
+            ->andReturnUsing(function (array $data) use (&$capturedCouponData) {
+                $capturedCouponData = $data;
+
+                return $this->fakeCoupon();
+            });
+
+        $mock->shouldReceive('createPromotionCode')->once()->andReturn($this->fakePromoCode());
+
+        $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'applies_to' => 'subscription',
+        ]))->assertRedirect();
+
+        $this->assertNotNull($capturedCouponData);
+        $this->assertContains('prod_sub_test', $capturedCouponData['applies_to']['products']);
     }
 
     public function test_store_validates_missing_required_fields(): void

--- a/tests/Feature/Admin/AdminCouponTest.php
+++ b/tests/Feature/Admin/AdminCouponTest.php
@@ -353,4 +353,15 @@ class AdminCouponTest extends TestCase
             ->postJson(route('admin.coupons.store'), $this->couponPayload())
             ->assertStatus(403);
     }
+
+    public function test_non_admin_cannot_toggle_promo_code(): void
+    {
+        $user = $this->nonAdminUser();
+
+        $this->actingAs($user)
+            ->patch(route('admin.coupons.promo-codes.toggle', ['coupon' => 'coupon_test123', 'promoCode' => 'promo_test456']), [
+                'active' => false,
+            ])
+            ->assertStatus(403);
+    }
 }

--- a/tests/Feature/Admin/AdminCouponTest.php
+++ b/tests/Feature/Admin/AdminCouponTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Services\StripePromotionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Inertia\Testing\AssertableInertia;
+use Mockery;
+use Stripe\Coupon;
+use Stripe\Exception\InvalidRequestException;
+use Stripe\PromotionCode;
+use Tests\TestCase;
+
+class AdminCouponTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Config::set('admin.emails', [$user->email]);
+
+        return $user;
+    }
+
+    private function nonAdminUser(): User
+    {
+        return User::factory()->withPersonalTeam()->create();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function couponPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Test Coupon',
+            'discount_type' => 'percent',
+            'discount_value' => 20,
+            'duration' => 'once',
+            'applies_to' => null,
+            'promo_code' => 'TEST20',
+            'max_redemptions' => null,
+            'max_redemptions_per_user' => null,
+            'minimum_amount' => null,
+            'expires_at' => null,
+        ], $overrides);
+    }
+
+    private function mockPromoService(): Mockery\MockInterface
+    {
+        $mock = Mockery::mock(StripePromotionService::class);
+        $this->app->instance(StripePromotionService::class, $mock);
+
+        return $mock;
+    }
+
+    private function fakeCoupon(array $attrs = []): Coupon
+    {
+        /** @var Coupon $coupon */
+        $coupon = Coupon::constructFrom(array_merge([
+            'id' => 'coupon_test123',
+            'name' => 'Test Coupon',
+            'percent_off' => 20.0,
+            'amount_off' => null,
+            'currency' => null,
+            'duration' => 'once',
+            'duration_in_months' => null,
+            'times_redeemed' => 0,
+            'max_redemptions' => null,
+            'redeem_by' => null,
+            'valid' => true,
+            'applies_to' => null,
+        ], $attrs));
+
+        return $coupon;
+    }
+
+    private function fakePromoCode(array $attrs = []): PromotionCode
+    {
+        /** @var PromotionCode $code */
+        $code = PromotionCode::constructFrom(array_merge([
+            'id' => 'promo_test456',
+            'code' => 'TEST20',
+            'active' => true,
+            'times_redeemed' => 0,
+            'max_redemptions' => null,
+            'restrictions' => ['minimum_amount' => null],
+            'created' => time(),
+        ], $attrs));
+
+        return $code;
+    }
+
+    public function test_unauthenticated_user_is_redirected_from_admin_coupons(): void
+    {
+        $this->get(route('admin.coupons.index'))->assertRedirect('/login');
+    }
+
+    public function test_non_admin_receives_403_on_admin_coupons(): void
+    {
+        $user = $this->nonAdminUser();
+
+        $this->actingAs($user)->get(route('admin.coupons.index'))->assertStatus(403);
+    }
+
+    public function test_admin_can_view_coupon_index(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $mock->shouldReceive('listCoupons')->once()->andReturn([$this->fakeCoupon()]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.coupons.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Admin/Coupons/Index')
+                ->has('coupons', 1)
+            );
+    }
+
+    public function test_admin_can_view_create_form(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->get(route('admin.coupons.create'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Admin/Coupons/Form'));
+    }
+
+    public function test_admin_can_create_coupon_with_percent_discount(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $coupon = $this->fakeCoupon();
+
+        $mock->shouldReceive('createCoupon')
+            ->once()
+            ->withArgs(fn ($data) => $data['percent_off'] === 20.0 && $data['duration'] === 'once')
+            ->andReturn($coupon);
+
+        $mock->shouldReceive('createPromotionCode')
+            ->once()
+            ->withArgs(fn ($couponId, $code) => $couponId === 'coupon_test123' && $code === 'TEST20')
+            ->andReturn($this->fakePromoCode());
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload());
+
+        $response->assertRedirect(route('admin.coupons.show', 'coupon_test123'));
+    }
+
+    public function test_admin_can_create_coupon_with_repeating_duration(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $coupon = $this->fakeCoupon(['duration' => 'repeating', 'duration_in_months' => 3]);
+
+        $mock->shouldReceive('createCoupon')
+            ->once()
+            ->withArgs(fn ($data) => $data['duration'] === 'repeating' && $data['duration_in_months'] === 3)
+            ->andReturn($coupon);
+
+        $mock->shouldReceive('createPromotionCode')->once()->andReturn($this->fakePromoCode());
+
+        $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'duration' => 'repeating',
+            'duration_in_months' => 3,
+        ]))->assertRedirect();
+    }
+
+    public function test_admin_can_create_coupon_with_minimum_amount(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $mock->shouldReceive('createCoupon')->once()->andReturn($this->fakeCoupon());
+
+        $mock->shouldReceive('createPromotionCode')
+            ->once()
+            ->withArgs(function ($couponId, $code, $extra) {
+                return isset($extra['restrictions']['minimum_amount'])
+                    && $extra['restrictions']['minimum_amount'] === 5000; // $50.00 in cents
+            })
+            ->andReturn($this->fakePromoCode());
+
+        $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'minimum_amount' => 50.00,
+        ]))->assertRedirect();
+    }
+
+    public function test_admin_can_view_coupon_show_page(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $coupon = $this->fakeCoupon();
+        $promoCode = $this->fakePromoCode();
+
+        $mock->shouldReceive('retrieveCoupon')->with('coupon_test123')->once()->andReturn($coupon);
+        $mock->shouldReceive('getPromotionCodesForCoupon')->with('coupon_test123')->once()->andReturn([$promoCode]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.coupons.show', 'coupon_test123'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Admin/Coupons/Show')
+                ->has('coupon')
+                ->has('promoCodes', 1)
+            );
+    }
+
+    public function test_admin_can_delete_coupon(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $mock->shouldReceive('deleteCoupon')->with('coupon_test123')->once();
+
+        $this->actingAs($admin)
+            ->delete(route('admin.coupons.destroy', 'coupon_test123'))
+            ->assertRedirect(route('admin.coupons.index'));
+    }
+
+    public function test_admin_can_toggle_promo_code_to_inactive(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $mock->shouldReceive('updatePromotionCode')
+            ->once()
+            ->withArgs(fn ($id, $active) => $id === 'promo_test456' && $active === false);
+
+        $this->actingAs($admin)
+            ->patch(route('admin.coupons.promo-codes.toggle', ['coupon' => 'coupon_test123', 'promoCode' => 'promo_test456']), [
+                'active' => false,
+            ])
+            ->assertRedirect(route('admin.coupons.show', 'coupon_test123'));
+    }
+
+    public function test_admin_can_toggle_promo_code_to_active(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $mock->shouldReceive('updatePromotionCode')
+            ->once()
+            ->withArgs(fn ($id, $active) => $id === 'promo_test456' && $active === true);
+
+        $this->actingAs($admin)
+            ->patch(route('admin.coupons.promo-codes.toggle', ['coupon' => 'coupon_test123', 'promoCode' => 'promo_test456']), [
+                'active' => true,
+            ])
+            ->assertRedirect(route('admin.coupons.show', 'coupon_test123'));
+    }
+
+    public function test_store_validates_missing_required_fields(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['name', 'discount_type', 'discount_value', 'duration', 'promo_code']);
+    }
+
+    public function test_store_rejects_invalid_discount_type(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'discount_type' => 'invalid',
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['discount_type']);
+    }
+
+    public function test_store_rejects_percent_discount_over_100(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'discount_type' => 'percent',
+            'discount_value' => 110,
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['discount_value']);
+    }
+
+    public function test_store_rejects_repeating_without_duration_in_months(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload([
+            'duration' => 'repeating',
+            'duration_in_months' => null,
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['duration_in_months']);
+    }
+
+    public function test_store_rollback_deletes_coupon_if_promo_code_creation_fails(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+        $coupon = $this->fakeCoupon();
+
+        $mock->shouldReceive('createCoupon')->once()->andReturn($coupon);
+        $mock->shouldReceive('createPromotionCode')->once()->andThrow(new \RuntimeException('Stripe error'));
+        $mock->shouldReceive('deleteCoupon')->with('coupon_test123')->once();
+
+        $response = $this->actingAs($admin)->postJson(route('admin.coupons.store'), $this->couponPayload());
+
+        $response->assertRedirect();
+    }
+
+    public function test_show_redirects_to_index_when_coupon_not_found(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $exception = InvalidRequestException::factory('No such coupon', 404);
+        $mock->shouldReceive('retrieveCoupon')->once()->andThrow($exception);
+        $mock->shouldReceive('getPromotionCodesForCoupon')->never();
+
+        $this->actingAs($admin)
+            ->get(route('admin.coupons.show', 'coupon_nonexistent'))
+            ->assertRedirect(route('admin.coupons.index'));
+    }
+
+    public function test_destroy_redirects_to_index_when_coupon_not_found(): void
+    {
+        $admin = $this->adminUser();
+        $mock = $this->mockPromoService();
+
+        $exception = InvalidRequestException::factory('No such coupon', 404);
+        $mock->shouldReceive('deleteCoupon')->once()->andThrow($exception);
+
+        $this->actingAs($admin)
+            ->delete(route('admin.coupons.destroy', 'coupon_nonexistent'))
+            ->assertRedirect(route('admin.coupons.index'));
+    }
+
+    public function test_non_admin_cannot_store_coupon(): void
+    {
+        $user = $this->nonAdminUser();
+
+        $this->actingAs($user)
+            ->postJson(route('admin.coupons.store'), $this->couponPayload())
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/CheckoutPromotionCodesTest.php
+++ b/tests/Feature/CheckoutPromotionCodesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Locker;
+use App\Models\LockerPlan;
+use App\Models\SecureLineProduct;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Stripe\StripeClient;
+use Tests\TestCase;
+
+class CheckoutPromotionCodesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function mockStripeCheckoutCapture(?array &$capturedData): void
+    {
+        $fakeSession = (object) ['url' => 'https://checkout.stripe.com/fake-session'];
+
+        $mockCheckoutService = Mockery::mock();
+        $mockCheckoutService->shouldReceive('create')
+            ->andReturnUsing(function (array $data) use (&$capturedData, $fakeSession) {
+                $capturedData = $data;
+
+                return $fakeSession;
+            });
+
+        $mockStripeClient = new \stdClass;
+        $mockStripeClient->checkout = new \stdClass;
+        $mockStripeClient->checkout->sessions = $mockCheckoutService;
+
+        $this->app->bind(StripeClient::class, fn () => $mockStripeClient);
+    }
+
+    public function test_locker_checkout_includes_allow_promotion_codes(): void
+    {
+        $capturedData = null;
+        $this->mockStripeCheckoutCapture($capturedData);
+
+        LockerPlan::create([
+            'tier' => 'text',
+            'years' => 1,
+            'amount_cents' => 2000,
+            'stripe_price_id' => 'price_locker_test',
+            'is_active' => true,
+        ]);
+
+        $this->post(route('lockers.checkout'), ['tier' => 'text', 'years' => 1]);
+
+        $this->assertNotNull($capturedData);
+        $this->assertTrue($capturedData['allow_promotion_codes'] ?? false);
+    }
+
+    public function test_locker_renewal_checkout_includes_allow_promotion_codes(): void
+    {
+        $capturedData = null;
+        $this->mockStripeCheckoutCapture($capturedData);
+
+        $verifier = bin2hex(random_bytes(32));
+
+        $locker = Locker::factory()->create([
+            'auth_verifier' => $verifier,
+            'public_key' => null,
+        ]);
+
+        LockerPlan::create([
+            'tier' => 'text',
+            'years' => 1,
+            'amount_cents' => 2000,
+            'stripe_price_id' => 'price_locker_renew_test',
+            'is_active' => true,
+        ]);
+
+        $this->post(route('lockers.renew.purchase', $locker->account_id), [
+            'verifier' => $verifier,
+            'years' => 1,
+            'tier' => 'text',
+        ]);
+
+        $this->assertNotNull($capturedData);
+        $this->assertTrue($capturedData['allow_promotion_codes'] ?? false);
+    }
+
+    public function test_secure_line_checkout_includes_allow_promotion_codes(): void
+    {
+        $capturedData = null;
+        $this->mockStripeCheckoutCapture($capturedData);
+
+        $product = SecureLineProduct::factory()->create([
+            'stripe_price_id' => 'price_secure_line_test',
+            'is_active' => true,
+        ]);
+
+        $this->post(route('calls.checkout'), ['product_id' => $product->id]);
+
+        $this->assertNotNull($capturedData);
+        $this->assertTrue($capturedData['allow_promotion_codes'] ?? false);
+    }
+}

--- a/tests/Feature/SecureLine/AnonymousCheckoutTest.php
+++ b/tests/Feature/SecureLine/AnonymousCheckoutTest.php
@@ -397,4 +397,54 @@ class AnonymousCheckoutTest extends TestCase
 
         $this->assertDatabaseCount('secure_line_credits', 0);
     }
+
+    public function test_webhook_creates_credit_for_100_percent_off_coupon(): void
+    {
+        $product = SecureLineProduct::factory()->withStripePrice()->create();
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_free_coupon',
+                    'payment_status' => 'no_payment_required',
+                    'metadata' => [
+                        'product_type' => 'secure_line',
+                        'secure_line_product_id' => $product->id,
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseHas('secure_line_credits', [
+            'stripe_session_id' => 'cs_test_free_coupon',
+            'secure_line_product_id' => $product->id,
+        ]);
+    }
+
+    public function test_webhook_skips_when_product_not_found_in_database(): void
+    {
+        $listener = new HandleSecureLineStripeWebhook;
+
+        $event = new WebhookReceived([
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_missing_product',
+                    'payment_status' => 'paid',
+                    'metadata' => [
+                        'product_type' => 'secure_line',
+                        'secure_line_product_id' => 99999,
+                    ],
+                ],
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $this->assertDatabaseCount('secure_line_credits', 0);
+    }
 }

--- a/tests/e2e/admin/coupons.spec.ts
+++ b/tests/e2e/admin/coupons.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import { resetDatabase } from '../helpers/db';
+import { createAdminUser, createTestUser, login } from '../helpers/auth';
+
+test.beforeEach(() => {
+    resetDatabase();
+});
+
+async function loginAsAdmin(page: Parameters<typeof login>[0]) {
+    const { email, password } = createAdminUser();
+    await login(page, email, password);
+}
+
+test('admin can view the coupon index page with empty state', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.goto('/admin/coupons');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Coupon & Promotion Code Management')).toBeVisible();
+    // Either shows coupons from Stripe test account or the empty state
+    const emptyOrTable = page.locator('table');
+    await expect(emptyOrTable).toBeVisible();
+});
+
+test('clicking New Coupon navigates to the create form', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.goto('/admin/coupons');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'New Coupon' }).click();
+
+    await expect(page).toHaveURL(/coupons\/create/);
+    await expect(page.getByText('New Coupon')).toBeVisible();
+});
+
+test('create form shows validation errors when submitted empty', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    // Clear required fields and submit
+    await page.getByTestId('coupon-name').clear();
+    await page.getByTestId('promo-code').clear();
+    await page.getByTestId('discount-value').clear();
+
+    await page.getByTestId('submit-coupon').click();
+
+    // Should stay on the form due to validation errors
+    await expect(page).toHaveURL(/coupons\/create/);
+});
+
+test('create form shows discount value label based on discount type', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    // Default is percent
+    await expect(page.getByText('Discount Value (%)')).toBeVisible();
+
+    // Switch to fixed amount
+    await page.getByTestId('discount-type-amount').click();
+    await expect(page.getByText('Discount Value ($ (AUD))')).toBeVisible();
+    await expect(page.getByTestId('currency')).toBeVisible();
+});
+
+test('create form shows duration in months field only when repeating selected', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('duration-in-months')).not.toBeVisible();
+
+    await page.getByTestId('duration').selectOption('repeating');
+
+    await expect(page.getByTestId('duration-in-months')).toBeVisible();
+});
+
+test('admin can create a coupon and is redirected to the show page', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    // Use a timestamp-based code to avoid Stripe duplicate code errors across runs
+    const uniqueCode = `TESTE2E${Date.now().toString().slice(-6)}`;
+
+    await page.getByTestId('coupon-name').fill('E2E Test Coupon');
+    await page.getByTestId('discount-value').fill('10');
+    await page.getByTestId('promo-code').fill(uniqueCode);
+
+    await page.getByTestId('submit-coupon').click();
+
+    // On success, redirected to the show page
+    await expect(page).toHaveURL(/coupons\/.+/);
+    await expect(page).not.toHaveURL(/coupons\/create/);
+    await expect(page.getByText('E2E Test Coupon')).toBeVisible();
+    await expect(page.getByText(uniqueCode)).toBeVisible();
+});
+
+test('admin can toggle a promo code to inactive on the show page', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    const uniqueCode = `TOGGL${Date.now().toString().slice(-6)}`;
+
+    await page.getByTestId('coupon-name').fill('Toggle Test Coupon');
+    await page.getByTestId('discount-value').fill('5');
+    await page.getByTestId('promo-code').fill(uniqueCode);
+
+    await page.getByTestId('submit-coupon').click();
+    await page.waitForURL(/coupons\/.+/);
+
+    // Wait for the promo codes table to load
+    await expect(page.getByText(uniqueCode)).toBeVisible();
+
+    // Click Deactivate on the promo code row
+    await page.getByRole('button', { name: 'Deactivate' }).first().click();
+    await page.waitForLoadState('networkidle');
+
+    // After deactivation the button changes to Activate
+    await expect(page.getByRole('button', { name: 'Activate' }).first()).toBeVisible();
+});
+
+test('admin can delete a coupon after confirming the modal', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    const uniqueCode = `DELET${Date.now().toString().slice(-6)}`;
+
+    await page.getByTestId('coupon-name').fill('Coupon To Delete');
+    await page.getByTestId('discount-value').fill('15');
+    await page.getByTestId('promo-code').fill(uniqueCode);
+
+    await page.getByTestId('submit-coupon').click();
+    await page.waitForURL(/coupons\/.+/);
+
+    // Verify on show page
+    await expect(page.getByText('Coupon To Delete')).toBeVisible();
+
+    // Open delete modal
+    await page.getByTestId('delete-coupon-btn').click();
+
+    // Modal should appear with warning text
+    await expect(page.getByRole('dialog').getByText(/permanently prevent ALL linked promotion codes/)).toBeVisible();
+
+    // Confirm deletion
+    await page.getByTestId('confirm-delete-coupon').click();
+
+    // Redirected back to the index
+    await expect(page).toHaveURL(/\/admin\/coupons$/);
+});
+
+test('non-admin user is denied access to admin coupon pages', async ({ page }) => {
+    const { email, password } = createTestUser();
+    await login(page, email, password);
+
+    await page.goto('/admin/coupons');
+
+    // A 403 response does not show the coupon management heading
+    await expect(page.getByText('Coupon & Promotion Code Management')).not.toBeVisible();
+});
+
+test('back link on create form navigates to coupon index', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/coupons/create');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('link', { name: '← Back to Coupons' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/coupons$/);
+});


### PR DESCRIPTION
## Summary

- Enables `allow_promotion_codes: true` on eLocker checkout, eLocker renewal, and Secure Line checkout Stripe sessions so customers can redeem promotion codes at the payment step
- Adds `StripePromotionService` and `AdminCouponController` with full CRUD for Stripe coupons and promotion codes (no local DB — all data lives in Stripe)
- Adds three admin Vue pages (`Admin/Coupons/Index`, `Admin/Coupons/Form`, `Admin/Coupons/Show`) with coupon listing, creation, detail view, promo code toggle, and delete with confirmation modal
- Adds a `payment_status` guard in `HandleLockerStripeWebhook::handleCreate()` to accept `paid` and `no_payment_required` (100%-off coupon) while rejecting `unpaid` (async payment methods not yet cleared)

## Regression Notes

- **`minimum_amount_currency` fallback**: When a minimum amount is set on a promo code without an explicit amount-type coupon currency, the code falls back to `config('cashier.currency', 'aud')`. Ensure `cashier.currency` is correctly set per environment.
- **N+1 Stripe API calls in `resolveProductIds()`**: Each active price ID triggers a separate `prices->retrieve()` call to resolve the product ID. At low cardinality (handful of plans) this is negligible, but worth noting if the product catalogue grows significantly.
- **Webhook guard**: The new `payment_status` guard in `HandleLockerStripeWebhook` changes behaviour for any future async payment methods (e.g. BECS Direct Debit). Sessions with `payment_status = unpaid` are now explicitly skipped — monitor Locker webhook logs if async payment methods are ever enabled.

## Test Plan

- [ ] Log in as admin → navigate to Admin → Coupons → confirm empty state or existing Stripe test coupons appear
- [ ] Create a percent-off coupon (e.g. 20% once, promo code `SAVE20`) → confirm redirect to Show page
- [ ] Create an amount-off coupon with currency and minimum amount → confirm promo code restrictions saved in Stripe
- [ ] Create a repeating coupon with duration in months → confirm `duration_in_months` field appears/hides correctly
- [ ] Toggle a promo code inactive on the Show page → confirm button state updates
- [ ] Delete a coupon via the confirmation modal → confirm redirect to Index and coupon removed
- [ ] Go to eLocker checkout → enter a valid Stripe test promo code → confirm discount applies
- [ ] Go to Secure Line checkout → enter a valid Stripe test promo code → confirm discount applies
- [ ] Apply a 100%-off coupon at eLocker checkout → confirm `payment_status = no_payment_required` and locker credit is created
- [ ] Non-admin user attempts `/admin/coupons` → confirm 403
- [ ] `php artisan test tests/Feature/Admin/AdminCouponTest.php tests/Feature/CheckoutPromotionCodesTest.php` — all 23 tests pass
- [ ] `npx playwright test tests/e2e/admin/coupons.spec.ts` — all 10 tests pass